### PR TITLE
Update material-ui.json

### DIFF
--- a/configs/material-ui.json
+++ b/configs/material-ui.json
@@ -17,7 +17,7 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": "//*[contains(@class, 'MuiCollapse-entered')]/../button/*[contains(@class, 'MuiButton-label')]",
+      "selector": "//*[contains(@class, 'algolia-lvl0')]",
       "type": "xpath",
       "global": true
     },


### PR DESCRIPTION
Given the latest styling improvement, that logic is no longer working:
![capture d ecran 2017-07-28 a 20 51 46](https://user-images.githubusercontent.com/3165635/28732043-a7d7c3a2-73d6-11e7-972b-65cb036acc4b.png)

I'm adding a new class name.

cc @maxiloc