### PR TITLE
[fusionjs.com] Add code blocks to text content

### DIFF
--- a/configs/fusionjs.json
+++ b/configs/fusionjs.json
@@ -13,7 +13,7 @@
     "lvl2": ".docSearch-content h3",
     "lvl3": ".docSearch-content h4",
     "lvl4": ".docSearch-content h5",
-    "text": ".docSearch-content p, .docSearch-content li"
+    "text": ".docSearch-content p, .docSearch-content li, .docSearch-content code"
   },
   "conversation_id": [
     "585325680"


### PR DESCRIPTION
As our content is technical in nature, we would like to add code blocks to indexed content so folks can surface code examples in search.

# Pull request motivation(s)
Lots of missing content from our current search implementation due to ignoring code blocks.

### What is the current behaviour?
Code blocks are not indexed.

### What is the expected behaviour?
Code blocks are indexed and code is displayed in search.

### Open questions
I'm not sure how code will be formatted in the search results, but ideally linebreaks would be preserved.
