### PR TITLE
changed start_urls

### DIFF
--- a/configs/mlflow.json
+++ b/configs/mlflow.json
@@ -1,7 +1,7 @@
 {
   "index_name": "mlflow",
   "start_urls": [
-    "https://mlflow.org/docs/latest"
+    "https://mlflow.org/docs/latest/index.html"
   ],
   "sitemap_urls": [
     "https://mlflow.org/sitemap.xml"


### PR DESCRIPTION
https://mlflow.org/docs/latest/ isn't reachable the way the site is currently built. Hoping to start search at https://mlflow.org/docs/latest/index.html

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
