### PR TITLE
Change url in the docusaurus demo config

### DIFF
--- a/configs/docusaurus_demo.json
+++ b/configs/docusaurus_demo.json
@@ -2,7 +2,7 @@
   "index_name": "docusaurus_demo",
   "start_urls": [
     {
-      "url": "https://docusaurus.io/docs/(?P<lang>.*?)/(?P<version>.*?)/",
+      "url": "https://joelmarcey.github.io/docusaurus-demo/docs/(?P<lang>.*?)/(?P<version>.*?)/",
       "variables": {
         "lang": [
           "en"
@@ -13,7 +13,7 @@
       }
     },
     {
-      "url": "https://docusaurus.io/docs/(?P<lang>.*?)/",
+      "url": "https://joelmarcey.github.io/docusaurus-demo/docs/(?P<lang>.*?)/",
       "variables": {
         "lang": [
           "en"
@@ -26,7 +26,7 @@
       }
     },
     {
-      "url": "https://docusaurus.io/blog/",
+      "url": "https://joelmarcey.github.io/docusaurus-demo/blog/",
       "tags": [
         "blog"
       ]
@@ -37,7 +37,7 @@
     "users"
   ],
   "sitemap_urls": [
-    "https://docusaurus.io/sitemap.xml"
+    "https://joelmarcey.github.io/docusaurus-demo/sitemap.xml"
   ],
   "selectors": {
     "lvl0": {

--- a/configs/docusaurus_demo.json
+++ b/configs/docusaurus_demo.json
@@ -56,7 +56,7 @@
     ".hash-link"
   ],
   "conversation_id": [
-    "415526327"
+    "516502774"
   ],
   "nb_hits": 1014
 }


### PR DESCRIPTION
# Pull request motivation(s)

The URLs pointed to the live Docusaurus site for this config. Just changing it back to the demo site.
