### PR TITLE
Update fusionjs.json config

### DIFF
--- a/configs/fusionjs.json
+++ b/configs/fusionjs.json
@@ -1,8 +1,9 @@
 {
   "index_name": "fusionjs",
   "start_urls": [
-    "https://fusionjs.com/docs/",
-    "https://fusionjs.com/docs/getting-started"
+    "https://fusionjs.com",
+    "https://fusionjs.com/docs/getting-started",
+    "https://fusionjs.com/api/fusion-docs/"
   ],
   "stop_urls": [],
   "selectors": {
@@ -13,12 +14,7 @@
     "lvl4": ".docSearch-content h5",
     "text": ".docSearch-content p, .docSearch-content li"
   },
-  "conversation_id": [
-    "585325680"
-  ],
-  "selectors_exclude": [
-    "#next-steps",
-    "#next-steps + ul"
-  ],
+  "conversation_id": ["585325680"],
+  "selectors_exclude": ["#next-steps", "#next-steps + ul"],
   "nb_hits": 557
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
Currently only "Getting Started" section of the doc website is indexed and shows up in the search results and it leaves out the API documentation completely. This fix is to make sure the whole content of the fusionjs.com is indexed and searchable.

### What is the current behaviour?

Indexes only "Getting Started" section.

### What is the expected behaviour?
Index all content in fusionjs.com

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
