### PR TITLE
Change of URL for Hugo docs concept website.

### DIFF
--- a/configs/hugodocsconcept.json
+++ b/configs/hugodocsconcept.json
@@ -1,10 +1,10 @@
 {
   "index_name": "hugodocsconcept",
   "start_urls": [
-    "https://hugodocsconcept.netlify.com/"
+    "https://hugodocs.info/"
   ],
   "stop_urls": [
-    "https://hugodocsconcept.netlify.com/$"
+    "https://hugodocs.info/$"
   ],
   "scrap_start_urls": false,
   "selectors": {


### PR DESCRIPTION
I changed the URL of this concept site for better integration with Netlify's subdomain/git integration. As a head's up, if the Hugo team digs the finished product, this would live as part of the docs on their official site (gohugo.io; already using Algolia) and I would therefore cancel this service altogether. Thanks so much --this is incredibly generous. Algolia rocks!