### PR TITLE
remove `only_content: true`

### DIFF
--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -78,7 +78,6 @@
   ],
   "min_indexed_level": 1,
   "scrap_start_urls": false,
-  "only_content_level": true,
   "conversation_id": [
     "434475832"
   ],


### PR DESCRIPTION
# Pull request motivation(s)

Revert changes introduced in https://github.com/algolia/docsearch-configs/pull/331:

The search results look nicer than before, but we're losing a lot of hits based on `h1`s. E.g.: docs.gitlab.com/search/ - search for GitLab Pages, it returns no hit.

Context in GitLab: https://gitlab.com/gitlab-com/gitlab-docs/issues/134#note_63634403

cc/ @s-pace @axilleas 
