### PR TITLE
fix start_urls for graphql-compose

### DIFF
--- a/configs/graphql-compose.json
+++ b/configs/graphql-compose.json
@@ -1,8 +1,8 @@
 {
   "index_name": "graphql-compose",
   "start_urls": [
-    "https://graphql-compose.github.io/docs/en/intro-quick-start.html",
-    "https://graphql-compose.github.io/docs"
+    "https://graphql-compose.github.io/docs/intro/quick-start.html",
+    "https://graphql-compose.github.io"
   ],
   "stop_urls": [],
   "selectors": {

--- a/configs/graphql-compose.json
+++ b/configs/graphql-compose.json
@@ -1,7 +1,8 @@
 {
   "index_name": "graphql-compose",
   "start_urls": [
-    "https://graphql-compose.github.io/docs/intro/quick-start.html"
+    "https://graphql-compose.github.io/docs/intro/quick-start.html",
+    "https://graphql-compose.github.io/docs"
   ],
   "stop_urls": [],
   "selectors": {

--- a/configs/graphql-compose.json
+++ b/configs/graphql-compose.json
@@ -1,8 +1,7 @@
 {
   "index_name": "graphql-compose",
   "start_urls": [
-    "https://graphql-compose.github.io/docs/intro/quick-start.html",
-    "https://graphql-compose.github.io"
+    "https://graphql-compose.github.io/docs/intro/quick-start.html"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

Make crawling alive.

### What is the current behaviour?

Search does not work properly. When click by search results it redirects to the wrong location (to 404 page).

