### PR TITLE
Remove #main-content from selectors to prevent it from being appended to result URL; Fix typo: 'release' --> 'releases'

### DIFF
--- a/configs/cockroachlabs.json
+++ b/configs/cockroachlabs.json
@@ -6,7 +6,7 @@
       "variables": {
         "version": [
           "dev",
-          "release",
+          "releases",
           "v1.0",
           "v1.1",
           "v2.0",
@@ -18,12 +18,12 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": "#main-content .post-header h1",
-    "lvl1": "#main-content .post-content h2",
-    "lvl2": "#main-content .post-content h3",
-    "lvl3": "#main-content .post-content h4",
-    "lvl4": "#main-content .post-content h5",
-    "text": "#main-content .post-content p, #main-content .post-content li"
+    "lvl0": ".post-header h1",
+    "lvl1": ".post-content h2",
+    "lvl2": ".post-content h3",
+    "lvl3": ".post-content h4",
+    "lvl4": ".post-content h5",
+    "text": ".post-content p, .post-content li"
   },
   "only_content_level": true,
   "selectors_exclude": [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
 1) prevent search results from appending `#main-content` to search results that should simply return the unappended URL
2) Make sure release notes are indexed

### What is the current behaviour?
1) search returns results with `#main-content` appended when it is not desireable
2) release notes not included in index