### PR TITLE
Adjusted Lvl0 Selector

### DIFF
--- a/configs/whitestar.json
+++ b/configs/whitestar.json
@@ -8,7 +8,7 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": "ul.sidebar-links > li p.open",
+      "selector": "div.sidebar-group.first > p.sidebar-heading",
       "global": true,
       "default_value": "Documentation"
     },


### PR DESCRIPTION
A change was made in #465, but it contained an error which resulted in the enhancement not correctly reflecting the intent of the change.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
An extension of #465, but this time with the correct Level 0 selector text. The first Sidebar header should always be used for the indexing, regardless of the page that is currently loaded. This is to work around some limitations in the theme, as it does not support nesting in the sidebar. 

![image](https://user-images.githubusercontent.com/2818202/41789909-b6a4d640-7605-11e8-8270-5de82033ed36.png)

### What is the current behaviour?

Currently, the sidebar header that is the parent of the current page is used.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
Again, the first sidebar header (as shown in the screenshot above) should be the level 0 index, as it is the title of this section of documentation, rather than the individual section headings.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
