### PR TITLE
TestCafe - Add tables to the index

### DIFF
--- a/configs/testcafe.json
+++ b/configs/testcafe.json
@@ -14,7 +14,7 @@
     "lvl3": ".post-content h3",
     "lvl4": ".post-content h4",
     "lvl5": ".post-content h5",
-    "text": ".post-content p, .post-content li"
+    "text": ".post-content p, .post-content li, .post-content table"
   },
   "strip_chars": " .,;:#",
   "min_indexed_level": 1,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Currently, DocSearch does not index table contents in TestCafe docs and thus they are not searchable.

It sometimes becomes painful as we occasionally use tables to describe some minor API members with simple meaning and usage.

### What is the current behaviour?

Table content is not searchable.

### What is the expected behaviour?

Users can search for API members described within tables.

##### NB: Do you want to request a **feature** or report a **bug**?

It's more of a bug I guess.