### PR TITLE
Added custom attributes for faceting (version)

### DIFF
--- a/configs/svgjs.json
+++ b/configs/svgjs.json
@@ -22,5 +22,10 @@
   "conversation_id": [
     "335727050"
   ],
-  "nb_hits": 1438
+  "nb_hits": 1438,
+  "custom_settings": {
+    "attributesForFaceting": [
+      "version"
+    ]
+  }
 }


### PR DESCRIPTION
We are working hard on a 3.0 of our library which will bring breaking changes to the API. therefore we need to create different version of our docs. This new configuration will make fragmentation possible.