### PR TITLE
Plone Docs: allow indexing of develop and old-reference

### DIFF
--- a/configs/plone.json
+++ b/configs/plone.json
@@ -15,8 +15,6 @@
     }
   ],
   "stop_urls": [
-    "/old-reference-manuals/",
-    "develop",
     "xml"
   ],
   "selectors": {


### PR DESCRIPTION
Currently if we search on docs.plone.org, certain content items are not showing up, for example, if I search for "Views" I do not find:

http://docs.plone.org/develop/plone/views/browserviews.html

We keep our develop docs under /develop, so this is kind of important for us, that we find this content :)

This pull request removes /develop and /old-reference from  "stop_urls" so that this content gets indexed and will be findable via the search.  