### PR TITLE
[Reason] Temporarily restrict search to English

### DIFF
--- a/configs/reason.json
+++ b/configs/reason.json
@@ -5,15 +5,7 @@
       "url": "https://reasonml.github.io/docs/(?P<language>.*?)/",
       "variables": {
         "language": [
-          "en",
-          "ja",
-          "es-ES",
-          "fr",
-          "ko",
-          "pt-BR",
-          "ru",
-          "zh-CN",
-          "zh-TW"
+          "en"
         ]
       }
     },


### PR DESCRIPTION
Our documentation generator doesn't search the right language yet, so a search for `foo` gives 5+ result across all languages. This disables that.

Once the documentation generator works correctly I'll revert this.