### PR TITLE
te3201_2019.json: add a level0 selector for 'Admin Info'

### DIFF
--- a/configs/te3201_2019.json
+++ b/configs/te3201_2019.json
@@ -10,6 +10,7 @@
     },
     {
       "url": "https://nus-te3201.github.io/2019/admin/",
+      "selectors_key": "admin",
       "tags": [
         "admin"
       ]
@@ -48,6 +49,19 @@
       "lvl3": ".website-content h4",
       "lvl4": ".website-content h5",
       "lvl5": ".website-content h6",
+      "text": ".website-content p, .website-content li, .website-content .table td"
+    },
+    "admin": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Admin Info"
+      },
+      "lvl1": ".website-content h1",
+      "lvl2": ".website-content h2",
+      "lvl3": ".website-content h3",
+      "lvl4": ".website-content h4",
+      "lvl5": ".website-content h5",
       "text": ".website-content p, .website-content li, .website-content .table td"
     },
     "programming": {


### PR DESCRIPTION
Following from [this comment](https://github.com/algolia/docsearch-configs/pull/775#issuecomment-473192414), I'm trying to divide the search results into three sections. @s-pace would this work too? If not, I'll try adding a hidden element to relevant pages as suggested.