### PR TITLE
Add some urls to Home Assistant

### DIFF
--- a/configs/home-assistant.json
+++ b/configs/home-assistant.json
@@ -2,6 +2,8 @@
   "index_name": "home-assistant",
   "start_urls": [
     "https://www.home-assistant.io/docs/",
+    "https://www.home-assistant.io/hassio/",
+    "https://www.home-assistant.io/lovelace/",
     "https://www.home-assistant.io/getting-started/",
     "https://www.home-assistant.io/developers/"
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
We're missing some documentation in our search results. They are part of the sitemap but are not getting picked up so I added them as start urls.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

https://www.home-assistant.io -> searching for lovelace should find [this page](https://www.home-assistant.io/lovelace) as it's part of the [submitted sitemap](https://www.home-assistant.io/sitemap.xml)

### What is the expected behaviour?
Lovelace UI to show up

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
