### PR TITLE
Update rsshub.json

### DIFF
--- a/configs/rsshub.json
+++ b/configs/rsshub.json
@@ -3,9 +3,7 @@
   "start_urls": [
     "https://docs.rsshub.app/"
   ],
-  "stop_urls": [
-    "\\.html$"
-  ],
+  "stop_urls": [],
   "selectors": {
     "lvl0": {
       "selector": "p.sidebar-heading.open",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Fix `stop_urls` value for `rsshub.json`

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

`*.html` is my correct urls, but it's added in `stop_urls`

The steps to reproduce:

1. Search `twitter` in <https://docs.rsshub.app>

1. Click the first item

1. Page will jump to `https://docs.rsshub.app/social-media#twitter`, but the correct url is `https://docs.rsshub.app/social-media.html#twitter`

### What is the expected behaviour?

Page jumps to correct url


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
