### PR TITLE
fix(getkong): escape paratheses on 'latest' regex for correct version

### DIFF
--- a/configs/getkong.json
+++ b/configs/getkong.json
@@ -6,7 +6,7 @@
       "variables": {
         "version": {
           "url": "https://getkong.org/docs/",
-          "js": "var versions = $('ul[aria-labelledby=version-dropdown] a, button#version-dropdown').map(function(i, e) { return $(e).text().replace(/\\s+/g, '').replace(/Version/g, '').replace(/(latest)/g, ''); }).toArray(); return JSON.stringify(versions);"
+          "js": "var versions = $('ul[aria-labelledby=version-dropdown] a, button#version-dropdown').map(function(i, e) { return $(e).text().replace(/\\s+/g, '').replace(/Version/g, '').replace(/\\(latest\\)/g, ''); }).toArray(); return JSON.stringify(versions);"
         }
       }
     }


### PR DESCRIPTION
# Pull request motivation(s)
Versions were showing up in facets as "0.12.x()" for latest version, while other facets were referred to as "0.11.x", "0.10.x" etc. with no parantheses.

### What is the current behaviour?
Steps to reproduce:
1. run scraper with config with an index
2. verify in index that version has parantheses

### What is the expected behaviour?
latest version shoudln't have parantheses

Emailed with @s-pace who setup this config initially. Thanks @s-pace !