### PR TITLE
new versions integration of gatsbyjs/gatsby#9159

### DIFF
--- a/configs/gatsbyjs.json
+++ b/configs/gatsbyjs.json
@@ -20,10 +20,31 @@
       "tags": [
         "blog"
       ]
+    },
+    {
+      "url": "https://v1.gatsbyjs.org/docs/",
+      "tags": [
+        "docs"
+      ]
+    },
+    {
+      "url": "https://v1.gatsbyjs.org/tutorial/",
+      "selectors_key": "tutorial",
+      "tags": [
+        "tutorial"
+      ]
+    },
+    {
+      "url": "https://v1.gatsbyjs.org/blog/",
+      "selectors_key": "blog",
+      "tags": [
+        "blog"
+      ]
     }
   ],
   "sitemap_urls": [
-    "https://www.gatsbyjs.org/sitemap.xml"
+    "https://www.gatsbyjs.org/sitemap.xml",
+    "https://v1.gatsbyjs.org/sitemap.xml"
   ],
   "stop_urls": [
     "/packages/",
@@ -86,8 +107,14 @@
     "#next-steps",
     "#next-steps ~ p"
   ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "version",
+      "tags"
+    ]
+  },
   "conversation_id": [
     "487785557"
   ],
-  "nb_hits": 7910
+  "nb_hits": 13227
 }


### PR DESCRIPTION
Let's help gatsbyjs to move their website to a new version.

We need them to:
- [ ] update their sitemap of the [v1 website](https://v1.gatsbyjs.org/sitemap.xml)

- [ ] update their javascript snippet as follow:

```js
<script type="text/javascript"> docsearch({
  apiKey: '71af1f9c4bd947f0252e17051df13f9c',
  indexName: 'gatsbyjs',
  inputSelector: '#doc-search',
  algoliaOptions: { 'facetFilters': ["version:$VERSION", "tags:$TAGS"] },
  debug: false // Set debug to true if you want to inspect the dropdown
});
</script>
```

- Replace $VERSION with the version you want to search on. The list of possible version is fetched from the meta tags within their website. So as of today they have: `1.0`, `2.0`

- Replace $TAGS with the tags you want to search on. The list of possible tags is hardcoded in the config. So as of today they have: `blog`, `docs`, `tutorial`

  For example if you want to refine the search to the version "1.0" and the tags "blog" just specify: 
```js
'facetFilters': ["version:1.0", "tags:blog"]
```