### PR TITLE
setup multiple version crawl for 'gauge'

### DIFF
--- a/configs/gauge.json
+++ b/configs/gauge.json
@@ -1,15 +1,15 @@
 {
   "index_name": "gauge",
   "start_urls": [
-    "https://docs.gauge.org"
+    "https://docs.gauge.org/latest/",
+    "https://docs.gauge.org/master/"
   ],
   "stop_urls": [
-    "https://docs.gauge.org/0",
-    "https://docs.gauge.org/master/"
+    "https://docs.gauge.org/0"
   ],
   "selectors": {
     "lvl0": {
-      "selector": ".toctree-l1.current > a",
+      "selector": ".section h1",
       "default_value": "Documentation"
     },
     "lvl1": ".section h1",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
docs.gauge.org is set to crawl only one version (latest) at the moment. This PR enables crawling of `latest` and `master` version of the site.

The intention is to compartmentalize the search to the version context. 

The use case is that version searches are independant of each other.

### What is the current behaviour?
Only crawls root, which is the latest version.

### What is the expected behaviour?
Should crawl both `latest` and `master` versions.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

I assume that with this PR (pending review/corrections) I should be able to let my users search in one version (i.e. the version that they invoke the search from). Is this correct?
