### PR TITLE
Adjust Gradle configuration to better index different sections

### DIFF
--- a/configs/gradle.json
+++ b/configs/gradle.json
@@ -1,25 +1,71 @@
 {
   "index_name": "gradle",
   "start_urls": [
-    "https://docs.gradle.org/current/"
+    {
+      "url": "https://docs.gradle.org/(?P<version>.*?)/",
+      "variables": {
+        "version": ["current"]
+      },
+      "selectors_key": "userguide",
+      "page_rank": 6,
+      "tags": "userguide"
+    },
+    {
+      "url": "https://docs.gradle.org/(?P<version>.*?)/userguide/plugin_reference.html",
+      "variables": {
+        "version": ["current"]
+      },
+      "selectors_key": "plugin_reference",
+      "page_rank": 4,
+      "tags": "plugin_reference"
+    },
+    {
+      "url": "https://docs.gradle.org/(?P<version>.*?)/dsl/",
+      "variables": {
+        "version": ["current"]
+      },
+      "selectors_key": "dsl",
+      "page_rank": 1,
+      "tags": "dsl"
+    }
   ],
+  "selectors_exclude": [".docs-navigation", ".site-header", ".site-footer", ".toc", ".chapter-meta", ".admonitionblock"],
   "stop_urls": [
     "\\?",
-    "/javadoc/"
+    "/javadoc/",
+    "/release-notes.html"
   ],
   "selectors": {
-    "lvl0": {
-      "selector": "//nav[contains(@class,'docs-navigation')]//a[contains(//head/link[@rel='canonical']/@href,@href)]/preceding::h3[1]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
+    "userguide": {
+      "lvl0": {
+        "selector": "#bogus",
+        "default_value": "User Manual"
+      },
+      "lvl1": ".chapter h1",
+      "lvl2": ".chapter h2",
+      "lvl3": ".chapter h3",
+      "lvl4": ".chapter h4",
+      "lvl5": ".chapter h5",
+      "text": ".chapter p, .chapter .dlist dt, .chapter .title"
     },
-    "lvl1": ".chapter h1",
-    "lvl2": ".chapter h2",
-    "lvl3": ".chapter h3",
-    "lvl4": ".chapter h4",
-    "lvl5": ".chapter h5",
-    "text": ".chapter p, .chapter li"
+    "plugin_reference": {
+      "lvl0": ".chapter h1",
+      "lvl1": ".chapter h2",
+      "lvl2": ".chapter .dlist dt",
+      "text": ".chapter p, .chapter .dlist dt ~ dd p"
+    },
+    "dsl": {
+      "lvl0": {
+        "selector": "#bogus",
+        "default_value": "DSL Reference"
+      },
+      "lvl1": ".chapter h1",
+      "lvl2": ".chapter h2",
+      "lvl3": ".chapter h3",
+      "lvl4": ".chapter h4",
+      "lvl5": ".chapter .title",
+      "text": ".chapter p"
+    }
   },
   "conversation_id": [
     "641563788"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

For Gradle...

* Separate indexing of user manual and DSL reference, allowing
us to treat them differently and rank user manual docs over the DSL
reference.
* Avoid indexing release notes
* Better index listings, especially the Core Plugins List

### What is the current behaviour?
Currently, Gradle core plugins aren't properly indexed, as well as sample/table titles. Furthermore, we want to prioritize written prose docs (like getting started) over reference documentation.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
Core plugins and titles are indexed, and Gradle User Manual pages are ranked higher than the DSL Reference.

##### NB: Do you want to request a **feature** or report a **bug**?
Guess I'd classify this as a config change ;)

##### NB2: Any other feedback / questions ?
I tested this locally following the "Run your own" document and am happier with the results for Gradle.

I understand that the `lvl0` values are kinda dumb. I'm working on injecting this info into the pages themselves and then submitting another PR to get that. I also intend to generate a proper sitemap.xml and add that before this goes live. Hope this is okay for now.