### PR TITLE
Update definition to index our blog posts as well

### DIFF
--- a/configs/express-gateway.json
+++ b/configs/express-gateway.json
@@ -6,15 +6,18 @@
   "sitemap_urls": [
     "http://www.express-gateway.io/sitemap.xml"
   ],
+  "sitemap_urls_regexs": [
+    "https:\/\/www\.express-gateway\.io\/((?!\/blog\/).)*$"
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": ".algoliaLv0",
-    "lvl1": ".algoliaLv1",
+    "lvl1": ".algoliaLv1, article h1",
     "lvl2": ".algoliaLv2",
     "lvl3": "section h1",
     "lvl4": "section h2",
     "lvl5": "section h3",
-    "text": "section p, section li"
+    "text": "section p, section li, article p"
   },
   "conversation_id": [
     "444614439"

--- a/configs/express-gateway.json
+++ b/configs/express-gateway.json
@@ -12,7 +12,7 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": ".algoliaLv0",
-    "lvl1": ".algoliaLv1, article h1",
+    "lvl1": ".algoliaLv1",
     "lvl2": ".algoliaLv2",
     "lvl3": "section h1",
     "lvl4": "section h2",


### PR DESCRIPTION
Hey,

we write a lot of good content on our blog. Therefore we thought that it makes sense to index its content as well.

Therefore I have modified the index in order to crawl all the pages we write except https://www.express-gateway.io/blog/ — that page is just the index blog page we're not interested in.

Thanks a lot as always for the great service!