### PR TITLE
Update Bootstrap config for beta release

### DIFF
--- a/configs/bootstrap-v4.json
+++ b/configs/bootstrap-v4.json
@@ -1,16 +1,13 @@
 {
   "index_name": "bootstrap-v4",
   "start_urls": [
-    "https://v4-alpha.getbootstrap.com/"
+    "https://getbootstrap.com/"
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".bd-pageheader h1",
     "lvl1": ".bd-content h1",
     "lvl2": ".bd-content h2",
     "lvl3": ".bd-content h3",
-    "lvl4": ".bd-content h4",
-    "lvl5": ".bd-content h5",
     "text": ".bd-content p, .bd-content li"
   },
   "min_indexed_level": 1,


### PR DESCRIPTION
I don't think I'm doing this 100% right, but here's what's up:

- We'll be shipping a v4 beta soon. That's the only place our instance of DocSearch will live moving forward (the `v4-alpha.getbootstrap.com` site will remain as-is).
- The bulk of the docs content will live at `getbootstrap.com/docs/4.0/`, but not all pages are there (home, examples, and about aren't).
- I don't want the page's first `<h1>`s to show up in the list—I want the _name_ of the page to show up. Dropping folks on the first heading like that skips a few pixels and doesn't give you the page's name. Is that possible?
- We don't need every `<h4>` and `<h5>` in there, so I've pull them out.

Other than that, we'll likely need to rebuild the index, too. I've reordered a good amount since we added DocSearch originally :).

Lemme know what else I can do, and thanks for all your help!