### PR TITLE
remove footer navigation indexing from hanami.json

### DIFF
--- a/configs/hanami.json
+++ b/configs/hanami.json
@@ -16,6 +16,10 @@
     "lvl4": ".content h5",
     "text": ".content p, .content li"
   },
+  "selectors_exclude": [
+    ".content.page-nav",
+    ".content.edit-link"
+  ],
   "scrap_start_urls": false,
   "strip_chars": " .,;:#",
   "conversation_id": [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

I need to remove redundant search result appearances, due to the duplicated indexing of footer navigation on my site.

### What is the current behaviour?

Not navigation link text appears in serach result

### What is the expected behaviour?

Navigation link text should not appear

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
