### PR TITLE
ESLint config: Blog posts only index h1 and text

### DIFF
--- a/configs/eslint.json
+++ b/configs/eslint.json
@@ -46,10 +46,6 @@
         "default_value": "Blog"
       },
       "lvl1": "main article h1",
-      "lvl2": "main article h2",
-      "lvl3": "main article h3",
-      "lvl4": "main article h4",
-      "lvl5": "main article h5",
       "text": "main article p, main article li"
     }
   },


### PR DESCRIPTION
Many blog posts have the same headers at h2 and lower levels, so including them in the index is not very helpful.

# Pull request motivation(s)

Changing indexing configuration for ESLint's blog posts to avoid indexing h2 or lower level headers. We only want to index the h1, title, and text.

94% of ESLint blogposts are release announcements with exactly the same headers (e.g., "Highlights", "Bug Fixes", "Enhancements", "Features"). Including these in the search index results in high cardinality when searching for those words. For the other 6% of posts, indexing the h1 and text should be enough for most practical applications.

### What is the current behaviour?

No incorrect behavior-- just over-indexing on our blog posts a bit.

### What is the expected behaviour?

Index only h1/title/p/li elements, don't index h2/h3/h4/h5/h6, in our blog posts only.