### PR TITLE
Use unescaped char in strip_chars for webpack

### DIFF
--- a/configs/webpack.json
+++ b/configs/webpack.json
@@ -5,7 +5,7 @@
   ],
   "js_render": true,
   "js_wait": 1,
-  "strip_chars": "\u2192",
+  "strip_chars": "→",
   "selectors": {
     "lvl0": {
       "selector": "//ul/li/a[@class=\"active\"]/../../../text()[1]",


### PR DESCRIPTION
The escaped unicode representation works in my config locally but doesn't cause the offending char to be stripped out in production.