### PR TITLE
Add header selector to Urban Airship config

### DIFF
--- a/configs/urbanairship.json
+++ b/configs/urbanairship.json
@@ -7,9 +7,10 @@
     "/reference/"
   ],
   "selectors": {
-    "lvl0": ".article__body h1",
-    "lvl1": ".article__body h2",
-    "lvl2": ".article__body h3",
+    "lvl0": ".article__heading h1",
+    "lvl1": ".article__body h1",
+    "lvl2": ".article__body h2",
+    "lvl3": ".article__body h3",
     "text": ".article__body p, .article__body li"
   },
   "nb_hits": 7061


### PR DESCRIPTION
Adds title selector for docs.urbanairship.com:

Example from https://docs.urbanairship.com/platform/ios/
```
  <header class="article__heading u-pad-top-5">
    <h1>iOS</h1>
  </header>
```

Example from https://docs.urbanairship.com/guides/account/:
```
    <header class="article__heading u-space-top-3">
      <h1>Connect: Server-Side Custom Events</h1>
    </header>
```