### PR TITLE
Use root sitemap for activeui

### DIFF
--- a/configs/activeui.json
+++ b/configs/activeui.json
@@ -1,10 +1,8 @@
 {
   "index_name": "activeui",
-  "start_urls": [
-    "https://www.activeviam.com/activeui/documentation/next/"
-  ],
+  "start_urls": [],
   "sitemap_urls": [
-    "https://www.activeviam.com/activeui/documentation/next/sitemap.xml"
+    "https://activeviam.com/activeui/documentation/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

### What is the current behaviour?

Only the `next` version is crawled.

### What is the expected behaviour?

New versions should be crawled as they are added to the [sitemap index](https://www.activeviam.com/activeui/documentation/sitemap.xml).

##### NB2: Any other feedback / questions ?

I checked the code source of [docsearch-scraper](https://github.com/algolia/docsearch-scraper) and its [scrapy dependency](https://github.com/scrapy/scrapy) and it [seems to support sitemapindex](https://github.com/scrapy/scrapy/blob/1fd1702a11a56ecbe9851ba4f9d3c10797e262dd/scrapy/spiders/sitemap.py#L46-L49). Do you confirm that the approach I'm taking will work with DocSearch?

Thanks!
