### PR TITLE
Material-UI domain name migration

### DIFF
--- a/configs/material-ui.json
+++ b/configs/material-ui.json
@@ -1,7 +1,7 @@
 {
   "index_name": "material-ui",
   "start_urls": [
-    "https://material-ui-next.com/"
+    "https://material-ui.com/"
   ],
   "stop_urls": [
     "\\?expend-path"


### PR DESCRIPTION
We are about to release Material-UI v1 stable. In the process we are going to change the documentation domain name.
⚠ It's **waiting** for https://github.com/mui-org/material-ui/pull/11365 to be merged.