### PR TITLE
te3201_2019.json: add js_render option

### DIFF
--- a/configs/te3201_2019.json
+++ b/configs/te3201_2019.json
@@ -1,5 +1,7 @@
 {
   "index_name": "te3201_2019",
+  "js_render": true,
+  "js_wait": 10,
   "start_urls": [
     {
       "url": "https://nus-te3201.github.io/2019/schedule/",


### PR DESCRIPTION
I'm adding `js_render` option because some of our contents are rendered on the client side. Our objective is to prevent indexing contents that are not visible on the page e.g., content in modal windows, collapsed panels, etc.