### PR TITLE
Added reference / and referenz as they should be indexed

### DIFF
--- a/configs/ultradox.json
+++ b/configs/ultradox.json
@@ -13,7 +13,8 @@
     "https://help.ultradox.com/en/guides/overview.html"
   ],
   "stop_urls": [
-    "/pricing/"
+    "/pricing/",
+    "/reference/api/"
   ],
   "selectors": {
     "lvl0": {

--- a/configs/ultradox.json
+++ b/configs/ultradox.json
@@ -13,9 +13,7 @@
     "https://help.ultradox.com/en/guides/overview.html"
   ],
   "stop_urls": [
-    "/pricing/",
-    "/reference/",
-    "/referenz/"
+    "/pricing/"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
Adjusted the Ultradox configuration to include /reference/ and /referenz/ in the index by removing them from the stop_urls section.