### PR TITLE
add oddlog/guide

### DIFF
--- a/configs/oddlog.json
+++ b/configs/oddlog.json
@@ -1,7 +1,8 @@
 {
   "index_name": "oddlog",
   "start_urls": [
-    "https://frissdiegurke.gitlab.io/oddlog/documentation/"
+    "https://frissdiegurke.gitlab.io/oddlog/documentation/",
+    "https://frissdiegurke.gitlab.io/oddlog/guide/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

I'd like the oddlog guide to be crawled in addition to the documentation.