### PR TITLE
[gravitee.io] do not index changelog page

### DIFF
--- a/configs/gravitee.json
+++ b/configs/gravitee.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://docs.gravitee.io/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://docs.gravitee.io/apim_changelog.html"
+  ],
   "selectors_exclude": [
     "#preamble"
   ],


### PR DESCRIPTION
the changelog page is not relevant in the search engine. 

fix gravitee-io/issues#406