### PR TITLE
GitLab docs: set "only_content_level": true

### DIFF
--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -78,6 +78,7 @@
   ],
   "min_indexed_level": 1,
   "scrap_start_urls": false,
+  "only_content_level": true,
   "conversation_id": [
     "434475832"
   ],


### PR DESCRIPTION
# Pull request motivation(s)

For https://gitlab.com/gitlab-com/gitlab-docs/issues/134

@s-pace does this solve the problem with the description? https://gitlab.com/gitlab-com/gitlab-docs/issues/134

### What is the current behaviour?

Results display headers only, with no content accompanying the hit.

### What is the expected behaviour?

Have a content description accompanying every hit that only shows headers

cc/ @axilleas 
