### PR TITLE
Use DocSearch meta tags for bootstrap pages

### DIFF
--- a/configs/bootstrap.json
+++ b/configs/bootstrap.json
@@ -10,10 +10,12 @@
           "4.0"
         ]
       }
-    }
+    },
+    "https://getbootstrap.com/docs/"
   ],
   "stop_urls": [
-    "/examples/.+"
+    "/examples/.+",
+    "getbootstrap.com/docs/3"
   ],
   "selectors": {
     "lvl0": {
@@ -31,5 +33,5 @@
   "selectors_exclude": [
     ".bd-example"
   ],
-  "nb_hits": 7609
+  "nb_hits": 7563
 }

--- a/configs/bootstrap.json
+++ b/configs/bootstrap.json
@@ -15,7 +15,8 @@
   ],
   "stop_urls": [
     "/examples/.+",
-    "getbootstrap.com/docs/3"
+    "getbootstrap.com/docs/3",
+    "getbootstrap.com/docs/versions/"
   ],
   "selectors": {
     "lvl0": {
@@ -23,15 +24,21 @@
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".bd-content h1",
-    "lvl2": ".bd-content h2",
-    "lvl3": ".bd-content h3",
-    "lvl4": ".bd-content h4",
-    "lvl5": ".bd-content h5",
-    "text": ".bd-content p, .bd-content li, .bd-example"
+    "lvl1": "main h1",
+    "lvl2": "main h2",
+    "lvl3": "main h3",
+    "lvl4": "main h4",
+    "lvl5": "main h5",
+    "text": "main p, main li, .bd-example"
   },
   "selectors_exclude": [
     ".bd-example"
   ],
-  "nb_hits": 7563
+  "custom_settings": {
+    "attributesForFaceting": [
+      "version",
+      "language"
+    ]
+  },
+  "nb_hits": 7557
 }


### PR DESCRIPTION
# Pull request motivation(s)

Following #684 

This PR will enable our crawler to correctly extract the attributes `version` & `language` introduced by the DocSearch meta tags in bootstrap for version released after 4.2. These meta tags are built this way:

```html
<meta name="docsearch:language" content="en">
<meta name="docsearch:version" content="4.3">
```

Pages for version <= 4.2 do not have these meta tags included in its DOM, this is why we need to keep the `variables` from `start_urls`.

## Update from the embedded JS:

```js
docsearch({
  apiKey: '5990ad008512000bba2cf951ccf0332f',
  indexName: 'bootstrap',
  inputSelector: '#search-input',
  algoliaOptions: { 'facetFilters': ['version:$VERSION', 'language:$LANGUAGE'] }
  debug: false // Set debug to true if you want to inspect the dropdown
});
```
- Replace `$VERSION` with the language you want to search on. The list of possible language is hardcoded in the config (version <= 4.2) or extracted according to the meta.
- Replace `$LANGUAGE` with the language you want to search on. The list of possible language is either extracted according to the meta tags or is not defined (version <= 4.2) . 

**WARNING**: If you plan to update the DocSearch JS snippet integrated in version 4.0, 4.1 or 4.2 we can defined a fallback selector matching the XPATH selector `/htlm/@lang`. Otherwise, no result will be returned since there is no record from these versions that has a `language` attribute set.

Note: Once this PR will be deployed, we could remove [the config `bootstrap-v4`](https://github.com/algolia/docsearch-configs/blob/master/configs/bootstrap-v4.json) since this index includes the version 4.0: cc @mdo or @mattonit (contributors of v4). Let us know if this can be done easily.

cc @XhmikosR 