### PR TITLE
Improve Gradle config

### DIFF
--- a/configs/gradle.json
+++ b/configs/gradle.json
@@ -1,5 +1,8 @@
 {
   "index_name": "gradle",
+  "sitemap_urls": [
+    "https://docs.gradle.org/current/sitemap.xml"
+  ],
   "start_urls": [
     {
       "url": "https://docs.gradle.org/(?P<version>.*?)/",
@@ -37,10 +40,7 @@
   ],
   "selectors": {
     "userguide": {
-      "lvl0": {
-        "selector": "#bogus",
-        "default_value": "User Manual"
-      },
+      "lvl0": ".site-header__doc-type",
       "lvl1": ".chapter h1",
       "lvl2": ".chapter h2",
       "lvl3": ".chapter h3",
@@ -55,10 +55,7 @@
       "text": ".chapter p, .chapter .dlist dt ~ dd p"
     },
     "dsl": {
-      "lvl0": {
-        "selector": "#bogus",
-        "default_value": "DSL Reference"
-      },
+      "lvl0": ".site-header__doc-type",
       "lvl1": ".chapter h1",
       "lvl2": ".chapter h2",
       "lvl3": ".chapter h3",


### PR DESCRIPTION
This change adds a newly-generated sitemap.xml for docs.gradle.org,
as well as more sustainable `lvl0` selectors. These selectors will exist early Monday Nov 19th when Gradle 5.0 is released. 

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->

This was tested by following the [run your own](https://community.algolia.com/docsearch/run-your-own.html) doc against [Gradle 5.0 release nightly](https://docs.gradle.org/release-nightly/userguide/userguide.html).

You can email me eric@gradle.com with any questions or comments. 

Finally, we will be thanking Algolia for hosting the search index via Twitter and in our docs next week. Thank you! 

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
Take advantage of better content structure in Gradle 5.0 and new sitemap.xml for Gradle docs.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
