### PR TITLE
Fix bug in Parcel.js search

### DIFF
--- a/configs/parceljs.json
+++ b/configs/parceljs.json
@@ -2,17 +2,10 @@
   "index_name": "parceljs",
   "start_urls": [
     {
-      "url": "https://parceljs.org",
-      "extra_attributes": {
-        "lang": [
-          "en"
-        ]
-      }
-    },
-    {
       "url": "https://(?P<lang>.*?).parceljs.org/",
       "variables": {
         "lang": [
+          "en",
           "es",
           "fr",
           "it",


### PR DESCRIPTION
# Pull request motivation(s)

Currently Parcel's search breaks if a user who isn't english is using the search in the english docs.
As parceljs.org isn't always english, it depends on the country of the visitor.

Related: https://github.com/parcel-bundler/website/issues/440

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

See https://github.com/parcel-bundler/website/issues/440

### What is the expected behaviour?

Should use `en.parceljs.org` if searching in the english docs

##### NB: Do you want to request a **feature** or report a **bug**?

This is a bug