### PR TITLE
Update Markdown Guide selectors

### DIFF
--- a/configs/markdownguide.json
+++ b/configs/markdownguide.json
@@ -14,11 +14,11 @@
       "selector": "",
       "default_value": "Documentation"
     },
-    "lvl1": ".col-xs-12.col-sm-9 > h1",
-    "lvl2": ".col-xs-12.col-sm-9 > h2",
-    "lvl3": ".col-xs-12.col-sm-9 > h3",
-    "lvl4": ".col-xs-12.col-sm-9 > h4",
-    "lvl5": ".col-xs-12.col-sm-9 > h5",
+    "lvl1": ".col-xs-12.col-sm-12.col-sm-9 > h1",
+    "lvl2": ".col-xs-12.col-sm-12.col-sm-9 > h2",
+    "lvl3": ".col-xs-12.col-sm-12.col-sm-9 > h3",
+    "lvl4": ".col-xs-12.col-sm-12.col-sm-9 > h4",
+    "lvl5": ".col-xs-12.col-sm-12.col-sm-9 > h5",
     "text": "p, li, td"
   },
   "selectors_exclude": [


### PR DESCRIPTION
# Pull request motivation(s)

Hello! I recently migrated the [Markdown Guide](https://www.markdownguide.org) from Bootstrap 3 to 4, and some of the CSS changed as a result. I noticed today that the search results aren't properly displayed or linked, so I'm hoping this solves the problem. 

### What is the current behaviour?

![image](https://user-images.githubusercontent.com/40424/44537343-c6405480-a6bb-11e8-8d37-e5ac8d01283d.png)


