### PR TITLE
Remove dead start url for Metals page

### DIFF
--- a/configs/metals.json
+++ b/configs/metals.json
@@ -1,8 +1,7 @@
 {
   "index_name": "metals",
   "start_urls": [
-    "http://scalameta.org/metals/docs/",
-    "http://scalameta.org/metals/docs/installation-contributors.html"
+    "http://scalameta.org/metals/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
The current search on https://scalameta.org/metals/ returns 404s
results. It might need to be re-indexed.

