### PR TITLE
Nanoc: Use h1 text for level 1 header

### DIFF
--- a/configs/nanoc.json
+++ b/configs/nanoc.json
@@ -10,10 +10,13 @@
       "type": "xpath",
       "selector": "//div[contains(@class, 'side')]//ul/li/span[contains(@class, 'active')]/../../preceding::h4[1]"
     },
-    "lvl1": ".article-content h2",
-    "lvl2": ".article-content h3",
-    "lvl3": ".article-content h4",
-    "lvl4": ".article-content h5",
+    "lvl1": {
+      "type": "xpath",
+      "selector": "//h1/text()"
+    },
+    "lvl2": ".article-content h2",
+    "lvl3": ".article-content h3",
+    "lvl4": ".article-content h4",
     "text": ".article-content p, .article-content li"
   },
   "min_indexed_level": 1,


### PR DESCRIPTION
This changes the text for the level 1 header for Nanoc to derive from `h1`, and for level 2 from `h2` and so on.

Currently, the level 1 header are the subheader on a page.