### PR TITLE
Update cubejs start_urls

### DIFF
--- a/configs/cubejs.json
+++ b/configs/cubejs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "cubejs",
   "start_urls": [
-    "https://statsbot.co/cubejs/docs"
+    "https://cube.dev/docs"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We've moved Cube.js website and docs to its own domain - cube.dev