### PR TITLE
Exclude Grafana archived versions from search

### DIFF
--- a/configs/grafana.json
+++ b/configs/grafana.json
@@ -4,7 +4,8 @@
     "https://grafana.com/docs/"
   ],
   "stop_urls": [
-    "https://grafana.com/(?!docs/)"
+    "https://grafana.com/(?!docs/)",
+    "https://grafana.com/docs/v\\d+\\.\\d+/"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation


### What is the current behaviour?

On the Grafana documentation site, search results from multiple docs version are returned.

### What is the expected behaviour?

We only want the current version to be indexed. This commit adds a `stop_urls` entry.