### PR TITLE
Fix CircleCI's bad search URLs.

### DIFF
--- a/configs/circleci.json
+++ b/configs/circleci.json
@@ -90,7 +90,8 @@
     }
   },
   "selectors_exclude": [
-    "#site-search"
+    "#site-search",
+    "#nav-button"
   ],
   "conversation_id": [
     "317414915"


### PR DESCRIPTION
With [CircleCI Docs](https://circleci.com/docs/), if you use the search box and get a result that returns the top of the page (aka not a result with an anchor), the anchor `#nav-button` is appended to the URL.

`#nav-button` is parts of our mobile menu and shouldn't really be coming up at all with regards to URLs and searching.

The goal of this PR is so that when someone searches for the word `images`, instead of them being taken to this URL (`https://circleci.com/docs/2.0/circleci-images/#nav-button`) they will just be taken to (`https://circleci.com/docs/2.0/circleci-images/`).

I'm not too familiar with Algolia so I don't know how to test if this PR will indeed fix the problem.