### PR TITLE
Customize isomorphic_git.json to index tables and code comments

### DIFF
--- a/configs/isomorphic_git.json
+++ b/configs/isomorphic_git.json
@@ -14,10 +14,10 @@
       "default_value": "Documentation"
     },
     "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "text": ".post article p, .post article li"
+    "lvl2": ".post table td:first-of-type",
+    "lvl3": ".post h2",
+    "lvl4": ".post h3",
+    "text": ".post article p, .post article li, .post table td:not(:first-of-type), .post .hljs-comment"
   },
   "selectors_exclude": [
     ".hash-link"


### PR DESCRIPTION
I'm using tables with this format:

| PARAM        | TYPE [= DEFAULT]         | DESCRIPTION                             |
| ------------ | ------------------------ | --------------------------------------- |
| argumentName | string = 'default_value' | This is the description of the argument |

Algolia isn't currently indexing the text inside the tables, which is bad because most of my documentation is inside tables. [example of git.clone() documentation page](https://isomorphic-git.github.io/docs/clone.html)

This proposed change adds indexing of `td` cells. Since level 1 are the function names, I designated level 2 as the function parameters (using ".post table td:first-of-type"). I also extended the "text" selector to match the remaining table columns so that default values, argument types like Date or EventEmitter, and the parameter descriptions are indexed as page text.

I'm also using `code` blocks with comments to document object schemas on occasion [such as in log.html](https://isomorphic-git.github.io/docs/log.html). So I think it would be helpful to index code comments. Luckily this is easy, because all the code blocks get formatted by highlight.js on the server, so all the code comments can be selected using ".post .hljs-comment". I extended the "text" selector to include those as well.