### PR TITLE
Update the domain to open.lianlianpay.com

### DIFF
--- a/configs/lianlianpay.json
+++ b/configs/lianlianpay.json
@@ -1,8 +1,8 @@
 {
   "index_name": "lianlianpay",
   "start_urls": [
-    "https://openllp.lianlianpay.com/docs/guides/overview",
-    "https://openllp.lianlianpay.com/docs/"
+    "https://open.lianlianpay.com/docs/guides/overview",
+    "https://open.lianlianpay.com/docs/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Looks like the config is reverted. Please help to merge since we are going to abort openllp.lianlianpay.com
