### PR TITLE
use parent breadcrumb as lvl0 selector for antora

### DIFF
--- a/configs/antora.json
+++ b/configs/antora.json
@@ -9,7 +9,9 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "nav.nav-menu li.is-current-page a.nav-link",
+      "selector": "//nav[@class='crumbs']//li[@class='crumb'][last()-1]",
+      "type": "xpath",
+      "global": true,
       "default_value": "Home"
     },
     "lvl1": ".doc h1",


### PR DESCRIPTION
Use the parent breadcrumb as the text for the lvl0 heading in the antora search. Also, reenable the global setting on the lvl0 selector.