### PR TITLE
Add other language variables, add subdomain version

### DIFF
--- a/configs/nativescript-vue.json
+++ b/configs/nativescript-vue.json
@@ -1,19 +1,26 @@
 {
   "index_name": "nativescript-vue",
   "start_urls": [
-    "https://nativescript-vue.org/en/docs/introduction/",
+    "https://(?P<version>.*?)nativescript-vue.org/en/docs/introduction/",
     {
       "url": "https://nativescript-vue.org/(?P<lang>.*?)/docs/",
       "variables": {
+        "version": [
+          "",
+          "v1-3-1"
+        ],
         "lang": [
           "en",
-          "ko"
+          "ko",
+          "pt-BR",
+          "ru"
         ]
       }
     }
   ],
   "sitemap_urls": [
-    "https://nativescript-vue.org/sitemap.xml"
+    "https://nativescript-vue.org/sitemap.xml",
+    "https://v1-3-1.nativescript-vue.org/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
I updated the config, but I'm not sure if the `version` variable is correct.

We recently split the docs by version, and the default domain is always the latest version, and older versions have the `vX-X-X` subdomain.

Please let me know if this is correct, or if I need to make some changes.

Thanks!

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Update existing configuration.

### What is the current behaviour?

N/A 

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

N/A

##### NB: Do you want to request a **feature** or report a **bug**?
N/A

##### NB2: Any other feedback / questions ?
 N/A