### PR TITLE
add stop_url: when url have /changelog or tag=

### DIFF
--- a/configs/bee_tinper.json
+++ b/configs/bee_tinper.json
@@ -3,7 +3,10 @@
   "start_urls": [
     "http://bee.tinper.org/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "/changelog",
+    "tag="
+  ],
   "selectors": {
     "lvl0": ".demo-container h2",
     "lvl1": ".demo-container h3",


### PR DESCRIPTION
# add stop_url

### What is the current behaviour?

It crawled all versions of documents and changelog

### What is the expected behaviour?

I don't want to crawled all versions of documents and changelog 

### NB: Do you want to request a **feature** or report a **bug**?

This is  **feature**