### PR TITLE
[FIX] Fix Wooclap DocSearch FAQ config

### DIFF
--- a/configs/wooclap.json
+++ b/configs/wooclap.json
@@ -108,7 +108,7 @@
       "lvl4": ".content .section__article h4",
       "lvl5": ".content .section__article h5",
       "lvl6": ".content .section__article h6",
-      "text": ".content .section__article p, .content li, .content .article__desc"
+      "text": ".content .section__article p, .content .section__article li, .content .section__article .article__desc"
     },
     "blog": {
       "lvl0": {

--- a/configs/wooclap.json
+++ b/configs/wooclap.json
@@ -32,8 +32,15 @@
       ]
     },
     {
-      "url": "https://docs.wooclap.com/",
+      "url": "https://docs.wooclap.com/faq-(?P<lang>[a-z]{2}?)",
       "selectors_key": "faq",
+      "variables": {
+        "lang": [
+          "en",
+          "es",
+          "fr"
+        ]
+      },
       "tags": [
         "faq"
       ]
@@ -101,12 +108,7 @@
       "lvl4": ".content h4",
       "lvl5": ".content h5",
       "lvl6": ".content h6",
-      "text": ".content p, .content li, .content .article__desc",
-      "lang": {
-        "selector": "/html/@lang",
-        "type": "xpath",
-        "global": true
-      }
+      "text": ".content p, .content li, .content .article__desc"
     },
     "blog": {
       "lvl0": {
@@ -115,7 +117,7 @@
         "default_value": "Blog"
       },
       "lvl1": ".entry-content h1",
-      "lvl2": ".entry-content h2",
+      "lvl2": ".entry-content h2:not(.cta-content-title)",
       "lvl3": ".entry-content h3",
       "lvl4": ".entry-content h4",
       "lvl5": ".entry-content h5",

--- a/configs/wooclap.json
+++ b/configs/wooclap.json
@@ -116,7 +116,7 @@
         "global": true,
         "default_value": "Blog"
       },
-      "lvl1": ".entry-content h1",
+      "lvl1": "h1.entry-title, .entry-content h1",
       "lvl2": ".entry-content h2:not(.cta-content-title)",
       "lvl3": ".entry-content h3",
       "lvl4": ".entry-content h4",

--- a/configs/wooclap.json
+++ b/configs/wooclap.json
@@ -98,21 +98,21 @@
     },
     "faq": {
       "lvl0": {
-        "selector": "body > div.container > div > section > div.breadcrumb > div:nth-child(3) > a",
+        "selector": "div.breadcrumb > div:nth-child(3) > a",
         "global": true,
         "default_value": "Documentation"
       },
-      "lvl1": ".content h1",
-      "lvl2": ".content h2",
-      "lvl3": ".content h3",
-      "lvl4": ".content h4",
-      "lvl5": ".content h5",
-      "lvl6": ".content h6",
-      "text": ".content p, .content li, .content .article__desc"
+      "lvl1": ".content .section__article h1",
+      "lvl2": ".content .section__article h2",
+      "lvl3": ".content .section__article h3",
+      "lvl4": ".content .section__article h4",
+      "lvl5": ".content .section__article h5",
+      "lvl6": ".content .section__article h6",
+      "text": ".content .section__article p, .content li, .content .article__desc"
     },
     "blog": {
       "lvl0": {
-        "selector": "h1.entry-title",
+        "selector": ".bread-navigation > li:nth-child(2) > a",
         "global": true,
         "default_value": "Blog"
       },


### PR DESCRIPTION
It seems that Intercom isn't setting the language of articles correctly.
We are slowly migrating off of it but in the meantime, we can extract the language from the url.
Also excluding CTA text from the text search.