### PR TITLE
Index tuturials

### DIFF
--- a/configs/jekyllrb.json
+++ b/configs/jekyllrb.json
@@ -1,7 +1,8 @@
 {
   "index_name": "jekyllrb",
   "start_urls": [
-    "https://jekyllrb.com/docs/"
+    "https://jekyllrb.com/docs/",
+    "https://jekyllrb.com/tutorials/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Index https://jekyllrb.com/tutorials/ and related subsections

### What is the current behaviour?

Users can't currently search content in the tuturials section.
For instance, when you type "bundler", the tutorial on using jekyll with bundler is not returned

### What is the expected behaviour?

Content from the tutorials is displayed in the search results.
