### PR TITLE
Prep for Bootstrap 4.1

### DIFF
--- a/configs/bootstrap-v4.1.json
+++ b/configs/bootstrap-v4.1.json
@@ -1,0 +1,19 @@
+{
+  "index_name": "bootstrap-v4.1",
+  "start_urls": [
+    "https://getbootstrap.com/docs/4.1/"
+  ],
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": ".bd-toc-item.active > a",
+    "lvl1": ".bd-content h1",
+    "lvl2": ".bd-content h2",
+    "lvl3": ".bd-content h3",
+    "text": ".bd-content p, .bd-content li, .bd-example"
+  },
+  "min_indexed_level": 1,
+  "conversation_id": [
+    "423628659"
+  ],
+  "nb_hits": 3068
+}


### PR DESCRIPTION
When we release v4.1 in the coming weeks (possibly next week, likely week after), we'll have a new docs subfolder to point to. We'll still have the v4.0 docs at the existing URLs though and will link to those through our site's header.

I'm unsure what else needs modifying here, but we'll need a fresh index of the new docs I imagine.