### PR TITLE
calliope.json: add versions to start_urls

### DIFF
--- a/configs/calliope.json
+++ b/configs/calliope.json
@@ -1,7 +1,16 @@
 {
   "index_name": "calliope",
   "start_urls": [
-    "https://calliope.readthedocs.io/"
+    {
+      "url": "https://calliope.readthedocs.io/en/(?P<version>.*?)/",
+      "variables": {
+        "version": [
+          "stable",
+          "latest",
+          "0.6.4"
+        ]
+      }
+    }
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

https://calliope.readthedocs.io/ redirects to https://calliope.readthedocs.io/en/stable/, thus all searches irrespective of what doc version is being displayed, show results from https://calliope.readthedocs.io/en/stable/

### What is the expected behaviour?

Searches from a specific doc version should show results from that version. E.g. searching in https://calliope.readthedocs.io/en/latest/ should show results from https://calliope.readthedocs.io/en/latest/.
