### PR TITLE
Update sproutsocial_seeds.json config 

### DIFF
--- a/configs/sproutsocial_seeds.json
+++ b/configs/sproutsocial_seeds.json
@@ -1,17 +1,17 @@
 {
   "index_name": "sproutsocial_seeds",
   "start_urls": [
-    "http://seeds.netlify.com/"
+    "https://sproutsocial.com/seeds/"
   ],
   "sitemap_urls": [
-    "https://seeds.netlify.com/sitemap.xml"
+    "https://sproutsocial.com/seeds/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {
     "lvl0": {
       "selector": "main h4:not([id])",
       "global": true,
-      "default_value": "Documentation"
+      "default_value": "Seeds"
     },
     "lvl1": "main h2",
     "lvl2": "main h3",


### PR DESCRIPTION
Hi Algolia team! This PR is to update a few things for our DocSearch config. Primarily, we've since launched from our test site URL (seeds.netlify.com) to our real, final URL (sproutsocial.com/seeds). 