### PR TITLE
Update Nebular docs config as per new release

### DIFF
--- a/configs/nebular.json
+++ b/configs/nebular.json
@@ -1,11 +1,11 @@
 {
   "index_name": "nebular",
   "start_urls": [
-    "https://akveo.github.io/nebular/#/docs/"
+    "https://akveo.github.io/nebular/docs/"
   ],
   "stop_urls": [
     "/themes/",
-    "https://akveo.github.io/nebular/#/docs/.*#.*"
+    "https://akveo.github.io/nebular/docs/.*#.*"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
We have changed a bit the website so search configuration needs to be updated consiquently to enable urls without a hash.