### PR TITLE
Add Magento 2 support page config

### DIFF
--- a/configs/magento2_algolia_support_page.json
+++ b/configs/magento2_algolia_support_page.json
@@ -1,0 +1,55 @@
+{
+  "index_name": "magento2_algolia_support_page",
+  "start_urls": [
+    {
+      "url": "https://community.algolia.com/magento/doc/m2/",
+      "selectors_key": "docs_m2",
+      "tags": [
+        "m2"
+      ],
+      "page_rank": 1
+    },
+    {
+      "url": "https://community.algolia.com/magento/faq/",
+      "selectors_key": "faq",
+      "page_rank": 0
+    }
+  ],
+  "stop_urls": [],
+  "selectors": {
+    "docs_m2": {
+      "lvl0": {
+        "type": "xpath",
+        "selector": "//a[contains(@class, 'active')]/../../preceding::span[1]",
+        "global": true
+      },
+      "lvl1": {
+        "selector": ".documentation-content h1",
+        "global": true
+      },
+      "lvl2": ".documentation-content h2",
+      "lvl3": ".documentation-content h3",
+      "text": ".documentation-content p, .documentation-content li, .documentation-content .highlight .nv"
+    },
+    "faq": {
+      "lvl0": {
+        "selector": "",
+        "default_value": "FAQ",
+        "global": true
+      },
+      "lvl1": ".faq h2",
+      "lvl2": ".faq h3",
+      "lvl3": ".faq h4",
+      "lvl4": ".faq h5",
+      "text": ".faq p, .faq li"
+    }
+  },
+  "only_content_level": true,
+  "selectors_exclude": [
+    ".toc_menu"
+  ],
+  "conversation_id": [
+    "153590584"
+  ],
+  "nb_hits": 1045
+}


### PR DESCRIPTION
I'm adding a new config file for DocSearch index which is used on Magento 2 support page.

Reasons for new index:
- Only M2 documentation
- Separate metrics / analytics
- Possible to improve / tweak relevancy only for support page purposes