### PR TITLE
Update ESLint config (refs eslint/eslint.github.io#475)

### DIFF
--- a/configs/eslint.json
+++ b/configs/eslint.json
@@ -7,12 +7,13 @@
       "selectors_key": "blog"
     },
     {
-      "url": "https://eslint.org/docs/(?P<version>.*?)/",
+      "url": "https://eslint.org/docs/(?P<area>.*?)/",
       "variables": {
-        "version": [
-          "3.0.0",
-          "2.0.0",
-          "1.0.0"
+        "area": [
+          "rules",
+          "user-guide",
+          "developer-guide",
+          "maintainer-guide"
         ]
       }
     }
@@ -20,7 +21,9 @@
   "sitemap_urls": [
     "https://eslint.org/sitemap.xml"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://eslint.org/docs/(?P<version>\\d+\.0\.0)/"
+  ],
   "selectors": {
     "default": {
       "lvl0": "main article h1",

--- a/configs/eslint.json
+++ b/configs/eslint.json
@@ -3,7 +3,9 @@
   "start_urls": [
     {
       "url": "https://eslint.org/blog/",
-      "tags": "blog",
+      "tags": [
+        "blog"
+      ],
       "selectors_key": "blog"
     },
     {
@@ -14,16 +16,19 @@
           "user-guide",
           "developer-guide",
           "maintainer-guide"
-        ],
-        "tags": "docs"
-      }
+        ]
+      },
+      "tags": [
+        "docs"
+      ]
     }
   ],
   "sitemap_urls": [
     "https://eslint.org/sitemap.xml"
   ],
   "stop_urls": [
-    "https://eslint.org/docs/(?P<version>\\d+\\.0\\.0)/"
+    ".html$",
+    "https://eslint.org/docs/\\d"
   ],
   "selectors": {
     "default": {
@@ -49,5 +54,5 @@
     }
   },
   "scrap_start_urls": false,
-  "nb_hits": 28652
+  "nb_hits": 17911
 }

--- a/configs/eslint.json
+++ b/configs/eslint.json
@@ -14,7 +14,8 @@
           "user-guide",
           "developer-guide",
           "maintainer-guide"
-        ]
+        ],
+        "tags": "docs"
       }
     }
   ],

--- a/configs/eslint.json
+++ b/configs/eslint.json
@@ -22,7 +22,7 @@
     "https://eslint.org/sitemap.xml"
   ],
   "stop_urls": [
-    "https://eslint.org/docs/(?P<version>\\d+\.0\.0)/"
+    "https://eslint.org/docs/(?P<version>\\d+\\.0\\.0)/"
   ],
   "selectors": {
     "default": {


### PR DESCRIPTION
Refs eslint/eslint.github.io#475.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Change ESLint config so that by default, it will index only latest documentation (and not historical documentation from older versions).

### What is the current behaviour?

Currently, the docsearch autocomplete (on our ESLint website repo) assumes that we should be faceting on "version:3.0.0" content. However, we actually have no real need to index old versions of content at this point (although this could change later). As a result, some search results are broken.

### What is the expected behaviour?

Hoping to fix the search results by structuring things a little more sensibly :smile:

#### NB2: Any other feedback / questions?

This is my first time working on docsearch, so I would be grateful for any feedback or suggestions.

If this is something that the docsearch/algolia maintainers should be doing exclusively, please close this and forgive my wasting your time.

Also, could we hold off on merging right away? I need to create a PR on our site and link it over here. Once the ESLint folks and any generous docsearch folks take a look and make sure all is well, then we can merge both this PR and the ESLint site PR and hopefully be good to go for the next crawl.