### PR TITLE
(apollodata) add custom page_rank for some pages

### DIFF
--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -1,7 +1,19 @@
 {
   "index_name": "apollodata",
   "start_urls": [
-    "https://www.apollographql.com/docs/"
+    "https://www.apollographql.com/docs/",
+    {
+      "url": "https://www.apollographql.com/docs/platform/",
+      "page_rank": 3
+    },
+    {
+      "url": "https://www.apollographql.com/docs/react/",
+      "page_rank": 2
+    },
+    {
+      "url": "https://www.apollographql.com/docs/apollo-server/",
+      "page_rank": 1
+    }
   ],
   "stop_urls": [
     "index\\.html"


### PR DESCRIPTION
This branch adjust the `apollodata` config to give more weight to results on the Platform, Client, and Server pages. I'm using the `page_rank` config option to achieve this, as described at https://community.algolia.com/docsearch/config-file.html#using-page-rank.

cc @peggyrayzis @abernix 