### PR TITLE
Update hackerone search config due to URL change and add sitemap

### DIFF
--- a/configs/hackerone.json
+++ b/configs/hackerone.json
@@ -1,7 +1,10 @@
 {
   "index_name": "hackerone",
   "start_urls": [
-    "https://hacker0x01.github.io/docs.hackerone.com/"
+    "https://docs.hackerone.com/"
+  ],
+  "sitemap_urls": [
+    "https://docs.hackerone.com/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We launched our new docs site, so need to update the URL to be https://docs.hackerone.com/.

Also, we have a sitemap now, so use it to make the scraper more efficient. :-)