### PR TITLE
Mailtop: replace 'Documentação' with 'Ajuda'

### DIFF
--- a/configs/mailtop.json
+++ b/configs/mailtop.json
@@ -9,7 +9,7 @@
   "selectors": {
     "lvl0": {
       "selector": "",
-      "default_value": "Documenta\u00e7\u00e3o"
+      "default_value": "Ajuda"
     },
     "lvl1": "article h1",
     "lvl2": "article h2",


### PR DESCRIPTION
Using 'Ajuda' (Help) will prevent the use of accented words that
did not appear correctly in the widget.