### PR TITLE
restore crawling for default UI component in Antora docs

### DIFF
--- a/configs/antora.json
+++ b/configs/antora.json
@@ -8,7 +8,8 @@
           "1.0"
         ]
       }
-    }
+    },
+    "https://docs.antora.org/antora-ui-default/"
   ],
   "sitemap_urls": [
     "https://docs.antora.org/sitemap.xml"


### PR DESCRIPTION
Also crawl the unversioned component in the Antora documentation.