### PR TITLE
[lagom] Adds new values on the version facet

### DIFF
--- a/configs/lagomframework.json
+++ b/configs/lagomframework.json
@@ -8,7 +8,10 @@
           "1.0.x",
           "1.1.x",
           "1.2.x",
-          "1.3.x"
+          "1.3.x",
+          "1.4.x",
+          "current",
+          "latest"
         ],
         "language": [
           "scala",
@@ -23,7 +26,10 @@
           "1.0.x",
           "1.1.x",
           "1.2.x",
-          "1.3.x"
+          "1.3.x",
+          "1.4.x",
+          "current",
+          "latest
         ],
         "language": [
           "scala",
@@ -38,6 +44,7 @@
   "stop_urls": [
     "/api/java/",
     "/java/api",
+    "/scala/api",
     "ReferenceGuide",
     "Home"
   ],


### PR DESCRIPTION
Lagom site publishes the documentation for each version separately and it also includes a `latest` and `current` aliases to point to preview and currently stable releases. This PR adds `1.4.x`, `latest` and `current` values to the `version` facet. The lagom team will make sure that `current` and `latest` contain the appropriate content as versions evolve. This means the contents under `latest` and `current` may suffer big changes overnight. Please let us know if that's an issue with the current indexing setup.


This PR also includes `/scala/api` to the `stop_urls` array so that Scala API Docs are not indexed. I noticed there was `stop_urls` for the Java API Docs URLs only and that seems like a mistake. I think `/api/java` is not required anymore but I think we're better off keeping that.


PS: this is part of https://www.lagomframework.com/documentation/