### PR TITLE
Canner doc change to framework.canner.io

### DIFF
--- a/configs/canner.json
+++ b/configs/canner.json
@@ -1,8 +1,8 @@
 {
   "index_name": "canner",
   "start_urls": [
-    "http://framework.canner.io/docs/",
-    "http://framework.canner.io/docs/guides-basic-setup.html"
+    "https://framework.canner.io/docs/",
+    "https://framework.canner.io/docs/guides-basic-setup.html"
   ],
   "stop_urls": [],
   "selectors": {

--- a/configs/canner.json
+++ b/configs/canner.json
@@ -1,8 +1,8 @@
 {
   "index_name": "canner",
   "start_urls": [
-    "http://nextdoc.canner.io/docs/",
-    "http://nextdoc.canner.io/docs/guides-basic-setup.html"
+    "http://framework.canner.io/docs/",
+    "http://framework.canner.io/docs/guides-basic-setup.html"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Canner document have moved to https://framework.canner.io/

### What is the current behaviour?

Wrong url

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

update to https://framework.canner.io/


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
