### PR TITLE
Update lianlianpay.json

### DIFF
--- a/configs/lianlianpay.json
+++ b/configs/lianlianpay.json
@@ -1,8 +1,10 @@
 {
   "index_name": "lianlianpay",
   "start_urls": [
-    "https://openllp.lianlianpay.com/docs/guides/overview",
-    "https://openllp.lianlianpay.com/docs/"
+    "https://open.lianlianpay.com/docs/guides/overview",
+    "https://open.lianlianpay.com/docs/",
+    "https://open.lianlianpay.com/apis/get-started",
+    "https://open.lianlianpay.com/apis/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Migrate domain from openllp.lianlianpay.com to open.lianlianpay.com.
Add api sites for crawler.
*Please merge this PR after 28th, September as the migration has not been released yet*
