### PR TITLE
[docs.rightscale.com] Disable https

### DIFF
--- a/configs/rightscale.json
+++ b/configs/rightscale.json
@@ -1,7 +1,7 @@
 {
   "index_name": "rightscale",
   "start_urls": [
-    "https://docs.rightscale.com/"
+    "http://docs.rightscale.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We currently don't support https in our documentation, so we need the results to be http.