### PR TITLE
Update config for bucklescript.github.io

### DIFF
--- a/configs/bucklescript.json
+++ b/configs/bucklescript.json
@@ -1,16 +1,23 @@
 {
   "index_name": "bucklescript",
   "start_urls": [
-    "http://bucklescript.github.io/bucklescript/Manual.html"
+    "http://bucklescript.github.io/"
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".article h1",
-    "lvl1": ".article h2",
-    "lvl2": ".article h3",
-    "lvl3": ".article h4",
-    "lvl4": ".article h5",
-    "text": ".article p, .article li"
+    "lvl0": {
+      "selector": "//*[contains(@class,'navGroupActive')]//a[contains(@class,'navItemActive')]/preceding::h3[1]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": ".post h1",
+    "lvl2": ".post h2",
+    "lvl3": ".post h3",
+    "lvl4": ".post h4",
+    "text": ".post p, .post li"
   },
-  "nb_hits": 1100
+  "min_indexed_level": 1,
+  "strip_chars": " .,;:#",
+  "nb_hits": 278
 }


### PR DESCRIPTION
We've launched a new doc site that's based on the same doc site generator as [reason-react](https://github.com/chenglou/docsearch-configs/blob/fb21662f71a0dac7c909349181a5a8702a066f3a/configs/react-reason.json), so I think most of the configs transfer over.

Also incorporated changes from #278