### PR TITLE
Update uniwebview.json

### DIFF
--- a/configs/uniwebview.json
+++ b/configs/uniwebview.json
@@ -1,27 +1,21 @@
 {
   "index_name": "uniwebview",
   "start_urls": [
-    "http://docs.uniwebview.com/#/"
-  ],
-  "stop_urls": [
-    "id=",
-    "/archived/"
+    "http://docs.uniwebview.com"
   ],
   "selectors": {
     "lvl0": {
       "selector": "",
       "default_value": "UniWebView - Docs"
     },
-    "lvl1": "article h1",
-    "lvl2": "article h2",
-    "lvl3": "article h3",
-    "lvl4": "article h4",
-    "lvl5": "article h5, .api-heading",
-    "text": "article p, article li"
+    "lvl1": ".content h1",
+    "lvl2": ".content h2",
+    "lvl3": ".content h3",
+    "lvl4": ".content h4",
+    "lvl5": ".content h5, .api-heading",
+    "text": ".content p, .content li"
   },
   "min_indexed_level": 1,
-  "js_render": true,
-  "js_wait": 1,
   "use_anchors": true,
   "conversation_id": [
     "373838376"


### PR DESCRIPTION
Hi,

We recreated our doc page for UniWebView: http://docs.uniwebview.com/

I am not quite sure about the config file since initially, some Algolia staff helped me to config the site (thank you a lot by the way!)

Previously it was not a static page, viewers have to render it in the browser (so the js render was used). Now it is a pure static website so I guess I need to change something. I read the recommendation and tried to update our config. It would be also great if you could check it since you are experts on this. :P

There is some tricky implementation on the API reference (like on this page http://docs.uniwebview.com/api/uniwebviewmessage.html)

![snip20180430_1](https://user-images.githubusercontent.com/1019875/39427145-af088c86-4cbd-11e8-8767-b72b80477d3e.png)

The `.api-anchor` is used to determine the navigation position and the `.api-heading` is where the DOM of the documentation entry (item) actually is. Is it possible to write a config file for this case, to make the search result correct and the navigating also going to right place?

Thank you!