### PR TITLE
Update oi_wiki.json

### DIFF
--- a/configs/oi_wiki.json
+++ b/configs/oi_wiki.json
@@ -11,12 +11,12 @@
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".md-content h1",
-    "lvl2": ".md-content h2",
-    "lvl3": ".md-content h3",
-    "lvl4": ".md-content h4",
-    "lvl5": ".md-content h5",
-    "text": ".md-content p, .md-content li"
+    "lvl1": "article.md-content__inner h1",
+    "lvl2": "article.md-content__inner h2",
+    "lvl3": "article.md-content__inner h3",
+    "lvl4": "article.md-content__inner h4",
+    "lvl5": "article.md-content__inner h5",
+    "text": "article.md-content__inner p, article.md-content__inner li"
   },
   "selectors_exclude": [
     "#gitment_container",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10709657/44539615-363ff080-a737-11e8-9b12-42ecbd992eff.png)
![image](https://user-images.githubusercontent.com/10709657/44539619-38a24a80-a737-11e8-9b67-cc7632d3b79d.png)
These two search get same results, I am trying to fix this by updating my selectors to the same as https://github.com/algolia/docsearch-configs/blob/master/configs/branchmetrics.json
As far as i know, they were also using mkdocs.