### PR TITLE
te3201_2019.json: remove js_render option

### DIFF
--- a/configs/te3201_2019.json
+++ b/configs/te3201_2019.json
@@ -107,6 +107,7 @@
     }
   },
   "selectors_exclude": [
+    ".algolia-no-index",
     "[id$='-toc']",
     "#toc",
     ".alert"
@@ -114,7 +115,6 @@
   "custom_settings": {
     "separatorsToIndex": "_"
   },
-  "js_render": true,
   "scrap_start_urls": false,
   "conversation_id": [
     "775254692"


### PR DESCRIPTION
As we have added an `algolia-no-index` class for content that are hidden, there is no longer a need to use `"js_render"=true`.