### PR TITLE
Temporarily exclude localized Branch docs pages

### DIFF
--- a/configs/branchmetrics.json
+++ b/configs/branchmetrics.json
@@ -3,7 +3,11 @@
   "start_urls": [
     "https://docs.branch.io/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "/ko/",
+    "/zh/",
+    "/ja/"
+  ],
   "sitemap_urls": [
     "https://docs.branch.io/sitemap.xml"
   ],


### PR DESCRIPTION
# Pull request motivation(s)
Branch is in the process of rolling out localized documentation. We plan to implement language-specific facets (as described [here](https://community.algolia.com/docsearch/config-file.html#using-regular-expressions)) but haven't quite finished development.

In the meantime, we've translated some ad-hoc pages into Korean and Chinese (e.g., https://docs.branch.io/ko/branch-android/ and https://docs.branch.io/zh/integrate/), and we observe that these pages are dominating our Docsearch results for certain keywords.

This PR is intended to temporarily exclude non-English pages from indexing, until we have properly rolled out language-specific facets.

### What is the current behaviour?
All pages are indexed, regardless of language.

### What is the expected behaviour?
The current behavior IS the expected behavior — we just need a temporary band-aide fix.