### PR TITLE
Update urls because public GitHub repo (and therefore documentation w…

### DIFF
--- a/configs/leonawicz_tiler.json
+++ b/configs/leonawicz_tiler.json
@@ -1,10 +1,10 @@
 {
   "index_name": "leonawicz_tiler",
   "start_urls": [
-    "https://leonawicz.github.io/tiler/"
+    "https://ropensci.github.io/tiler/"
   ],
   "sitemap_urls": [
-    "https://leonawicz.github.io/tiler/sitemap.xml"
+    "https://ropensci.github.io/tiler/sitemap.xml"
   ],
   "stop_urls": [
     "LICENSE-text.html"


### PR DESCRIPTION
Update urls because public GitHub repo (and therefore documentation website) was transferred from personal account to organizational account.