### PR TITLE
RightScale - add searchableAttributes

### DIFF
--- a/configs/rightscale.json
+++ b/configs/rightscale.json
@@ -25,6 +25,14 @@
       "desc(version_patch)",
       "desc(weight.level)",
       "asc(weight.position)"
+    ],
+    "searchableAttributes": [
+      "keywords",
+      "hierarchy",
+      "hierarchy_camel",
+      "content",
+      "anchor",
+      "url"
     ]
   },
   "nb_hits": 48649


### PR DESCRIPTION
This will allow us to use 

`<meta content=“<JSON containing your key word>” name=‘docsearch:keywords’>`
For example: `<meta content='["remove", "user"]' name=‘docsearch:keywords’>`