### PR TITLE
Update Phenomic.io config to get all packages pages

### DIFF
--- a/configs/phenomic.json
+++ b/configs/phenomic.json
@@ -2,7 +2,7 @@
   "index_name": "phenomic",
   "start_urls": [
     "https://phenomic.io/en/tutorials/",
-    "https://phenomic.io/en/packages/core/docs/",
+    "https://phenomic.io/en/packages/",
     "https://phenomic.io/en/plugins/"
   ],
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

### What is the current behaviour?

Currently the config is not able to get other docs than the core, and tutorials are at then end under /en/packages/preset-..../docs.

### What is the expected behaviour?

This update should help to get this pages from the search.