### PR TITLE
Update search weightings

### DIFF
--- a/configs/chartiq_doc.json
+++ b/configs/chartiq_doc.json
@@ -12,7 +12,7 @@
     "lvl1": "#main h2",
     "lvl2": "#main h3",
     "lvl3": "#main h4",
-    "lvl4": ".tutorial-section",
+    "lvl4": ".tutorial-section p",
     "lvl5": "#main h1",
     "lvl6": "#main h5",
     "text": "#main p, #main li"


### PR DESCRIPTION
When we last updated our search rankings we ended up with the entire tutorial section in our search results. I'm assuming this is because we weighted the class name and not the individual headers, will this change make it so that our entire tutorial isn't returned as the search result?