### PR TITLE
Adding v0.10 release documentation in the config

### DIFF
--- a/configs/aahframework.json
+++ b/configs/aahframework.json
@@ -5,6 +5,7 @@
       "url": "https://docs.aahframework.org/(?P<version>.*?)",
       "variables": {
         "version": [
+          "v0.10",
           "v0.9",
           "v0.8",
           "v0.7",


### PR DESCRIPTION
aah framework v0.10 have been released. Updated the config for indexing v0.10 documentation.