### PR TITLE
add start_url

### DIFF
--- a/configs/sendgrid_hc.json
+++ b/configs/sendgrid_hc.json
@@ -3,7 +3,6 @@
   "start_urls": [
     {
       "url": "http://sendgrid-knowledge-center-staging.s3-website-us-east-1.amazonaws.com/glossary/",
-      "selectors_key": "Glossary",
       "tags": [
         "glossary"
       ]

--- a/configs/sendgrid_hc.json
+++ b/configs/sendgrid_hc.json
@@ -1,6 +1,13 @@
 {
   "index_name": "sendgrid_hc",
   "start_urls": [
+    {
+      "url": "http://sendgrid-knowledge-center-staging.s3-website-us-east-1.amazonaws.com/glossary/",
+      "selectors_key": "Glossary",
+      "tags": [
+        "glossary"
+      ]
+    },
     "http://sendgrid-knowledge-center-staging.s3-website-us-east-1.amazonaws.com/"
   ],
   "stop_urls": [],


### PR DESCRIPTION
Add glossary `start_url`. Currently child pages are not being crawled. 
