### PR TITLE
Update costream.json

### DIFF
--- a/configs/costream.json
+++ b/configs/costream.json
@@ -1,8 +1,8 @@
 {
   "index_name": "costream",
   "start_urls": [
-    "https://cn.costream.site/guide/",
-    "https://cn.costream.site/api/"
+    "https://cn.costream.org/guide/",
+    "https://cn.costream.org/api/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Our website has changed its domain name from `cn.costream.site` to `cn.costream.org`.