### PR TITLE
Revert "Update index selectors for Express-Gateway"

### DIFF
--- a/configs/express-gateway.json
+++ b/configs/express-gateway.json
@@ -8,10 +8,10 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".algoliaLv0",
-    "lvl1": ".algoliaLv1",
-    "lvl2": ".algoliaLv2",
-    "lvl3": "section h1",
+    "lvl0": "section h1",
+    "lvl1": "section h2",
+    "lvl2": "section h3",
+    "lvl3": "section h4",
     "lvl4": "section h5",
     "text": "section p, section li"
   },


### PR DESCRIPTION
Reverts algolia/docsearch-configs#343
@XVincentX 
Please revers the order of your elements within your page. It should be:
```html
<p class="algoliaLv0">...</p>
<p class="algoliaLv1">...</p>
<p class="algoliaLv2">...</p>
```