### PR TITLE
Update sitemap URL to specify docs site instead of marketing site

### DIFF
--- a/configs/cockroachlabs.json
+++ b/configs/cockroachlabs.json
@@ -17,6 +17,9 @@
     }
   ],
   "stop_urls": [],
+  "sitemap_urls": [
+    "https://www.cockroachlabs.com/docs/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": ".post-header h1",
     "lvl1": ".post-content h2",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
* specify correct sitemap in config
* re: #556 

### What is the current behaviour?
Some links not appearing in search results when you would expect them to
