### PR TITLE
Update stop_urls of kyma-project

### DIFF
--- a/configs/kyma-project.json
+++ b/configs/kyma-project.json
@@ -13,7 +13,8 @@
     "https://kyma-project.io/sitemap.xml"
   ],
   "stop_urls": [
-    "root/kyma/"
+    "docs/latest/",
+    "docs/root/kyma/"
   ],
   "selectors": {
     "docs": {


### PR DESCRIPTION
### What is the current behaviour?

Update stop_urls of kyma-project. At the moment we have duplicated records - from `docs/` path and `docs/latest` path. So we decided to add `docs/latest` path to `stop_urls` array.