### PR TITLE
Add version 3.0 to Laravel-Excel index

### DIFF
--- a/configs/laravel_excel.json
+++ b/configs/laravel_excel.json
@@ -5,7 +5,8 @@
       "url": "https://laravel-excel.maatwebsite.nl/docs/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "2.1"
+          "2.1",
+          "3.0"
         ]
       }
     }


### PR DESCRIPTION
We just added `3.0` to the versions of our documentation. If I understand the config correctly, the version should be added here to make indexable.

Thanks!