### PR TITLE
Update hull.json

### DIFF
--- a/configs/hull.json
+++ b/configs/hull.json
@@ -1,16 +1,16 @@
 {
   "index_name": "hull",
   "start_urls": [
-    "https://www.hull.io/help/"
+    "https://www.hull.io/docs/"
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".header__title",
-    "lvl1": ".content--help-post h1",
-    "lvl2": ".content--help-post h2",
-    "lvl3": ".content--help-post h3",
-    "lvl4": ".content--help-post h4",
-    "text": ".content--help-post p, .content--help-post li"
+    "lvl0": ".nav--docs__sidebar__title",
+    "lvl1": ".content--docs h1",
+    "lvl2": ".content--docs h2",
+    "lvl3": ".content--docs h3",
+    "lvl4": ".content--docs h4",
+    "text": ".content--docs p, .content--docs li"
   },
   "min_indexed_level": 1,
   "conversation_id": [


### PR DESCRIPTION
Migrate from `/help` to `/docs` on our docs website.
