### PR TITLE
[GitLab] Force sitemap crawling

### DIFF
--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -32,16 +32,11 @@
       }
     }
   ],
+  "stop_urls": [],
   "sitemap_urls": [
     "https://docs.gitlab.com/sitemap.xml"
   ],
-  "stop_urls": [
-    "https://docs.gitlab.com/ee/$",
-    "https://docs.gitlab.com/omnibus/$",
-    "https://docs.gitlab.com/runner/$",
-    "https://.*?//.*?$",
-    ".*^(?!.*html)"
-  ],
+  "force_sitemap_urls_crawling": "true",
   "selectors": {
     "lvl0": ".main h1",
     "lvl1": ".main h2",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Closes https://github.com/algolia/docsearch-configs/issues/429

I tested with a new app in Algolia and it works as expected. I didn't notice any duplicate indices.

### What is the current behaviour?

The crawler was ignoring files not ending in `.html`, so clear URLs wouldn't be taken in to account.

### What is the expected behaviour?

With the new config, there are no `stop_urls` since we rely on sitemap being correct and the force crawl flag was added.