### PR TITLE
Removing old releases from indexes.

### DIFF
--- a/configs/polysync.json
+++ b/configs/polysync.json
@@ -6,7 +6,9 @@
   ],
   "stop_urls": [
     "http://docs.polysync.io/flows/getting-started/",
-    "https://docs.polysync.io/flows/getting-started/"
+    "https://docs.polysync.io/flows/getting-started/",
+    "http://docs.polysync.io/releases",
+    "https://docs.polysync.io/releases"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
Anything with a url that begins `http://docs.polysync.io/releases` should be ignored.