### PR TITLE
Update antora configuration to index branch 1.1 instead of 1.0

### DIFF
--- a/configs/antora.json
+++ b/configs/antora.json
@@ -5,7 +5,7 @@
       "url": "https://docs.antora.org/antora/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "1.0"
+          "1.1"
         ]
       }
     },


### PR DESCRIPTION
# Pull request motivation(s)

This PR changes the branch of Antora docs being indexed to point to the current version 1.1.

### What is the current behaviour?

The seach box in the site (https://docs.antora.org/) always returns docs from the 1.0 branch.

### What is the expected behaviour?

The search returns results from the current (1.1) branch.

##### NB: Do you want to request a **feature** or report a **bug**?

N/A

##### NB2: Any other feedback / questions ?

Is it possible to index both branches and show in the results preview if the result points to branch 1.0 or 1.1?