### PR TITLE
index the 3.4 directory instead of 3.3

### DIFF
--- a/configs/todc-bootstrap.json
+++ b/configs/todc-bootstrap.json
@@ -5,7 +5,7 @@
       "url": "https://todc.github.io/todc-bootstrap/docs/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "3.3",
+          "3.4",
           "4.1"
         ]
       }


### PR DESCRIPTION
Updating the config to reflect the doc versions that I would like to be searchable.