### PR TITLE
Rename metro-bundler to metro

### DIFF
--- a/configs/metro.json
+++ b/configs/metro.json
@@ -2,7 +2,7 @@
   "index_name": "metro",
   "start_urls": [
     {
-      "url": "http://facebook.github.io/metro-bundler/docs/(?P<lang>.*?)/getting-started.html",
+      "url": "http://facebook.github.io/metro/docs/(?P<lang>.*?)/getting-started.html",
       "variables": {
         "lang": [
           "en"
@@ -10,7 +10,7 @@
       }
     },
     {
-      "url": "http://facebook.github.io/metro-bundler/docs/(?P<lang>.*?)/",
+      "url": "http://facebook.github.io/metro/docs/(?P<lang>.*?)/",
       "variables": {
         "lang": [
           "en"


### PR DESCRIPTION
Today we are renaming metro-bundler to metro. I will ping this PR once the rename is complete. Let me know if there is something else I need to do.

See https://github.com/algolia/docsearch-configs/pull/264