### PR TITLE
Change top-level heading from "Guides" to "Guide"

### DIFF
--- a/meteor_api_guide.json
+++ b/meteor_api_guide.json
@@ -33,7 +33,7 @@
     "guide": {
       "lvl0": {
         "selector": "",
-        "default_value": "Guides"
+        "default_value": "Guide"
       },
       "lvl1": ".content-wrapper h1",
       "lvl2": ".content-wrapper h2",


### PR DESCRIPTION
We refer to it as the "guide" rather than a collection of "guides"