### PR TITLE
Add specific start URL

### DIFF
--- a/configs/docusaurus.json
+++ b/configs/docusaurus.json
@@ -2,7 +2,7 @@
   "index_name": "docusaurus",
   "start_urls": [
     {
-      "url": "https://docusaurus.io/docs/(?P<lang>.*?)/",
+      "url": "https://docusaurus.io/docs/(?P<lang>.*?)/installation",
       "variables": {
         "lang": [
           "en"


### PR DESCRIPTION
# Pull request motivation(s)

> There is no redirection from `https://docusaurus.io/docs/<lang>/` to a document page like `https://docusaurus.io/docs/<lang>/installation`. Could it be possible to have such redirection straight away?

Temporarily stop the redirection problem.

ref https://github.com/facebook/Docusaurus/pull/744

### What is the current behaviour?

No redirection

### What is the expected behaviour?

Some redirection. This is a temp fix until we can come up with something better

##### NB: Do you want to request a **feature** or report a **bug**?

No

##### NB2: Any other feedback / questions ?

No