### PR TITLE
Update start url for Afosto

### DIFF
--- a/configs/afosto.json
+++ b/configs/afosto.json
@@ -1,7 +1,7 @@
 {
   "index_name": "afosto",
   "start_urls": [
-    "https://afosto.github.io/afosto-docs/"
+    "http://help.afosto.com/"
   ],
   "stop_urls": [
     "/blog/"


### PR DESCRIPTION
We moved the GH pages to a subdomain of our site
Therefore the url to crawl needs to be updated
