### PR TITLE
Update UrbanAirship selectors

### DIFF
--- a/configs/urbanairship.json
+++ b/configs/urbanairship.json
@@ -13,16 +13,15 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": ".sidenav > a",
-      "global": true,
+      "selector": ".article__heading h1",
       "default_value": "Documentation"
     },
-    "lvl1": "#content h1",
-    "lvl2": "#content h2",
-    "lvl3": "#content h3",
-    "lvl4": "#content h4",
-    "lvl5": "#content h5",
-    "text": "#content p, #content li"
+    "lvl1": ".article__body h1",
+    "lvl2": ".article__body h2",
+    "lvl3": ".article__body h3",
+    "lvl4": ".article__body h4",
+    "lvl5": ".article__body h5",
+    "text": ".article__body p, .article__body li"
   },
   "conversation_id": [
     "377464724"


### PR DESCRIPTION
Updates the Urban Airship docs selector. This is actually what we had before, but we accidentally broke the old selectors by removing `.article__*` in our HTML. We added it back to get better search results. 