### PR TITLE
Update akeneo-api.json

### DIFF
--- a/configs/akeneo-api.json
+++ b/configs/akeneo-api.json
@@ -1,19 +1,18 @@
 {
   "index_name": "akeneo-api",
   "start_urls": [
-    "https://api.akeneo.com/getting-started.html",
-    "https://api.akeneo.com/getting-started-admin.html",
-    "https://api.akeneo.com/getting-started-admin.html",
-    "https://api.akeneo.com/documentation/",
-    "https://api-staging.akeneo.com/api-reference-index.html"
+    "https://api.akeneo.com/"
+  ],
+  "stop_urls": [
+    "https://api.akeneo.com/index.html"
   ],
   "selectors": {
-    "lvl0": "h1",
-    "lvl1": "h2",
-    "lvl2": "h3",
-    "lvl3": "h4",
-    "lvl4": "h5",
-    "text": "p, li"
+    "lvl0": "#mainContent h1",
+    "lvl1": "#mainContent h2",
+    "lvl2": "#mainContent h3",
+    "lvl3": "#mainContent h4",
+    "lvl4": "#mainContent h5",
+    "text": "#mainContent p, #mainContent li"
   },
   "min_indexed_level": 2,
   "nb_hits": 133,

--- a/configs/akeneo-api.json
+++ b/configs/akeneo-api.json
@@ -1,15 +1,19 @@
 {
   "index_name": "akeneo-api",
   "start_urls": [
-    "https://api.akeneo.com/documentation.html"
+    "https://api.akeneo.com/getting-started.html",
+    "https://api.akeneo.com/getting-started-admin.html",
+    "https://api.akeneo.com/getting-started-admin.html",
+    "https://api.akeneo.com/documentation/",
+    "https://api-staging.akeneo.com/api-reference-index.html"
   ],
   "selectors": {
-    "lvl0": "#includedContent h1",
-    "lvl1": "#includedContent h2",
-    "lvl2": "#includedContent h3",
-    "lvl3": "#includedContent h4",
-    "lvl4": "#includedContent h5",
-    "text": "#includedContent p, #includedContent li"
+    "lvl0": "h1",
+    "lvl1": "h2",
+    "lvl2": "h3",
+    "lvl3": "h4",
+    "lvl4": "h5",
+    "text": "p, li"
   },
   "min_indexed_level": 2,
   "nb_hits": 133,


### PR DESCRIPTION
We did some changes on api.akeneo.com (not in production yet)
- Split the /documentation.html to several files (/documentation/file1.html, /documentation/file2.html)
- We want Algolia to be able to search on all the pages of the documentation (except the /index.html). I don't know if there is a better solution than list all them
- I changed the selectors because "#includedContent" selector is only on the /documentation/* pages.

Just say me if I did something wrong, I can update this PR ;)

Best regards