### PR TITLE
te3201_2019.json: tweak level 0 headings

### DIFF
--- a/configs/te3201_2019.json
+++ b/configs/te3201_2019.json
@@ -51,11 +51,16 @@
       "text": ".website-content p, .website-content li, .website-content .table td"
     },
     "programming": {
-      "lvl0": ".website-content h1",
-      "lvl1": ".website-content h3",
-      "lvl2": ".website-content h4",
-      "lvl3": ".website-content h5",
-      "lvl4": ".website-content h6",
+       "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Programming Textbook"
+      },
+      "lvl1": ".website-content h1",
+      "lvl2": ".website-content h3",
+      "lvl3": ".website-content h4",
+      "lvl4": ".website-content h5",
+      "lvl5": ".website-content h6",
       "text": ".website-content p, .website-content li, .website-content .table td"
     },
     "schedule": {
@@ -75,7 +80,7 @@
       "lvl0": {
         "selector": "",
         "global": true,
-        "default_value": "SE topics"
+        "default_value": "SE Textbook"
       },
       "lvl1": ".website-content h1",
       "lvl2": ".website-content h2",


### PR DESCRIPTION
I'm trying to tweak the level 0 headings in search results. The top one should be `Programming Textbook` and the second one should be `SE Textbook`.

![image](https://user-images.githubusercontent.com/1673303/54365330-9aada780-46a9-11e9-8840-6b66cb0ae94b.png)

On a related note, I'm wondering if you can help to tweak the config file so that the lower level headings of [the admin info page](https://nus-te3201.github.io/2019/admin/te3201-admin.html) can be captured in results too.
![image](https://user-images.githubusercontent.com/1673303/54365644-34755480-46aa-11e9-9714-4a883c7774b2.png)

