### PR TITLE
Update quanteda.json

### DIFF
--- a/configs/quanteda.json
+++ b/configs/quanteda.json
@@ -8,20 +8,13 @@
     "LICENSE-text.html"
   ],
   "selectors": {
-    "lvl0": {
-      "selector": ".page-header h1",
-      "default_value": "No Header"
-    },
-    "lvl1": {
-      "selector": ".contents h1",
-      "default_value": "Unsorted"
-    },
-    "lvl2": ".contents h2",
-    "lvl3": ".contents h3, .contents th",
-    "lvl4": ".contents h4",
-    "lvl5": ".contents h4",
+    "lvl0": ".contents h1",
+    "lvl1": ".contents h2",
+    "lvl2": ".contents h3, .contents th, .contents dt",
+    "lvl3": ".contents h4",
+    "lvl4": ".contents h5",
     "text": ".contents p, .contents li, .usage, .template-article .contents .pre"
-  },
+},
   "selectors_exclude": [
     ".dont-index",
     "#see-also"


### PR DESCRIPTION
# Pull request motivation(s)

Make search results more informative

### What is the current behaviour?

There are too may 'Unsorted' in the result

### What is the expected behaviour?

Some thing similar to the pkgdown website: http://pkgdown.r-lib.org/index.html

##### NB2: Any other feedback / questions ?

We have functions named like `tokens_select()` and `dfm_group()`. DocSearch seems to separate these strings into 'tokens' + 'select' and 'dfm' + 'group' unless quanteda. I don't think it should segment query by underscore.

Otherwise, its is great responsive search tool! 