### PR TITLE
Update Front-Commerce’s config to match v2 docs markup

### DIFF
--- a/configs/front-commerce.json
+++ b/configs/front-commerce.json
@@ -1,28 +1,23 @@
 {
   "index_name": "front-commerce",
-  "start_urls": [
-    "https://developers.front-commerce.com/docs/welcome.html",
-    "https://developers.front-commerce.com/docs/"
+  "start_urls": ["https://developers.front-commerce.com/docs/"],
+  "stop_urls": [
+    "https://developers.front-commerce.com/$",
+    "https://developers.front-commerce.com/docs$",
+    "index\\.html"
   ],
-  "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//*[contains(@class,'navGroupActive')]//a[contains(@class,'navItemActive')]/preceding::h3[1]",
-      "type": "xpath",
-      "global": true,
+      "selector": "div.sidebar span.title-sidebar",
       "default_value": "Documentation"
     },
-    "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "text": ".post article p, .post article li"
+    "lvl1": ".header-wrapper h1",
+    "lvl2": ".content-wrapper h2",
+    "lvl3": ".content-wrapper h3",
+    "lvl4": ".content-wrapper h4",
+    "text": ".content-wrapper p, .content-wrapper li, .header-wrapper div.subtitle-page"
   },
-  "selectors_exclude": [
-    ".hash-link"
-  ],
-  "conversation_id": [
-    "541631444"
-  ],
+  "min_indexed_level": 2,
+  "conversation_id": ["541631444"],
   "nb_hits": 268
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

We have released a new version of our documentation with different markup and many more pages.
This PR contains the updated config.

### What is the current behaviour?

The search redirects to old urls

### What is the expected behaviour?

Search results must go to the new url

##### NB2: Any other feedback / questions ?

I ran it locally using the docker image and it seemed to work fine (I got relevant results from https://community.algolia.com/docsearch-preview/).

That being said, the output froze at some point in my terminal so I am not sure it works perfectly. Could it be related to the [`nb_hits`](https://community.algolia.com/docsearch/config-file.html#nb_hits-special) current value detecting a spike because of new content on this new version?
I would really appreciate if you could do a test run before merging (you can override the current index)… to have a more experienced eye looking into this :smile: 

Feel free to tweak the configuration if needed (it should be close to the `apollodata` one).

Thank you very much.