### PR TITLE
Always search and return results from 'current'

### DIFF
--- a/configs/akka-http.json
+++ b/configs/akka-http.json
@@ -2,42 +2,30 @@
   "index_name": "akka-http",
   "start_urls": [
     {
-      "url": "https://doc.akka.io/docs/akka-http/(?P<version>.*?)/(?P<language>.*?).html",
+      "url": "https://doc.akka.io/docs/akka-http/current/(?P<language>.*?).html",
       "variables": {
         "language": [
           "scala",
           "java"
-        ],
-        "version": {
-          "url": "https://doc.akka.io/docs/akka-http/",
-          "js": "var versions = []; for(var i = 0 ; i < document.getElementsByTagName(\"a\").length; i++) { versions.push(document.getElementsByTagName(\"a\")[i].attributes[0].value); }; versions = versions.filter(function(e) { return !e.startsWith('?') && e.endsWith(\"/\") && !e.startsWith('rp') && (parseInt(e, 10) > 1 || e.startsWith('current') || e.startsWith('snapshot')); }).map(function(e) { return e.replace(/\\//g, ''); }); return JSON.stringify(versions);"
-        }
+        ]
       }
     },
     {
-      "url": "https://doc.akka.io/docs/akka-http/(?P<version>.*?)/(?P<language>.*?)/",
+      "url": "https://doc.akka.io/docs/akka-http/current/(?P<language>.*?)/",
       "variables": {
         "language": [
           "scala",
           "java"
-        ],
-        "version": {
-          "url": "https://doc.akka.io/docs/akka-http/",
-          "js": "var versions = []; for(var i = 0 ; i < document.getElementsByTagName(\"a\").length; i++) { versions.push(document.getElementsByTagName(\"a\")[i].attributes[0].value); }; versions = versions.filter(function(e) { return !e.startsWith('?') && e.endsWith(\"/\") && !e.startsWith('rp') && (parseInt(e, 10) > 1 || e.startsWith('current') || e.startsWith('snapshot')); }).map(function(e) { return e.replace(/\\//g, ''); }); return JSON.stringify(versions);"
-        }
+        ]
       }
     },
     {
-      "url": "https://doc.akka.io/docs/akka-http/(?P<version>.*?)/",
+      "url": "https://doc.akka.io/docs/akka-http/current/",
       "variables": {
         "language": [
           "scala",
           "java"
-        ],
-        "version": {
-          "url": "https://doc.akka.io/docs/akka-http/",
-          "js": "var versions = []; for(var i = 0 ; i < document.getElementsByTagName(\"a\").length; i++) { versions.push(document.getElementsByTagName(\"a\")[i].attributes[0].value); }; versions = versions.filter(function(e) { return !e.startsWith('?') && e.endsWith(\"/\") && !e.startsWith('rp') && (parseInt(e, 10) > 1 || e.startsWith('current') || e.startsWith('snapshot')); }).map(function(e) { return e.replace(/\\//g, ''); }); return JSON.stringify(versions);"
-        }
+        ]
       }
     }
   ],


### PR DESCRIPTION
This aligns the configuration to the akka_io config. We are no longer sending version parameter to algolia when searching.