### PR TITLE
Update cosmos_network.json

### DIFF
--- a/configs/cosmos_network.json
+++ b/configs/cosmos_network.json
@@ -1,8 +1,7 @@
 {
   "index_name": "cosmos_network",
   "start_urls": [
-    "https://cosmos.network/docs/",
-    "https://cosmos-staging.interblock.io/docs/"
+    "https://cosmos.network/docs/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

I am CDO at Tendermint Inc, and we maintain the Cosmos website and the Cosmos documentation at https://cosmos.network/docs. We want to hide the `cosmos-staging.interblock.io` search results from the `cosmos.network` website.

### What is the current 

The search field at https://cosmos.network/docs shows duplicated results for every query, with a 50/50 chance of sending the user to our staging website.

### What is the expected 

Only one set of search results, from the correct website.

Thank you!
