### PR TITLE
Update dnnsoftware.json to use sitemap

### DIFF
--- a/configs/dnnsoftware.json
+++ b/configs/dnnsoftware.json
@@ -1,5 +1,6 @@
 {
   "index_name": "dnnsoftware",
+  "sitemap_urls": ["https://dnndocs.com/sitemap.xml"],
   "start_urls": [
     {
       "url": "https://dnndocs.com/api/",


### PR DESCRIPTION
We're now building a sitemap.xml file and want docsearch to use that as the source of truth.