### PR TITLE
Update wepay_developer.json

### DIFF
--- a/configs/wepay_developer.json
+++ b/configs/wepay_developer.json
@@ -2,7 +2,7 @@
   "index_name": "wepay_developer",
   "start_urls": [
     "https://developer.wepay.com/docs/",
-    "https://developwer.wepay.com/api/"
+    "https://developer.wepay.com/api/"
   ],
   "stop_urls": [],
   "sitemap_urls": [

--- a/configs/wepay_developer.json
+++ b/configs/wepay_developer.json
@@ -1,7 +1,8 @@
 {
   "index_name": "wepay_developer",
   "start_urls": [
-    "https://developer.wepay.com/docs/"
+    "https://developer.wepay.com/docs/",
+    "https://developwer.wepay.com/api/"
   ],
   "stop_urls": [],
   "sitemap_urls": [


### PR DESCRIPTION
# Pull request motivation(s)

Adding in a new path to index. Currently, the implementation doesn't search our API reference content, and I think this fixes it.

### What is the current behaviour?

Current behavior only shows search results for what is under /docs on developer.wepay.com. 

### What is the expected behaviour?

We should be showing search results for API calls on developer.wepay.com/api

