### PR TITLE
Modify pilosa config to use versioning

### DIFF
--- a/configs/pilosa.json
+++ b/configs/pilosa.json
@@ -1,7 +1,17 @@
 {
   "index_name": "pilosa",
   "start_urls": [
-    "https://www.pilosa.com/docs"
+    {
+      "url": "https://www.pilosa.com/docs/(?P<version>.*?)/",
+      "variables": {
+        "version": [
+          "v0.4",
+          "v0.5",
+          "v0.6",
+          "latest"
+        ]
+      }
+    }
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
The latest release of our website adds a version separator. If I understand correctly, this PR will make the search engine index each version separately. Please advise if this will work as expected. Thanks!