### PR TITLE
[tags] laravel

### DIFF
--- a/configs/laravel.json
+++ b/configs/laravel.json
@@ -1,4 +1,13 @@
 {
+  "tags": {
+    "name": "Laravel",
+    "url": "https://laravel.com/docs/",
+    "categories": [
+      "ecommerce",
+      "framework",
+      "php"
+    ]
+  },
   "index_name": "laravel",
   "start_urls": [
     {


### PR DESCRIPTION
First pass at a `tags` object in a Docsearch config (see #221). I selected Laravel more or less randomly. :) If we like how this looks, we can start rolling the format out to existing configs, and introducing it to new configs as a best practice as well.