### PR TITLE
Update expressionengine.json

### DIFF
--- a/configs/expressionengine.json
+++ b/configs/expressionengine.json
@@ -5,9 +5,7 @@
       "url": "https://docs.expressionengine.com/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "latest",
-          "v4",
-          "v3"
+          "latest"
         ]
       }
     }
@@ -15,18 +13,22 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": ".top-nav .breadcrumb li + li a",
-      "global": true
+        "selector": "#docsearch-content h1",
+        "global": true,
+        "default_value": "Documentation"
     },
-    "lvl1": {
-      "selector": ".top-nav .breadcrumb li + li + li a",
-      "global": true
-    },
-    "lvl2": "#content h1",
-    "lvl3": "#content h2",
-    "lvl4": "#content h3",
-    "lvl5": "#content h4",
-    "text": "#content p, #content li"
+    "lvl1": "#docsearch-content h2",
+    "lvl2": "#docsearch-content h3",
+    "lvl3": "#docsearch-content h4",
+    "lvl4": "#docsearch-content h5",
+    "text": "#docsearch-content p, #docsearch-content li"
+  },
+  "selectors_exclude": [
+    ".table-of-contents",
+    ".docs-footer"
+  ],
+  "custom_settings": {
+    "separatorsToIndex": "_"
   },
   "conversation_id": [
     "732264627"


### PR DESCRIPTION
# Pull request motivation(s)

We re-designed our docs, and the HTML structure has changed.

## Questions

The headings in our docs all have an `<a>` tag in them, and some of the headings can also contain inline code elements. Do the selectors need to account for them?