### PR TITLE
Index all of tailwindcss.com

### DIFF
--- a/configs/tailwindcss.json
+++ b/configs/tailwindcss.json
@@ -2,7 +2,7 @@
   "index_name": "tailwindcss",
   "start_urls": [
     {
-      "url": "https://tailwindcss.com/docs/",
+      "url": "https://tailwindcss.com/",
       "selectors_key": "v1",
       "extra_attributes": {
         "version": [


### PR DESCRIPTION
I've moved a few pages on the Tailwind site from out of the /docs path to just top level, for example:

https://tailwindcss.com/components/alerts

Hopefully this change is what's required to fix that!

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
