### PR TITLE
Update Scalafix configuration for new website.

### DIFF
--- a/configs/scalafix.json
+++ b/configs/scalafix.json
@@ -1,29 +1,35 @@
 {
   "index_name": "scalafix",
   "start_urls": [
-    "https://scalacenter.github.io/scalafix/docs/",
-    "https://scalacenter.github.io/scalafix/docs/users/installation"
+    "https://scalacenter.github.io/scalafix/",
   ],
-  "stop_urls": [
-    "/api/"
+  "sitemap_urls": [
+    "https://scalacenter.github.io/scalafix/sitemap.xml"
   ],
+  "sitemap_alternate_links": true,
+  "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//ul[@id='sidebar']//a[contains(@class,'active')][1]/../../../a",
+      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "section h1",
-    "lvl2": "section h2",
-    "lvl3": "section h3",
-    "lvl4": "section h4",
-    "lvl5": "section h5",
-    "text": "section p, section li"
+    "lvl1": ".post h1",
+    "lvl2": ".post h2",
+    "lvl3": ".post h3",
+    "lvl4": ".post h4",
+    "text": ".post article p, .post article li"
   },
   "selectors_exclude": [
-    "#markdown-toc"
+    ".hash-link"
   ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "language",
+      "version"
+    ]
+  },
   "conversation_id": [
     "662864585"
   ],


### PR DESCRIPTION
Updates scalafix.json to match [scalameta.json](https://github.com/algolia/docsearch-configs/blob/master/configs/scalameta.json). The two
websites use the same documentation tool https://docusaurus.io/

- This one works great: https://scalameta.org/
- This one has outdated config: https://scalacenter.github.io/scalafix/

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

I updated the Scalafix site recently to use Docusaurus (https://docusaurus.io/) instead of sbt-microsite (https://47deg.github.io/sbt-microsites/)

### What is the current behaviour?

Searching "Cookbook" yields no results.

### What is the expected behaviour?

I expected "cookbook" to yield a result linking for example here https://scalacenter.github.io/scalafix/docs/developers/semantic-tree.html#cookbook 

##### NB2: Any other feedback / questions ?

Algolia DocSearch is great, we are using it in a few Scala libraries and our users love it. Thank you so much!