### PR TITLE
Revert "Update Nebular docs config as per new release"

### DIFF
--- a/configs/nebular.json
+++ b/configs/nebular.json
@@ -1,11 +1,11 @@
 {
   "index_name": "nebular",
   "start_urls": [
-    "https://akveo.github.io/nebular/docs/"
+    "https://akveo.github.io/nebular/#/docs/"
   ],
   "stop_urls": [
     "/themes/",
-    "https://akveo.github.io/nebular/docs/.*#.*"
+    "https://akveo.github.io/nebular/#/docs/.*#.*"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
Reverts algolia/docsearch-configs#459 

@nnixaa There is some issue with your URLs. For example, when you browse it, you are redirecting to https://akveo.github.io/nebular//(docs/guides/install-based-on-starter-kit)

Could you please fix it? 

Cheers