### PR TITLE
Bootstrap: add 4.2

### DIFF
--- a/configs/bootstrap.json
+++ b/configs/bootstrap.json
@@ -5,6 +5,7 @@
       "url": "https://getbootstrap.com/docs/(?P<version>.*?)/",
       "variables": {
         "version": [
+          "4.2",
           "4.1",
           "4.0"
         ]


### PR DESCRIPTION
Hey, guys. We were informed that search doesn't work for 4.2 so I had a look. I thought that with the current implementation where we make use of `facetFilters` and the version we wouldn't need to do something else for each major/minor relase, but something is missing.
Do we need to do this every time we have a new major/minor version?

Here's our 4.2 JS file https://github.com/twbs/bootstrap/blob/v4-dev/site/docs/4.2/assets/js/src/search.js