### PR TITLE
Craftcms edits

### DIFF
--- a/configs/craftcms.json
+++ b/configs/craftcms.json
@@ -54,6 +54,7 @@
       "text": ".content p, .content li"
     }
   },
+  "selectors_exclude": [".table-of-contents"],
   "strip_chars": " .,;:#",
   "conversation_id": [
     "555461426"

--- a/configs/craftcms.json
+++ b/configs/craftcms.json
@@ -39,7 +39,7 @@
       "lvl2": ".content h2",
       "lvl3": ".content h3",
       "lvl4": ".content h4",
-      "text": ".content p, .content li, .table"
+      "text": ".content p, .content li"
     },
     "api": {
       "lvl0": {

--- a/configs/craftcms.json
+++ b/configs/craftcms.json
@@ -2,6 +2,19 @@
   "index_name": "craftcms",
   "start_urls": [
     {
+      "url": "https://docs.craftcms.com/(?P<version>.*?)/ja",
+      "variables": {
+        "version": [
+          "v2",
+          "v3"
+        ]
+      },
+      "tags": [
+        "doc",
+        "ja"
+      ]
+    },
+    {
       "url": "https://docs.craftcms.com/(?P<version>.*?)",
       "variables": {
         "version": [
@@ -10,7 +23,8 @@
         ]
       },
       "tags": [
-        "doc"
+        "doc",
+        "en"
       ]
     },
     {
@@ -22,7 +36,8 @@
         ]
       },
       "tags": [
-        "api"
+        "api",
+        "en"
       ],
       "selectors_key": "api"
     }

--- a/configs/craftcms.json
+++ b/configs/craftcms.json
@@ -39,7 +39,7 @@
       "lvl2": ".content h2",
       "lvl3": ".content h3",
       "lvl4": ".content h4",
-      "text": ".content p, .content li"
+      "text": ".content p, .content li, .table"
     },
     "api": {
       "lvl0": {


### PR DESCRIPTION
Reference: https://github.com/craftcms/docs/issues/114

Our general documentation has a few tables (not many) with Twig functions that should appear in search because they demonstrate usage differences between Craft CMS v2 and v3. (This does not apply to our class reference, only general documentation.)

I also added a commit to ignore tables of contents per the DocSearch documentation recommendations.
