### PR TITLE
Update nuxeo.json with new documentation version

### DIFF
--- a/configs/nuxeo.json
+++ b/configs/nuxeo.json
@@ -24,6 +24,12 @@
       ]
     },
     {
+      "url": "https://doc.nuxeo.com/910",
+      "tags": [
+        "910"
+      ]
+    },
+    {
       "url": "https://doc.nuxeo.com/admindoc",
       "tags": [
         "ft"
@@ -80,6 +86,7 @@
     "http://doc.nuxeo.com/nxdoc",
     "http://doc.nuxeo.com/studio",
     "http://doc.nuxeo.com/userdoc",
+    "http://doc.nuxeo.com/910",
     "http://doc.nuxeo.com/810",
     "http://doc.nuxeo.com/corg",
     "http://doc.nuxeo.com/710",


### PR DESCRIPTION
We have a version of our documentation that's currently not covered, this resolves that.