### PR TITLE
Target actual jmonkey documentation url.

### DIFF
--- a/configs/jmonkeyengine.json
+++ b/configs/jmonkeyengine.json
@@ -1,7 +1,7 @@
 {
   "index_name": "jmonkeyengine",
   "start_urls": [
-    "http://wiki.jmonkeyengine.org/"
+    "https://jmonkeyengine.github.io/wiki/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
On https://jmonkeyengine.github.io/wiki/ our search box return url with http://wiki.jmonkeyengine.org/ which is not working anymore.
This PR replace it with the github.io url that will less likely change in the future.