### PR TITLE
Update Waylay crawler URL

### DIFF
--- a/configs/waylay.json
+++ b/configs/waylay.json
@@ -1,7 +1,7 @@
 {
   "index_name": "waylay",
   "start_urls": [
-    "https://developers.waylay.io/"
+    "https://docs.waylay.io/"
   ],
   "selectors": {
     "lvl0": ".breadcrumbs li:first-child",


### PR DESCRIPTION
We've decided to host the documentation on a different subdomain, unfortunately the CNAME record doesn't cooperate with our SNI proxy.