### PR TITLE
Do not index Buck's permalink markers

### DIFF
--- a/configs/buckbuild.json
+++ b/configs/buckbuild.json
@@ -31,7 +31,7 @@
     "lvl5": {
       "selector": "article h5",
       "strip_chars": " .,;:#"
-    }
+    },
     "text": "article p, article li"
   },
   "min_indexed_level": 1,

--- a/configs/buckbuild.json
+++ b/configs/buckbuild.json
@@ -12,11 +12,26 @@
       "type": "xpath",
       "global": true
     },
-    "lvl1": "article h1",
-    "lvl2": "article h2",
-    "lvl3": "article h3",
-    "lvl4": "article h4",
-    "lvl5": "article h5",
+    "lvl1": {
+      "selector": "article h1",
+      "strip_chars": " .,;:#"
+    },
+    "lvl2": {
+      "selector": "article h2",
+      "strip_chars": " .,;:#"
+    },
+    "lvl3": {
+      "selector": "article h3",
+      "strip_chars": " .,;:#"
+    },
+    "lvl4": {
+      "selector": "article h4",
+      "strip_chars": " .,;:#"
+    },
+    "lvl5": {
+      "selector": "article h5",
+      "strip_chars": " .,;:#"
+    }
     "text": "article p, article li"
   },
   "min_indexed_level": 1,


### PR DESCRIPTION
If you search for `deps` on buckbuild.com, you'll see all of the `#` in the headings for the permalink markers that are visible on hover.  I believe this will remove them.