### PR TITLE
Add a config for new Rudder docs based on Antora

### DIFF
--- a/configs/rudder.json
+++ b/configs/rudder.json
@@ -1,0 +1,36 @@
+{
+  "index_name": "rudder",
+  "start_urls": [
+    {
+      "url": "https://docs.rudder.io/reference/(?P<version>.*?)/",
+      "variables": {
+        "version": [
+          "5.0"
+        ]
+      }
+    },
+    "https://docs.rudder.io/get-started/",
+    "https://docs.rudder.io/rudder-by-example/"
+  ],
+  "sitemap_urls": [
+    "https://docs.rudder.io/sitemap.xml"
+  ],
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": {
+      "selector": "//nav[@class='crumbs']//li[@class='crumb'][last()-1]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Home"
+    },
+    "lvl1": ".doc h1",
+    "lvl2": ".doc h2",
+    "lvl3": ".doc h3",
+    "lvl4": ".doc h4",
+    "text": ".doc p, .doc td.content, .doc th.tableblock"
+  },
+  "conversation_id": [
+    "0"
+  ],
+  "nb_hits": 0
+}


### PR DESCRIPTION
This is a new config for Rudder documentation (we already have https://github.com/algolia/docsearch-configs/blob/master/configs/rudder_project.json), for our new doc site based on Antora. This config is hence based on https://github.com/algolia/docsearch-configs/blob/master/configs/antora.json.
Note: I put 0 as `conversation_id` as I do not know what to put here.