### PR TITLE
Migrate docs.grafana.org to grafana.com/docs

### DIFF
--- a/configs/grafana.json
+++ b/configs/grafana.json
@@ -1,12 +1,10 @@
 {
   "index_name": "grafana",
   "start_urls": [
-    "http://docs.grafana.org/"
+    "https://grafana.com/docs/"
   ],
   "stop_urls": [
-    "http://docs.grafana.org/$",
-    "v2.1",
-    "archive"
+    "https://grafana.com/(?!docs/)"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
Grafana Labs migrated their docs site from http://docs.grafana.org/ to https://grafana.com/docs.