### PR TITLE
Lightning Design System:

### DIFF
--- a/configs/lightningdesignsystem.json
+++ b/configs/lightningdesignsystem.json
@@ -61,7 +61,6 @@
   "stop_urls": [],
   "selectors_exclude": [
     "span.slds-badge",
-    "#overview",
     ".docsearch-ignore"
   ],
   "selectors": {


### PR DESCRIPTION
Stop ignoring the overview, hoping it will improve usability of class name searching.

(class names are now indexed but unfortunately clicking on the result redirects to a component flavor instead of the component overview)

Sorry for the many edits today… this is a lot of trial and error but we're getting there :)