### PR TITLE
Add the archived doc version 0.9.x for Zowe

### DIFF
--- a/configs/zowe.json
+++ b/configs/zowe.json
@@ -5,7 +5,8 @@
       "url": "https://zowe.github.io/docs-site/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "latest"
+          "latest",
+          "v0-9-x"
         ]
       }
     }


### PR DESCRIPTION
# Pull request motivation(s)
With Zowe 1.0.0 rolling out soon, we archived Zowe 0.9.x docs to support version control of docs. Added this archived version to the list to continue to support Algolia search.

### What is the expected behaviour?
Algolia search can continue to work in our old version doc. 
