### PR TITLE
Fix chartiq selectors to reflect new CSS

### DIFF
--- a/configs/chartiq.json
+++ b/configs/chartiq.json
@@ -5,15 +5,12 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "",
-      "default_value": "Documentation"
-    },
-    "lvl1": "article h2",
-    "lvl2": "article h3",
-    "lvl3": "article h4",
-    "lvl4": "article h5",
-    "text": "article p, article li"
+    "lvl0": "h1",
+    "lvl1": "h2",
+    "lvl2": "h3",
+    "lvl3": "h4",
+    "lvl4": "h5",
+    "text": "p, li"
   },
   "conversation_id": [
     "316287518"


### PR DESCRIPTION
Our search results were looking pretty bad. Turns out it was our fault.