### PR TITLE
Update cockroachlabs config

### DIFF
--- a/configs/cockroachlabs.json
+++ b/configs/cockroachlabs.json
@@ -20,12 +20,12 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": "#main-content .content-col h1",
-    "lvl1": "#main-content .content-col h2",
-    "lvl2": "#main-content .content-col h3",
-    "lvl3": "#main-content .content-col h4",
-    "lvl4": "#main-content .content-col h5",
-    "text": "#main-content .content-col p, #main-content .content-col li"
+    "lvl0": "#main-content .post-header h1",
+    "lvl1": "#main-content .post-content h2",
+    "lvl2": "#main-content .post-content h3",
+    "lvl3": "#main-content .post-content h4",
+    "lvl4": "#main-content .post-content h5",
+    "text": "#main-content .post-content p, #main-content .post-content li"
   },
   "only_content_level": true,
   "conversation_id": [

--- a/configs/cockroachlabs.json
+++ b/configs/cockroachlabs.json
@@ -18,7 +18,9 @@
   "sitemap_urls": [
     "https://www.cockroachlabs.com/sitemap.xml"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "#see-also"
+  ],
   "selectors": {
     "lvl0": "#main-content .post-header h1",
     "lvl1": "#main-content .post-content h2",


### PR DESCRIPTION
__[description]:__
* restrict `<h1>` target to `.post-header`; restrict lower hierarchy selectors to target content in `.post-content` only
* ignore URLs with `see-also` anchor

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
We're seeing some unhelpful information being returned in hit content.  It seems to stem from two main sources: 

1. Content from `<li>` tags in the header container being indexed
2. Content from `<li>` tags in `See Also` section at end of page being indexed

### What is the current behaviour?
See above.

![indexing_issues](https://user-images.githubusercontent.com/6320333/37674434-422a8004-2c49-11e8-8b52-56193f1b84fe.png)

### What is the expected behaviour?
We would like to have more descriptive content summaries available in our search results. 

##### NB: Do you want to request a **feature** or report a **bug**?
Bug

##### NB2: Any other feedback / questions ?
