### PR TITLE
Update UrbanAirship config

### DIFF
--- a/configs/urbanairship.json
+++ b/configs/urbanairship.json
@@ -8,7 +8,8 @@
   ],
   "stop_urls": [
     "/reference/",
-    "/page/"
+    "/page/",
+    "/whats-new/"
   ],
   "selectors": {
     "lvl0": ".article__heading h1",


### PR DESCRIPTION
# Pull request motivation(s)
To remove https://docs.urbanairship.com/whats-new/ from Urban Airship search. The whats-new section is more of a blog/update then our actual docs and right now its burying results for actual doc pages.

### What is the current behaviour?

`/whats-new/` is indexed.

### What is the expected behaviour?

`/whats-new/` to no longer be searchable 
