### PR TITLE
Change default_value for selectors

### DIFF
--- a/configs/twilio.json
+++ b/configs/twilio.json
@@ -19,7 +19,7 @@
     "lvl1": {
       "selector": "//*[contains(@class,'docs-sidebar__file-tree')]//li[contains(@class,'is-selected')]/preceding::label[1]",
       "type": "xpath",
-      "default_value": "Chapter",
+      "default_value": "Tutorial",
       "global": true
     },
     "lvl2": ".docs-prose h1",


### PR DESCRIPTION
Hoping to use "Tutorial" rather than "Chapter" for un-categorized content in Twilio's docs.

Our users generally think of all non-API reference documentation, broadly, as 'Tutorials' – so this categorization for anything not included in our side navigation should make more sense to them than 'Chapter'.

Let me know if you have any questions! Thanks!

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
