### PR TITLE
removed /reference/ from stop_urls

### DIFF
--- a/configs/urbanairship.json
+++ b/configs/urbanairship.json
@@ -7,7 +7,6 @@
     "https://docs.urbanairship.com/sitemap.xml"
   ],
   "stop_urls": [
-    "/reference/",
     "/page/",
     "/whats-new/"
   ],


### PR DESCRIPTION
# Pull request motivation(s)

We migrated a large amount of content to `/reference` and made that part of the site much more prominent. We want it indexed for search.

### What is the current behaviour?

/reference is excluded from search.

### What is the expected behaviour?

/reference appears in search.
