### PR TITLE
Add exclude selector to OneLogin's config.json

### DIFF
--- a/configs/onelogin.json
+++ b/configs/onelogin.json
@@ -17,6 +17,9 @@
     "lvl4": ".content h5",
     "text": ".content p, .content li"
   },
+  "selectors_exclude": [
+    ".stackoverflow"
+  ],
   "conversation_id": [
     "523323235"
   ],


### PR DESCRIPTION
This PR will add a custom `exclude_selector` to our `onelogin.json` config file.