### PR TITLE
[FIX] Fix Wooclap DocSearch config

### DIFF
--- a/configs/wooclap.json
+++ b/configs/wooclap.json
@@ -1,31 +1,62 @@
 {
   "index_name": "wooclap",
   "start_urls": [
-    "https://www.wooclap.com/en/features/votes/",
-    "https://www.wooclap.com/en/features",
-    "https://www.wooclap.com/de/features",
-    "https://www.wooclap.com/es/features",
-    "https://www.wooclap.com/fr/fonctionnalites",
-    "https://www.wooclap.com/nl/functies",
-    "https://www.wooclap.com/ru/instrumenty",
     {
-      "url": "https://docs.wooclap.com",
+      "url": "https://www.wooclap.com/en/features/votes/",
+      "tags": ["features"]
+    },
+    {
+      "url": "https://www.wooclap.com/es/features/votos/",
+      "tags": ["features"]
+    },
+    {
+      "url": "https://www.wooclap.com/fr/fonctionnalites/votes/",
+      "tags": ["features"]
+    },
+    {
+      "url": "https://www.wooclap.com/ru/instrumenty/ochnoye-obucheniye/",
+      "tags": ["features"]
+    },
+    {
+      "url": "https://www.wooclap.com/de/",
+      "tags": ["features"]
+    },
+    {
+      "url": "https://docs.wooclap.com/",
       "selectors_key": "faq",
-      "tags": [
-        "faq"
-      ]
+      "tags": ["faq"]
+    },
+    {
+      "url": "https://www.wooclap.com/en/blog/",
+      "selectors_key": "blog",
+      "tags": ["blog"]
+    },
+    {
+      "url": "https://www.wooclap.com/fr/blog/",
+      "selectors_key": "blog",
+      "tags": ["blog"]
+    },
+    {
+      "url": "https://www.wooclap.com/es/blog/",
+      "selectors_key": "blog",
+      "tags": ["blog"]
     }
   ],
   "stop_urls": [],
   "sitemap_urls": [
-    "https://www.wooclap.com/sitemap.xml"
+    "https://www.wooclap.com/sitemap.xml",
+    "https://www.wooclap.com/landing-sitemap.xml",
+    "https://www.wooclap.com/en/sitemap.xml",
+    "https://www.wooclap.com/es/sitemap.xml",
+    "https://www.wooclap.com/fr/sitemap.xml"
   ],
+  "sitemap_alternate_links": true,
   "selectors": {
     "default": {
       "lvl0": {
         "selector": "main nav h2",
         "global": true,
-        "default_value": "Documentation"
+        "default_value": "Features"
       },
       "lvl1": "main section h1",
       "lvl2": "main section h2",
@@ -53,6 +84,25 @@
       "lvl5": ".content h5",
       "lvl6": ".content h6",
       "text": ".content p, .content li, .content .article__desc",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true
+      }
+    },
+    "blog": {
+      "lvl0": {
+        "selector": "h1.entry-title",
+        "global": true,
+        "default_value": "Blog"
+      },
+      "lvl1": ".entry-content h1",
+      "lvl2": ".entry-content h2",
+      "lvl3": ".entry-content h3",
+      "lvl4": ".entry-content h4",
+      "lvl5": ".entry-content h5",
+      "lvl6": ".entry-content h6",
+      "text": ".entry-content p, .entry-content blockquote, .entry-content li",
       "lang": {
         "selector": "/html/@lang",
         "type": "xpath",


### PR DESCRIPTION
Changing the configuration for the Wooclap search index.

- adding the four sitemaps on top of the sitemap index
- crawl alternate links
- set the tags for the various start urls
- add our blog that contains the active / blended / neuro learning content required to understand the tool

