### PR TITLE
feat(yarn): add i18n documentations

### DIFF
--- a/configs/yarnpkg.json
+++ b/configs/yarnpkg.json
@@ -1,7 +1,14 @@
 {
   "index_name": "yarnpkg",
   "start_urls": [
-    "https://yarnpkg.com/en/docs/"
+    {
+      "url": "https://yarnpkg.com/(?P<lang>)/docs/",
+      "variables": {
+        "lang": [
+          "en"
+        ]
+      }
+    }
   ],
   "stop_urls": [],
   "selectors_exclude": [


### PR DESCRIPTION
Yarn is internationalised, and these are the languages that are currently visible