### PR TITLE
pusher-docs config change: there's only one Chatkit

### DIFF
--- a/configs/docs-pusher.json
+++ b/configs/docs-pusher.json
@@ -36,7 +36,7 @@
       "lvl0": {
         "selector": "",
         "global": true,
-        "default_value": "Chatkits"
+        "default_value": "Chatkit"
       },
       "lvl1": "main article h1",
       "lvl2": "main article h2",


### PR DESCRIPTION
# Pull request motivation(s)

When we search for items tagged with chatkit the drop-down says "Chatkits" rather than "Chatkit" which is the product name. I'm hoping this change would fix this. 

##### NB: Do you want to request a **feature** or report a **bug**?

Config change

##### NB2: Any other feedback / questions ?

I don't think this change would affect anything else .... but I'm not confident I understand the config very well.