### PR TITLE
Update stackpath.json

### DIFF
--- a/configs/stackpath.json
+++ b/configs/stackpath.json
@@ -1,13 +1,33 @@
 {
   "index_name": "stackpath",
   "start_urls": [
-    "http://www.taniayjustin.com:3000/docs/",
-    "http://www.taniayjustin.com:3000/docs/en/doc1",
-    "http://www.taniayjustin.com/docs/"
+    {
+      "url": "http://144.217.92.155:3000/docs/(?P<lang>.*?)/",
+      "variables": {
+        "lang": [
+          "en"
+        ]
+      },
+      "tags": [
+        "docs"
+      ]
+    },
+    {
+      "url": "http://144.217.92.155:3000/api/",
+      "tags": [
+        "api"
+      ]
+    },
+    {
+      "url": "http://144.217.92.155:3000/blog/",
+      "tags": [
+        "blog"
+      ]
+    }
   ],
   "stop_urls": [],
   "sitemap_urls": [
-    "http://www.taniayjustin.com:3000/sitemap.xml"
+    "http://144.217.92.155:3000/sitemap.xml"
   ],
   "selectors": {
     "lvl0": {
@@ -22,6 +42,8 @@
     "lvl4": ".post h4",
     "text": ".post article p, .post article li"
   },
+  "js_render": true,
+  "js_wait": 5,
   "conversation_id": [
     "602333353"
   ],


### PR DESCRIPTION
A few changes to better test Algolia search on our dummy site:

- Add /blog/ which for now is actually sort of a changelog. If later we don't actually use this feature of Docusaurus, or it ends up not being docs-related, we can rethink this.
- Add /api/ which is a ReDoc page.
- `js_render` and `js_wait` since the /api/ page is currently rendered client-side by ReDoc.
- `js_wait` is set to 5 seconds just to see how well that page gets indexed, but this can be lowered for release.
- Replace the dummy domain name with an IP address for now. When the site goes public, we'll switch to the real domain, of course.
- I'm not sure why ".../docs/en/doc1" and ".../docs/" were in the original list...if it has something to do with the 301 redirect and the port? Or if it's because our sitemap was using the wrong domain (patching that for the demo site).

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
