### PR TITLE
Can we remove the advisory text

### DIFF
--- a/docker.json
+++ b/docker.json
@@ -6,6 +6,9 @@
   "stop_urls": [
     "/v1.*$"
   ],
+  "selectors_exclude": [
+    ".advisory"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "//div[contains(@class, 'region')]/ul[@class='nav-sub']/li[contains(@class, 'active')]/a",


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

we'd like to strip the advisory text at the top of https://docs.docker.com/engine/swarm/

will this work?