### PR TITLE
Remove get-started install from stop urls

### DIFF
--- a/configs/dvc.json
+++ b/configs/dvc.json
@@ -3,9 +3,7 @@
   "start_urls": [
     "https://dvc.org/doc/"
   ],
-  "stop_urls": [
-    "https://dvc.org/doc/get-started/install"
-  ],
+  "stop_urls": [],
   "selectors": {
     "lvl0": {
       "selector": ".docSearch-lvl0",


### PR DESCRIPTION
We have fixed a duplication issue on our side, we should keep indexing this page.

