### PR TITLE
Sample -> Samples, add "example" as a tag

### DIFF
--- a/configs/typescriptlang.json
+++ b/configs/typescriptlang.json
@@ -5,7 +5,7 @@
     {
       "url": "http://www.typescriptlang.org/samples/",
       "tags": [
-        "sample"
+        "sample", "example"
       ],
       "selectors_key": "sample"
     }
@@ -31,7 +31,7 @@
     "sample": {
       "lvl0": {
         "selector": "",
-        "default_value": "Sample"
+        "default_value": "Samples"
       },
       "lvl1": ".exampleBox h3.exampleHeadline",
       "text": ".exampleSummary"


### PR DESCRIPTION
I believe this change would allow searches for "example" to direct to "sample", and to change the text for "Sample" to "Samples":

![image](https://user-images.githubusercontent.com/972891/38753253-b0b1de1a-3f12-11e8-90f3-05660b5ed921.png)
