### PR TITLE
Zowe documentation has added versioning support

### DIFF
--- a/configs/zowe.json
+++ b/configs/zowe.json
@@ -1,7 +1,12 @@
 {
   "index_name": "zowe",
   "start_urls": [
-    "https://zowe.github.io/docs-site/"
+    {
+      "url": "https://zowe.github.io/docs-site/(?P<version>.*?)/",
+      "variables": {
+        "version": ["latest"]
+      }
+    }
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

Our documentation has version information in the URL, we wish the search only shows result of current version. We currently only have one version "latest", but expect within this year, we may have a new legacy version of documentations along with "latest".

### What is the current behaviour?

Currently will show results of all versions.

### What is the expected behaviour?

Show only current version of documentation.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

I will update our search client to add algoliaOptions.facetFilters with version filter.

Thank you very much!
