### PR TITLE
Update Bolt config to index version 3.6

### DIFF
--- a/configs/bolt.json
+++ b/configs/bolt.json
@@ -5,6 +5,7 @@
       "url": "https://docs.bolt.cm/(?P<version>.*?)/getting-started/introduction",
       "variables": {
         "version": [
+          "3.6",
           "3.5",
           "3.4",
           "3.3",
@@ -19,6 +20,7 @@
       "url": "https://docs.bolt.cm/(?P<version>.*?)/.*",
       "variables": {
         "version": [
+          "3.6",
           "3.5",
           "3.4",
           "3.3",


### PR DESCRIPTION
# Pull request motivation(s)

We've released Bolt 3.6, and the accompanying version of the docs at docs.bolt.cm needs to be indexed.

Thanks! 
