### PR TITLE
Reconfigure Apollo to work across all docs repos.

### DIFF
--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -19,8 +19,7 @@
       "text": ".content-wrapper p, .content-wrapper li, .header-wrapper div.subtitle-page"
     }
   },
-  "only_content_level": true,
-  "min_indexed_level": 1,
+  "min_indexed_level": 2,
   "conversation_id": [
     "355172644"
   ],

--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -24,5 +24,5 @@
   "conversation_id": [
     "355172644"
   ],
-  "nb_hits": 2420
+  "nb_hits": 3623
 }

--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -4,7 +4,7 @@
     "https://www.apollographql.com/docs/"
   ],
   "stop_urls": [
-    "#"
+    "index\\.html"
   ],
   "selectors": {
     "default": {

--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -23,5 +23,5 @@
   "conversation_id": [
     "355172644"
   ],
-  "nb_hits": 3623
+  "nb_hits": 3263
 }

--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -4,17 +4,23 @@
     "https://www.apollographql.com/docs/"
   ],
   "stop_urls": [
-    "index\\.html"
+    "#"
   ],
   "selectors": {
-    "lvl0": ".content h1",
-    "lvl1": ".content h2",
-    "lvl2": ".content h3",
-    "lvl3": ".content h4",
-    "lvl4": ".content h5",
-    "text": ".content p, .content li"
+    "default": {
+      "lvl0": {
+        "selector": "div.sidebar span.title-sidebar",
+        "default_value": "Documentation"
+      },
+      "lvl1": ".header-wrapper h1",
+      "lvl2": ".content-wrapper h2",
+      "lvl3": ".content-wrapper h3",
+      "lvl4": ".content-wrapper h4",
+      "text": ".content-wrapper p, .content-wrapper li, .header-wrapper div.subtitle-page"
+    }
   },
-  "min_indexed_level": 2,
+  "only_content_level": true,
+  "min_indexed_level": 1,
   "conversation_id": [
     "355172644"
   ],


### PR DESCRIPTION
I'd appreciate some input on this!

Most all of the Apollo docs repositories now use the same format and I'm
hoping this will allow us to re-enable search on all of them, with a simple
configuration that will automatically expand as we deploy more properties.

A partial list of docs which would use this new configuration can be found at [this URL](https://github.com/meteor/hexo-theme-meteor#known-deployments) (paying attention to only observe the Apollo GraphQL links, not the Meteor links.

It's possible that some of these haven't been updated yet, but they will be soon!