### PR TITLE
add new version 4.3 of boosted to docsearch

### DIFF
--- a/configs/boosted-orange.json
+++ b/configs/boosted-orange.json
@@ -8,7 +8,8 @@
           "3.4",
           "4.0",
           "4.1",
-          "4.2"
+          "4.2",
+          "4.3"
         ]
       }
     },
@@ -19,13 +20,14 @@
           "3.4",
           "4.0",
           "4.1",
-          "4.2"
+          "4.2",
+          "4.3"
         ]
       }
     }
   ],
   "sitemap_urls": [
-    "http://boosted.orange.com/sitemap.xml"
+    "https://boosted.orange.com/sitemap.xml"
   ],
   "stop_urls": [
     "/examples/.+"


### PR DESCRIPTION
Publish official documentation for next release 4.3 so need to add it to boosted-orange configuration.

Thanks