### PR TITLE
Added language and version in the start_urls for docs.zephir-lang.com

### DIFF
--- a/configs/zephir-lang.json
+++ b/configs/zephir-lang.json
@@ -1,7 +1,13 @@
 {
   "index_name": "zephir-lang",
   "start_urls": [
-    "https://docs.zephir-lang.com/en/0.10"
+    {
+      "url": "https://docs.zephir-lang.com/(?P<lang>.*?)/(?P<version>.*?)/",
+      "variables": {
+        "lang": ["en", "el", "ru", "uk"],
+        "version": ["latest", "0.10"]
+      }
+    }
   ],
   "stop_urls": [],
   "selectors": {

--- a/configs/zephir-lang.json
+++ b/configs/zephir-lang.json
@@ -4,12 +4,23 @@
     {
       "url": "https://docs.zephir-lang.com/(?P<lang>.*?)/(?P<version>.*?)/",
       "variables": {
-        "lang": ["en", "el", "ru", "uk"],
-        "version": ["latest", "0.10"]
+        "lang": [
+          "en",
+          "el",
+          "ru",
+          "uk"
+        ],
+        "version": [
+          "latest",
+          "0.10"
+        ]
       }
     }
   ],
   "stop_urls": [],
+  "sitemap_urls": [
+    "https://docs.zephir-lang.com/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": "main h1",
     "lvl1": "main h2",


### PR DESCRIPTION
# Pull request motivation(s)
Added version and language to further localize the search results based on what is selected on the site

### What is the current behaviour?
Currently the crawler only picks up the English language and version 0.10

### What is the expected behaviour?
Localized results version specific
