### PR TITLE
Update URLs for Tailwind docs

### DIFF
--- a/configs/tailwindcss.json
+++ b/configs/tailwindcss.json
@@ -2,7 +2,7 @@
   "index_name": "tailwindcss",
   "start_urls": [
     {
-      "url": "https://next.tailwindcss.com/docs/",
+      "url": "https://tailwindcss.com/docs/",
       "selectors_key": "v1",
       "extra_attributes": {
         "version": [
@@ -11,7 +11,7 @@
       }
     },
     {
-      "url": "https://tailwindcss.com/docs",
+      "url": "https://v0.tailwindcss.com/docs",
       "extra_attributes": {
         "version": [
           "v0"


### PR DESCRIPTION
I'm not totally sure if this is what's necessary, but I recently moved the beta docs (at the "next" subdomain) to our bare domain and would love if the search result links would be updated so they stop going to the next URL 👍🏻

Thanks!
