### PR TITLE
Refined Level 0 Selector & Ignored Acknowledgements Page

### DIFF
--- a/configs/whitestar.json
+++ b/configs/whitestar.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://docs.whitestar.systems/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+  "/acknowledgements.html"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "div.sidebar-group.first > p.sidebar-heading.open",

--- a/configs/whitestar.json
+++ b/configs/whitestar.json
@@ -6,7 +6,7 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "p.sidebar-heading.open",
+      "selector": "div.sidebar-group.first > p.sidebar-heading.open",
       "global": true,
       "default_value": "Documentation"
     },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

# Pull request motivation(s)
Refined Level 0 Selector to grab the first sidebar heading, since the first is always the Section title, while others are usually for sub sections. We also want to omit the Acknowledgements (/acknowledgements.html) from the index, as it does not contain any documentation, and would provide misleading results in the search.

### What is the current behaviour?
Currently all sidebar headings are used for the index, which can yield confusing search results.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
