### PR TITLE
update drone.io

### DIFF
--- a/configs/drone_io.json
+++ b/configs/drone_io.json
@@ -1,7 +1,7 @@
 {
   "index_name": "drone_io",
   "start_urls": [
-    "http://docs.drone.io/"
+    "http://docs.drone.io/sitemap/"
   ],
   "stop_urls": [
     "/tags/",

--- a/configs/drone_io.json
+++ b/configs/drone_io.json
@@ -1,27 +1,24 @@
 {
   "index_name": "drone_io",
   "start_urls": [
-    "http://readme.drone.io/"
+    "http://docs.drone.io/"
   ],
   "stop_urls": [
     "/tags/",
-    "http://readme.drone.io/fr/",
-    "http://readme.drone.io/en/",
-    "http://readme.drone.io/es/",
-    "http://readme.drone.io/pt/",
-    "http://readme.drone.io/zh-cn",
-    "http://readme.drone.io/zh-tw/",
-    "http://readme.drone.io/ja/",
-    "http://readme.drone.io/ru/",
-    "http://readme.drone.io/hu/"
+    "http://docs.drone.io/fr/",
+    "http://docs.drone.io/en/",
+    "http://docs.drone.io/es/",
+    "http://docs.drone.io/pt/",
+    "http://docs.drone.io/zh-cn",
+    "http://docs.drone.io/zh-tw/",
+    "http://docs.drone.io/ja/",
+    "http://docs.drone.io/ru/",
+    "http://docs.drone.io/hu/"
   ],
   "selectors": {
-    "lvl0": "header nav a.selected",
-    "lvl1": "main h1",
-    "lvl2": "main h2",
-    "lvl3": "main h3",
-    "lvl4": "main h4",
-    "lvl5": "main h5",
+    "lvl0": "body > ul > li > span",
+    "lvl1": "body > ul > li > ul > li > span",
+    "lvl2": "body > ul > li > ul > li > ul > li > a",
     "text": "main p, main li"
   },
   "min_indexed_level": 1,


### PR DESCRIPTION
Updating configuration per https://github.com/algolia/docsearch-configs/issues/186

I have confirmed the selectors work, but I was hoping someone could review and confirm that this configuration will work as expected. The goal is for docsearch to crawl the documentation sitemap:
http://docs.drone.io/sitemap/

The hope is that by crawling the sitemap and then indexing each page the he sitemap, the crawler configuration and selectors would no longer be impacted by structural changes to the our documentation templates, navigation, etc.

So hoping this configuration works the way I think it will. Thanks for the code review and for providing this service!
