### PR TITLE
blocking a specific URL from showing up in SendGrid docssearch

### DIFF
--- a/configs/sendgrid_hc.json
+++ b/configs/sendgrid_hc.json
@@ -9,7 +9,7 @@
     },
     "https://sendgrid.com/docs/"
   ],
-  "stop_urls": [],
+  "stop_urls": ["https://sendgrid.com/docs/ui/sending-email/getting-started-with-automation/"],
   "selectors": {
     "lvl0": {
       "selector": ".breadcrumb li:nth-child(2) a",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
We are releasing functionality in a beta and right now, we don't want this page to show up in any search results.

### What is the current behaviour?
Currently the page doesn't exist. We are deploying it today.
*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

We're expecting this page not to show up in search results when we deploy it today
