### PR TITLE
Fix Sourcegraph

### DIFF
--- a/configs/sourcegraph.json
+++ b/configs/sourcegraph.json
@@ -16,11 +16,11 @@
       "global": true,
       "default_value": "Introduction"
     },
-    "lvl2": ".markdown h1",
-    "lvl3": ".markdown h2",
-    "lvl4": ".markdown h3",
-    "lvl5": ".markdown h4",
-    "text": ".markdown p, .markdown li"
+    "lvl2": ".documentation__markdown h1",
+    "lvl3": ".documentation__markdown h2",
+    "lvl4": ".documentation__markdown h3",
+    "lvl5": ".documentation__markdown h4",
+    "text": ".documentation__markdown p, .documentation__markdown li"
   },
   "conversation_id": [
     "499959410"

--- a/configs/sourcegraph.json
+++ b/configs/sourcegraph.json
@@ -20,7 +20,7 @@
     "lvl3": ".documentation__markdown h2",
     "lvl4": ".documentation__markdown h3",
     "lvl5": ".documentation__markdown h4",
-    "text": ".documentation__markdown p, .documentation__markdown li"
+    "text": ".documentation__markdown p, .documentation__markdown li, .documentation__markdown td"
   },
   "conversation_id": [
     "499959410"


### PR DESCRIPTION
We recently changed the CSS selector for our docs pages, this PR addresses that change.

Also adds `td` elements as text, in order to index content in the table on this page: https://about.sourcegraph.com/docs/search/query-syntax/.  I think the change is correct, but let me know if otherwise! 

Thanks! 