### PR TITLE
Update v-play.json config

### DIFF
--- a/configs/v-play.json
+++ b/configs/v-play.json
@@ -2,7 +2,13 @@
   "index_name": "v-play",
   "start_urls": [
     "https://v-play.net/doc/",
-    "https://v-play.net/doc/vplayapps-appbutton/"
+    "https://v-play.net/doc/apps-api/",
+    "https://v-play.net/doc/vplay-group/",
+    "https://v-play.net/doc/plugin-overview/"
+  ],
+  "sitemap_urls": [
+    "https://v-play.net/sitemap_vpdocs.xml",
+    "https://v-play.net/sitemap_vpdocsqt.xml"
   ],
   "stop_urls": [
     "\\?utm"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->
Update config with start urls of component overview pages and sitemap files for V-Play and Qt components.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
Improve search results returned by doc search.

### What is the current behaviour?
Current crawl coverage missing key pages of our documentation. This was tested by an Algolia engineer, by adding one example page as start_url, which then showed up in search results as expected.

### What is the expected behaviour?
Important pages should show up in search results, especially when there is a 1to1 string match on the page h1 tag.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
