### PR TITLE
Scrape the Ember api docs using SSL

### DIFF
--- a/configs/emberjs_versions.json
+++ b/configs/emberjs_versions.json
@@ -11,7 +11,7 @@
       }
     },
     {
-      "url": "http://emberjs.com/api",
+      "url": "https://emberjs.com/api",
       "tags": [
         "api"
       ]


### PR DESCRIPTION
We recently updated to requiring SSL for all our pages.  API search stopped working sometime after that, which seems like it might be related 😀 