### PR TITLE
Update reason-react urls

### DIFF
--- a/configs/react-reason.json
+++ b/configs/react-reason.json
@@ -1,8 +1,7 @@
 {
   "index_name": "react-reason",
   "start_urls": [
-    "https://reasonml.github.io/reason-react/docs/",
-    "https://reasonml.github.io/reason-react/docs/en/installation.html"
+    "https://reasonml.github.io/reason-react/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
https://reasonml.github.io/reason-react/docs/ is actually 404.
I'm not sure why https://reasonml.github.io/reason-react/docs/en/installation.html is listed as a start url. Maybe that's a default (thanks though =))