### PR TITLE
Update sendbird.json

### DIFF
--- a/configs/sendbird.json
+++ b/configs/sendbird.json
@@ -37,7 +37,8 @@
   "custom_settings": {
     "separatorsToIndex": "_",
     "attributesForFaceting": [
-      "version"
+      "version",
+      "platform"
     ]
   },
   "only_content_level": true,


### PR DESCRIPTION
We lose platform faceting after previous PR merged so i want to add `platform` as a facet

### What is the current behaviour?
`platform` is removed from facet

### What is the expected behaviour?
`platform` has to be on the facet list

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
