### PR TITLE
Update denali js config

### DIFF
--- a/configs/denalijs.json
+++ b/configs/denalijs.json
@@ -7,7 +7,7 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".docs-header .item-type",
+    "lvl0": ".docs-header .item-package",
     "lvl1": ".docs-content h1",
     "lvl2": ".docs-content h2",
     "lvl3": ".docs-content h3",


### PR DESCRIPTION
Fix lvl0 selector. This might take a couple tries as I figure out how the `lvlN` selectors correspond to various parts on the search dropdown UI.