### PR TITLE
update config param for doc search following the publication of the v4.1 of Boosted

### DIFF
--- a/configs/boosted-orange.json
+++ b/configs/boosted-orange.json
@@ -1,7 +1,13 @@
 {
   "index_name": "boosted-orange",
   "start_urls": [
-    "http://boosted.orange.com/docs/4.0/"
+    "http://boosted.orange.com/docs/(?P<version>.*?)/",
+    "variables": {
+      "version": [
+        "4.0",
+        "4.1"
+      ]
+    }
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Hello,

Following the publication of the documentation of our v4.1 which will coexist with the old v4.0 we need to update the index.

As I understand it will indexed both urls as http://boosted.orange.com/docs/4.0 and http://boosted.orange.com/docs/4.1.

There's still one question for me, how could I filter the search result from my website to serve the right content on each versions?

Thanks to you for your great job