### PR TITLE
Update bazel.json

### DIFF
--- a/configs/bazel.json
+++ b/configs/bazel.json
@@ -23,7 +23,7 @@
     "lvl3": ".container div[class$='-9'] h2",
     "lvl4": ".container div[class$='-9'] h3",
     "lvl5": ".container div[class$='-9'] h4",
-    "text": ".container div[class$='-9'] p, .container div[class$='-9'] li"
+    "text": ".container div[class$='-9'] p, .container div[class$='-9'] li, pre.rule-signature"
   },
   "stop_content": [
     "404 - Page not found"


### PR DESCRIPTION
Index pre.rule-signature

The signature includes the fully qualified names (e.g. "ctx.actions" in
https://docs.bazel.build/versions/master/skylark/lib/ctx.html#actions),
which is what the users are going to search for.