### PR TITLE
update glamorous.rocks config

### DIFF
--- a/configs/glamorous.json
+++ b/configs/glamorous.json
@@ -2,12 +2,14 @@
   "index_name": "glamorous",
   "start_urls": [
     {
-      "url": "https://(?P<language>.*?).glamorous.rocks/",
+      "url": "https://(?P<language>.*?)rc.glamorous.rocks/",
       "variables": {
         "language": [
-          "fr.rc",
-          "rc",
-          "es"
+          "",
+          "fr",
+          "es",
+          "de",
+          "zh"
         ]
       }
     }


### PR DESCRIPTION
In the future, we'll remove the `rc.` prefix (stands for release-candidate). But for now this is how our URL schema works. Thanks!