### PR TITLE
Add braze config (site not live yet)

### DIFF
--- a/configs/braze.json
+++ b/configs/braze.json
@@ -1,0 +1,30 @@
+{
+  "index_name": "braze",
+  "start_urls": [
+    {
+      "url": "https://www.braze.com/(?P<section>.*?)/",
+      "variables": {
+        "section": [
+          "documentation",
+          "academy"
+        ]
+      }
+    },
+    "https://www.braze.com/documentation/Platform_Wide",
+    "https://www.braze.com/academy/Getting_Started"
+  ],
+  "scrap_start_urls": false,
+  "stop_urls": [
+    ".*?[^/]$"
+  ],
+  "selectors": {
+    "lvl0": "ul.nav a.heading",
+    "lvl1": ".article h1",
+    "lvl2": ".article h2",
+    "lvl3": ".article h3",
+    "lvl4": ".article h4",
+    "text": ".article p, .article li"
+  },
+  "nb_hits": 8625,
+  "min_indexed_level": 2
+}


### PR DESCRIPTION
We are currently going through a rename from Appboy to Braze. We use docsearch for our searching for our Documentation and Academy pages, located at 

https://www.appboy.com/documentation/Platform_Wide and https://www.appboy.com/academy/Getting_Started 

On Thursday, when we officially change names, we'll be switching from:

https://www.appboy.com/documentation/Platform_Wide 
https://www.appboy.com/academy/Getting_Started 

to (not live yet): 

https://www.braze.com/documentation/Platform_Wide
https://www.braze.com/academy/Getting_Started 

This config is functionally identical to the one currently located at configs/appboy.json.

We'll let you know when the new site is live so that it can get scraped -- not sure how the merge schedule would work with that (idk if that happens automatically upon merge -- if so, we should hold off on merging). Thanks! We're working to get the new sites live within the next 36h.



