### PR TITLE
Change GitLab tag from ee to gitlab

### DIFF
--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -3,9 +3,9 @@
   "start_urls": [
     {
       "url": "https://docs.gitlab.com/ee/",
-      "selectors_key": "ee",
+      "selectors_key": "gitlab",
       "tags": [
-        "ee"
+        "gitlab"
       ]
     },
     {
@@ -34,7 +34,7 @@
     ".*^(?!.*html)"
   ],
   "selectors": {
-    "ee": {
+    "gitlab": {
       "lvl0": {
         "selector": "",
         "default_value": "GitLab"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

We need to display GITLAB instead of EE in our custom search results, so we need to change the tag https://gitlab.com/gitlab-com/gitlab-docs/merge_requests/203.
