### PR TITLE
Remove sitemap crawling for realm.io

### DIFF
--- a/configs/realm-io.json
+++ b/configs/realm-io.json
@@ -26,9 +26,6 @@
       ]
     }
   ],
-  "sitemap_urls": [
-    "https://realm.io/sitemap.xml"
-  ],
   "stop_urls": [
     "api",
     "objc/\\d",
@@ -46,7 +43,6 @@
     "lvl4": ".docs-body h6",
     "text": ".docs-body p, .docs-body li"
   },
-  "force_sitemap_urls_crawling": true,
   "min_indexed_level": 1,
   "nb_hits": 16390
 }


### PR DESCRIPTION
Our nginx makes finding our sitemap more difficult. I would like to revert this new functionality and keep my algolia docsearch as it was in https://github.com/algolia/docsearch-configs/commit/fac8eafaf1eff97806b587a94dccb07e9ceeb1de#diff-3e79a39e093bf5c49813ab4fbb489bfe