### PR TITLE
Changing of the url

### DIFF
--- a/configs/c_vladislav.json
+++ b/configs/c_vladislav.json
@@ -1,7 +1,7 @@
 {
   "index_name": "c_vladislav",
   "start_urls": [
-    "https://vladislav-lyuminarskiy.github.io/C-course-website"
+    "https://vladislav-lyuminarskiy-websites.github.io/C-course-website/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
The site moved to another url.

I also want to use Algolia search in another site on the same domain:
https://vladislav-lyuminarskiy-websites.github.io/Java-course-website/

Is it possible to create two independent indexes in this situation?