### PR TITLE
Wait for tailwindcss team to filter on version

### DIFF
--- a/configs/tailwindcss.json
+++ b/configs/tailwindcss.json
@@ -1,25 +1,69 @@
 {
   "index_name": "tailwindcss",
   "start_urls": [
-    "https://tailwindcss.com/docs"
+    {
+      "url": "https://next.tailwindcss.com/docs/",
+      "selectors_key": "v1",
+      "extra_attributes": {
+        "version": [
+          "v1"
+        ]
+      }
+    },
+    {
+      "url": "https://tailwindcss.com/docs",
+      "extra_attributes": {
+        "version": [
+          "v0"
+        ]
+      }
+    }
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "//nav[contains(@id, 'nav')]//a[contains(@class, 'font-semibold')][1]/preceding::p[1]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
+    "default": {
+      "lvl0": {
+        "selector": "//nav[contains(@id, 'nav')]//a[contains(@class, 'font-semibold')][1]/preceding::p[1]",
+        "type": "xpath",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": ".markdown h1",
+      "lvl2": ".markdown h2",
+      "lvl3": ".markdown h3",
+      "lvl4": ".markdown h4",
+      "lvl5": ".markdown h5",
+      "text": ".markdown > p, .markdown > ul li, .markdown td:first-child, .markdown .text-xl"
     },
-    "lvl1": ".markdown h1",
-    "lvl2": ".markdown h2",
-    "lvl3": ".markdown h3",
-    "lvl4": ".markdown h4",
-    "lvl5": ".markdown h5",
-    "text": ".markdown p, .markdown li, .markdown td:first-child"
+    "v1": {
+      "lvl0": {
+        "selector": "//nav[contains(@id, 'nav')]//*[contains(@class, 'opacity-25')][1]/preceding::h5[1]",
+        "type": "xpath",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": ".markdown h1",
+      "lvl2": ".markdown h2",
+      "lvl3": ".markdown h3",
+      "lvl4": ".markdown h4",
+      "lvl5": ".markdown h5",
+      "text": ".markdown > p, .markdown > ul li, .markdown td:first-child, .markdown .text-gray-600"
+    }
+  },
+  "selectors_exclude": [
+    "p.text-base",
+    ".list-inside",
+    ".bg-gray-200"
+  ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "version",
+      "tags"
+    ],
+    "separatorsToIndex": "@_-"
   },
   "conversation_id": [
     "459164857"
   ],
-  "nb_hits": 2103
+  "nb_hits": 4456
 }


### PR DESCRIPTION
This PR:
- make tailwindcss ready for their new release
- remove loremp ipsum content from the search
- scrap subtitle
- enable the search with specific separtors

We will merged it once their use of the JS snippet is updated. They need to enable filtering on version by updating the snippet:

```js
docsearch({
  apiKey: '3df93446658cd9c4e314d4c02a052188',
  indexName: 'tailwindcss',
  inputSelector: '#docsearch',
  algoliaOptions: { 'facetFilters': ["version:$VERSION"] },
```

- Replace $VERSION with the version you want to search on. The list of possible version is hardcoded in the config. So as of today, it can be: `v0` or `v1`

For example if you want to refine the JS on these pages https://tailwindcss.com/docs/ (version is "v0") the snippet should be: 
```js
docsearch({
  apiKey: '3df93446658cd9c4e314d4c02a052188',
  indexName: 'tailwindcss',
  inputSelector: '#docsearch',
  algoliaOptions: { 'facetFilters': ["version:v0"]},
```
 cc @adamwathan, please ping us once this is live.

Cheers and congrats for the new release 🎉 