### PR TITLE
Added support for faceting by version to project calico config

### DIFF
--- a/configs/projectcalico.json
+++ b/configs/projectcalico.json
@@ -24,7 +24,10 @@
     "670943385"
   ],
   "custom_settings": {
-    "separatorsToIndex": "_"
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "version"
+    ]
   },
   "selectors_exclude": [
     "#markdown-toc"


### PR DESCRIPTION
Hello!

I would like to update project calico crawler configuration to enable faceting by version from <meta name="docsearch:version> tag on documentation pages.

Thanks!