### PR TITLE
updates Appboy configuration

### DIFF
--- a/configs/appboy.json
+++ b/configs/appboy.json
@@ -13,7 +13,7 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": "ul.nav a.active",
+    "lvl0": "ul.nav a.heading",
     "lvl1": ".article h1",
     "lvl2": ".article h2",
     "lvl3": ".article h3",


### PR DESCRIPTION
The current configuration isn't indexing lvl0 selectors, I think because the class it's looking for is added dynamically by javascript after the page loads. I added a class to identify lvl0 and updated the config.