### PR TITLE
Update asciidwango.json

### DIFF
--- a/configs/asciidwango.json
+++ b/configs/asciidwango.json
@@ -6,7 +6,7 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//nav//li[contains(@class, 'active')][1]/preceding::*[contains(@data-level,'1.2')][1]",
+      "selector": "//nav//li[1]/preceding::*[contains(@data-level,'1')]/a",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"

--- a/configs/asciidwango.json
+++ b/configs/asciidwango.json
@@ -6,7 +6,7 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//nav//li[1]/preceding::*[contains(@data-level,'1')]/a",
+      "selector": "//nav//li[contains(@class, 'active')]/a",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"


### PR DESCRIPTION
Hi, I want to change `lvl0` selector on https://asciidwango.github.io/js-primer/
Because, it show mismatch title("本書の読み方") on search result.
![javascript jsprimer 2018-02-13 16-52-12](https://user-images.githubusercontent.com/19714/36138797-4c943b92-10de-11e8-8bd3-14285ba0960b.png)

Current `selector` match one element that is the same all the time.

```
$x("//nav//li[contains(@class, 'active')][1]/preceding::*[contains(@data-level,'1.2')][1]")
// [li.chapter]
// This selector match always "本書の読み方".
// It is wrong match
```

I've fixed this `selector`.

```
$x("//nav//li[contains(@class, 'active')]/a");
// [a]
// This link node will include current page title
```