### PR TITLE
v4 was released, it's no longer needed to crawl it

### DIFF
--- a/configs/material-ui.json
+++ b/configs/material-ui.json
@@ -1,8 +1,7 @@
 {
   "index_name": "material-ui",
   "start_urls": [
-    "https://material-ui.com/",
-    "https://next.material-ui.com/"
+    "https://material-ui.com/"
   ],
   "stop_urls": [
     "\\?expend-path"


### PR DESCRIPTION
We will most likely need this subdomain for v5, in 6 months for now.