### PR TITLE
Update rafaelmaia.net/pavo config with pkgdown auto-generated config

### DIFF
--- a/configs/rafaelmaia_pavo.json
+++ b/configs/rafaelmaia_pavo.json
@@ -1,35 +1,94 @@
 {
   "index_name": "rafaelmaia_pavo",
   "start_urls": [
-    "http://rafaelmaia.net/pavo/"
+    {
+      "url": "http://rafaelmaia.net/pavo/index.html",
+      "selectors_key": "homepage",
+      "tags": [
+        "homepage"
+      ]
+    },
+    {
+      "url": "http://rafaelmaia.net/pavo/reference",
+      "selectors_key": "reference",
+      "tags": [
+        "reference"
+      ]
+    },
+    {
+      "url": "http://rafaelmaia.net/pavo/articles",
+      "selectors_key": "articles",
+      "tags": [
+        "articles"
+      ]
+    }
+  ],
+  "stop_urls": [
+    "/reference/$",
+    "/reference/index.html",
+    "/articles/$",
+    "/articles/index.html"
   ],
   "sitemap_urls": [
     "http://rafaelmaia.net/pavo/sitemap.xml"
   ],
-  "stop_urls": [
-    "LICENSE-text.html"
-  ],
   "selectors": {
-    "lvl0": {
-      "selector": ".contents h1",
-      "default_value": "Documentation"
+    "homepage": {
+      "lvl0": {
+        "selector": ".contents h1",
+        "default_value": "pavo Home page"
+      },
+      "lvl1": {
+        "selector": ".contents h2"
+      },
+      "lvl2": {
+        "selector": ".contents h3",
+        "default_value": "Context"
+      },
+      "lvl3": ".ref-arguments td, .ref-description",
+      "text": ".contents p, .contents li, .contents .pre"
     },
-    "lvl1": ".contents h2",
-    "lvl2": ".contents h3, .contents th",
-    "lvl3": ".contents h4",
-    "lvl4": ".contents h5",
-    "text": ".contents p, .contents li, .usage, .template-article .contents .pre"
+    "reference": {
+      "lvl0": {
+        "selector": ".contents h1"
+      },
+      "lvl1": {
+        "selector": ".contents .name",
+        "default_value": "Argument"
+      },
+      "lvl2": {
+        "selector": ".ref-arguments th",
+        "default_value": "Description"
+      },
+      "lvl3": ".ref-arguments td, .ref-description",
+      "text": ".contents p, .contents li"
+    },
+    "articles": {
+      "lvl0": {
+        "selector": ".contents h1"
+      },
+      "lvl1": {
+        "selector": ".contents .name"
+      },
+      "lvl2": {
+        "selector": ".contents h2, .contents h3",
+        "default_value": "Context"
+      },
+      "text": ".contents p, .contents li, .tempate-article .contents .pre"
+    }
   },
   "selectors_exclude": [
     ".dont-index"
-  ],
+    ],
+  "min_indexed_level": 2,
   "custom_settings": {
-    "separatorsToIndex": "_"
-  },
-  "user_agent": "Googlebot",
-  "conversation_id": [
-    "688693033"
-  ],
-  "scrap_start_urls": false,
-  "nb_hits": 2335
+    "separatorsToIndex": "_",
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor"
+    ]
+  }
 }


### PR DESCRIPTION
# Pull request motivation(s)

This PR fine-tunes the configuration of docsearch for http://rafaelmaia.net/pavo by using the recommended config for `pkgdown` websites.

I also expect this change to fix the `HTTP 404` errors we get by following the steps below.

### What is the current behaviour?

Some links in the search suggestion cause `HTTP 404` errors.

Steps to reproduce:

1. Visit http://rafaelmaia.net/pavo/index.html
1. Search `dichromat`
1. Click on `Arguments` in one of the suggested items
1. It leads to http://rafaelmaia.net/pavo/undefined?q=dichromat#arguments which does not exist

### What is the expected behaviour?

No `HTTP 404` errors.

##### NB2: Any other feedback / questions ?

I am not 100% sure the 404 errors come from this but this PR is still useful anyways because it makes sense for us to stick to the recommended `pkgdown` documentation.

This file was auto-generated using the latest `pkgdown` version (`1.1.0.9000`, still in development).

Please let me know if I need to change anything on this PR.

cc @rmaia
