### PR TITLE
Updated Craft CMS documentation selectors

### DIFF
--- a/configs/craftcms.json
+++ b/configs/craftcms.json
@@ -31,14 +31,14 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": "main h1",
+        "selector": "span.site-name",
         "default_value": "Documentation"
       },
-      "lvl1": "main h1",
-      "lvl2": "main h2",
-      "lvl3": "main h3",
-      "lvl4": "main h4",
-      "text": "main p, main li"
+      "lvl1": ".content h1",
+      "lvl2": ".content h2",
+      "lvl3": ".content h3",
+      "lvl4": ".content h4",
+      "text": ".content p, .content li"
     },
     "api": {
       "lvl0": {
@@ -53,9 +53,6 @@
       "text": "main p, main li"
     }
   },
-  "selectors_exclude": [
-    ".intro dl"
-  ],
   "strip_chars": " .,;:#",
   "conversation_id": [
     "555461426"


### PR DESCRIPTION
We just moved the Craft CMS documentation over to [VuePress](https://vuepress.vuejs.org/), which broke Algolia DocSearch’s indexing, as the selectors no longer apply. These selector changes should get it working again.