### PR TITLE
Blog posts should be indexed

### DIFF
--- a/configs/shopware.json
+++ b/configs/shopware.json
@@ -8,8 +8,7 @@
     "https://developers.shopware.com"
   ],
   "stop_urls": [
-    "\\.md$",
-    "blog"
+    "\\.md$"
   ],
   "selectors": {
     "default": {


### PR DESCRIPTION
A lot of you blog posts contain important information for developers. In fact a lot of our documentation starts out as a blog post and is split up and moved into "real" documentation later on.