### PR TITLE
Many of our blog posts serve as documentation

### DIFF
--- a/configs/aerobatic.json
+++ b/configs/aerobatic.json
@@ -1,7 +1,8 @@
 {
   "index_name": "aerobatic",
   "start_urls": [
-    "https://www.aerobatic.com/docs/"
+    "https://www.aerobatic.com/docs/",
+    "https://www.aerobatic.com/blog/"
   ],
   "sitemap_urls": [
     "https://www.aerobatic.com/sitemap.xml"


### PR DESCRIPTION
Hoping to include the `/blog/*` pages of our site to the search index.
