### PR TITLE
update boosted.orange.com v4 documentation path

### DIFF
--- a/configs/boosted-orange.json
+++ b/configs/boosted-orange.json
@@ -1,7 +1,7 @@
 {
   "index_name": "boosted-orange",
   "start_urls": [
-    "http://boosted.orange.com/4.0/"
+    "http://boosted.orange.com/docs/4.0/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Hi,

We've update our deployment path for boosted.orange.com, documentation is now at boosted.orange.com/docs/4.0

So this pull request update the indexation path