### PR TITLE
change tinymce configs min_indexed_level

### DIFF
--- a/configs/tinymce-v3.json
+++ b/configs/tinymce-v3.json
@@ -18,6 +18,6 @@
     "lvl4": ".content h4",
     "text": ".content p"
   },
-  "min_indexed_level": 2,
+  "min_indexed_level": 1,
   "nb_hits": 3699
 }

--- a/configs/tinymce.json
+++ b/configs/tinymce.json
@@ -18,6 +18,6 @@
     "lvl4": ".content h4",
     "text": ".content p"
   },
-  "min_indexed_level": 2,
+  "min_indexed_level": 1,
   "nb_hits": 5108
 }


### PR DESCRIPTION
Hi again!

I figured out that our H1s weren't being indexed, making the search on the tinymce docs working pretty bad and I think this is the reason. Perhaps there is some reason that this was set to `2` before? 