### PR TITLE
Added salesforce vscode docs

### DIFF
--- a/configs/salesforce-vscode.json
+++ b/configs/salesforce-vscode.json
@@ -1,0 +1,18 @@
+{
+  "index_name": "salesforce_vscode",
+  "start_urls": [],
+  "stop_urls": [],
+  "sitemap_urls": [
+    "https://forcedotcom.github.io/salesforcedx-vscode/sitemap.xml"
+  ],
+  "selectors": {
+    "lvl0": ".site-main h1",
+    "lvl1": ".docs h2",
+    "lvl2": ".docs h3",
+    "lvl3": ".docs h4",
+    "lvl4": ".docs h5",
+    "lvl5": ".docs h6",
+    "text": ".docs p, .docs li"
+  },
+  "keep_tags": ["code"]
+}


### PR DESCRIPTION
Adding config for Salesforce Extensions for VS Code docs. Site will be live on Feb. 14th. 
