### PR TITLE
Update README for sitemap_alternate_links

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ Specifies if matched URL should not respect the same rules as the hyperlink craw
 ```
 Given this configuration, each webpage whose the URL contains '/doc/' will be scrapped even if they don't complied the `start_urls` or `stop_urls`
 
+### `sitemap_alternate_links`
+It specifies if alternate links should be followed. Your sitemap should inlcude localized versions of your page in such format:
+
+```
+<url>
+    <loc>http://example.com/</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="http://example.com/de"/>
+</url>
+```
+
+If 'sitemap_alternate_links' is not set, the link "http://example.com/de" will not be parsed from the sitemap. Default is `false`
 
 ### Global selectors
 

--- a/configs/jest.json
+++ b/configs/jest.json
@@ -2,62 +2,19 @@
   "index_name": "jest",
   "start_urls": [
     {
-      "url": "http://jestjs.io/docs/(?P<lang>.*?)/",
-      "variables": {
-        "lang": [
-          "en",
-          "ja",
-          "es-ES",
-          "pt-BR",
-          "ro",
-          "ru",
-          "uk",
-          "zh-Hans"
-        ]
-      }
-    },
-    {
-      "url": "http://jestjs.io/docs/(?P<lang>.*?)/getting-started",
-      "variables": {
-        "lang": [
-          "en",
-          "ja",
-          "es-ES",
-          "pt-BR",
-          "ro",
-          "ru",
-          "uk",
-          "zh-Hans"
-        ]
-      }
-    },
-    {
-      "url": "http://jestjs.io/(?P<lang>.*?)/versions",
-      "variables": {
-        "lang": [
-          "en",
-          "ja",
-          "es-ES",
-          "pt-BR",
-          "ro",
-          "ru",
-          "uk",
-          "zh-Hans"
-        ]
-      }
+      "url": "https://jestjs.io/docs/"
     }
   ],
   "stop_urls": [
     "/help",
-    "/videos",
-    ".html$"
+    "/videos"
   ],
   "sitemap_urls": [
     "https://jestjs.io/sitemap.xml"
   ],
   "selectors": {
     "lvl0": {
-      "selector": "//nav//*[contains(@class,'navListItemActive')]/../../h3",
+      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"
@@ -69,6 +26,7 @@
     "lvl5": ".post article h5",
     "text": ".post article p, .post article li"
   },
+  "sitemap_alternate_links": true,
   "selectors_exclude": [
     ".hash-link",
     ".edit-page-link"


### PR DESCRIPTION
## Motivation

1. Fix typo on jest ? I think the start_url should be `https` because `http://jestjs.io` won't match `https://jestjs.io` 
1. Update docsearch config README on sitemap_alternate_links