### PR TITLE
Update selectors for StackOverflow.design after site update

### DIFF
--- a/configs/stackoverflow_design.json
+++ b/configs/stackoverflow_design.json
@@ -6,20 +6,16 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": ".-item a.is-active",
-      "global": true,
+      "selector": ".stacks-h1",
       "default_value": "Documentation"
     },
     "lvl1": {
-      "selector": "//nav//a[contains(@class,'-active')]/preceding::span[contains(@class,'-label')][1]",
-      "type": "xpath",
-      "default_value": "Chapter",
-      "global": true
+      "selector": ".stacks-h2",
+      "default_value": "Section"
     },
-    "lvl2": "main h2",
-    "lvl3": "main h3",
-    "lvl4": "main h4",
-    "text": "main p, main li"
+    "lvl2": ".stacks-h3",
+    "lvl3": ".stacks-h4",
+    "text": ".stacks-copy, .stacks--list li"
   },
   "min_indexed_level": 1,
   "conversation_id": [

--- a/configs/stackoverflow_design.json
+++ b/configs/stackoverflow_design.json
@@ -15,7 +15,7 @@
     },
     "lvl2": ".stacks-h3",
     "lvl3": ".stacks-h4",
-    "text": ".stacks-copy, .stacks--list li"
+    "text": ".stacks-copy, .stacks--list li, main .s-table"
   },
   "min_indexed_level": 1,
   "conversation_id": [


### PR DESCRIPTION
We recently updated the class names on StackOverflow.design and the Docsearch functionality isn't displaying the correct results anymore. Here's an example of what we're seeing now:

![image](https://user-images.githubusercontent.com/1544281/41996900-4f00d3d6-7a24-11e8-8090-f399dba876cd.png)

This PR attempts to update `stackoverflow_design.json` so it's grabbing the correct selectors.

I have not tested this, so I'm not 100% sure how to test this locally.
