### PR TITLE
Revert "Add specific start URL"

### DIFF
--- a/configs/docusaurus.json
+++ b/configs/docusaurus.json
@@ -2,7 +2,7 @@
   "index_name": "docusaurus",
   "start_urls": [
     {
-      "url": "https://docusaurus.io/docs/(?P<lang>.*?)/installation",
+      "url": "https://docusaurus.io/docs/(?P<lang>.*?)/",
       "variables": {
         "lang": [
           "en"


### PR DESCRIPTION
Reverts algolia/docsearch-configs#453

We already avoid duplicates. The redirection is not needed thank to your sitemap (we scrap it in order to find an available link.

ref facebook/Docusaurus#744
cc @JoelMarcey 