### PR TITLE
Move resin.io to balena.io

### DIFF
--- a/configs/resin_io.json
+++ b/configs/resin_io.json
@@ -1,7 +1,7 @@
 {
   "index_name": "resin_io",
   "start_urls": [
-    "https://docs.resin.io"
+    "https://www.balena.io/docs"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Resin.io has been renamed to balena: https://www.balena.io/blog/resin-io-changes-name-to-balena-releases-open-source-edition/

As part of that, we have moved our docs from docs.resin.io to balena.io/docs, and we need to continue indexing them there.

I've left the file name the same, to avoid requiring any changes elsewhere, but I can rename it if that's preferable.

Let me know if there's any other docsearch changes that we need to make after moving domains like this.