### PR TITLE
katex.json: exclude KaTeX rendering

### DIFF
--- a/configs/katex.json
+++ b/configs/katex.json
@@ -23,7 +23,8 @@
     "text": ".post article p, .post article li, .post article td"
   },
   "selectors_exclude": [
-    ".hash-link"
+    ".hash-link",
+    ".katex"
   ],
   "custom_settings": {
     "attributesForFaceting": [


### PR DESCRIPTION
# Pull request motivation(s)

It seems KaTeX rendering, MathML, and annotations are scraped and included in the search result. This excludes KaTeX rendered nodes.

### What is the current behaviour?

KaTeX KaTeX rendering, MathML, and annotations are included in the search result.

### What is the expected behaviour?

KaTeX KaTeX rendering, MathML, and annotations should not be included in the search result.