### PR TITLE
use semantic tags in selectors

### DIFF
--- a/configs/drstearns.json
+++ b/configs/drstearns.json
@@ -5,12 +5,12 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".content h1, .hero-body h1",
-    "lvl1": ".content h2, .hero-body h2",
-    "lvl2": ".content h3, .hero-body h3",
-    "lvl3": ".content h4, .hero-body h4",
-    "lvl4": ".content h5, .hero-body h5",
-    "text": ".content p, .hero-body p, .content li, .hero-body li"
+    "lvl0": "main h1, header h1",
+    "lvl1": "main h2, header h2",
+    "lvl2": "main h3, header h3",
+    "lvl3": "main h4, header h4",
+    "lvl4": "main h5, header h5",
+    "text": "main p, header p, main li, main dt, main dd"
   },
   "nb_hits": 1801
 }


### PR DESCRIPTION
I exchanged email with Rémy-Christophe Schermesser about this, and he said I should open a pull request to correct it.

The `.content` and `.hero-body` style classes are part of the CSS framework I happen to use, and I may change that framework in the future. A more reliable set of selectors would leverage the `header` and `main` semantic elements, which I use in my template. I'm careful to include indexable content only within those elements. I also added `dt` and `dd` elements, in case I start using those in the future.

If I've misunderstood anything here, or if you have concerns about this change, feel free to add comments and I can add further commits to this pull request.

Thanks!