### PR TITLE
katex: Add td to text selectors

### DIFF
--- a/configs/katex.json
+++ b/configs/katex.json
@@ -20,7 +20,7 @@
     "lvl2": ".post h2",
     "lvl3": ".post h3",
     "lvl4": ".post h4",
-    "text": ".post article p, .post article li"
+    "text": ".post article p, .post article li, .post article td"
   },
   "selectors_exclude": [
     ".hash-link"


### PR DESCRIPTION
# Pull request motivation(s)

KaTeX has lists of supported functions in https://katex.org/docs/supported.html and https://katex.org/docs/support_table.html using `table`s. It'd be nice to have them searchable.

@s-pace What do you think is the best course of action here? Thank you!

### What is the current behaviour?

Supported functions in `<td>` are not searchable.

### What is the expected behaviour?

Supported functions in `<td>` are searchable.