### PR TITLE
Update nexenta.json

### DIFF
--- a/configs/nexenta.json
+++ b/configs/nexenta.json
@@ -1,8 +1,8 @@
 {
   "index_name": "nexenta",
   "start_urls": [
-    "https://nexentaedge.io/docs/",
-    "https://nexentaedge.io/docs/introduction.html"
+    "https://nexenta.github.io/docs/",
+    "https://nexenta.github.io/openstack/docs/cinder/overview.html"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Hello @s-pace,

There was identical "start_urls" configuration for two different websites: https://github.com/algolia/docsearch-configs/blob/master/configs/nexenta.json and https://github.com/algolia/docsearch-configs/blob/master/configs/nexentaedge.json, that causes to the same search indexes for both websites.
Websites we have:
- https://nexentaedge.io/ - has right configuration in `nexentaedge.json` file
- https://nexenta.github.io - another community website, this PR fixes "start_urls" configuration for this site in `nexenta.json` file.

Thank you!