### PR TITLE
update mdanalysis.org search config

### DIFF
--- a/configs/mdanalysis.json
+++ b/configs/mdanalysis.json
@@ -1,13 +1,17 @@
 {
   "index_name": "mdanalysis",
+  "sitemap_urls": [
+    "https://www.mdanalysis.org/sitemap.xml",
+  ]
   "start_urls": [
     "https://www.mdanalysis.org"
   ],
   "stop_urls": [
     "https://www.mdanalysis.org/.*?//.*?",
-    "https://www.mdanalysis.org/mdanalysis/_modules",
+    "https://www.mdanalysis.org/mdanalysis",
     "https://www.mdanalysis.org/docs/_modules/",
-    "https://www.mdanalysis.org/docs/_sources"
+    "https://www.mdanalysis.org/docs/_sources",
+    "https://www.mdanalysis.org/blog/page.*",      
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Improve the relevance of the index for the site https://www.mdanalysis.org

- do not index development docs (https://www.mdanalysis.org/mdanalysis) or paginated blog
- use sitemap (probably now needed to find all blog posts now that pagination has been removed); however, the sitemap currently only includes the content generated by jekyll (using the jekyll-sitemap plugin), not the sub-sites that are accessible by crawling. I am reading the ["How it works" docs](https://community.algolia.com/docsearch/documentation/docsearch-scraper/config-options/) as if Algolia will crawl starting from the pages in the sitemap so I hope this will still index most of our site.
- closes MDAnalysis/MDAnalysis.github.io#77

### What is the current behaviour?

Content shows up duplicated or near duplicated (and the [Recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/) rightly advise against such duplication).

### What is the expected behaviour?
Users only expect to see a single relevant topic of the same name.

##### NB: Do you want to request a **feature** or report a **bug**?
Update to our indexer config.

##### NB2: Any other feedback / questions ?
We now provide a sitemap.xml and we hope that the indexer will simply start crawling from there. If not then we have to come up with additional ways to create more sitemaps.