### PR TITLE
Feat: Adding version search in the API Platform project documentation

### DIFF
--- a/configs/api-platform.json
+++ b/configs/api-platform.json
@@ -1,7 +1,15 @@
 {
   "index_name": "api-platform",
   "start_urls": [
-    "https://api-platform.com/docs"
+    {
+      "url": "https://api-platform.com/docs"
+    },
+    {
+      "url": "https://api-platform.com/docs/(?P<version>.*?)/",
+      "variables": {
+        "version": ["master", "2.4", "2.3", "2.2", "2.1"]
+      }
+    }
   ],
   "sitemap_urls": [
     "https://api-platform.com/sitemap.xml"

--- a/configs/api-platform.json
+++ b/configs/api-platform.json
@@ -2,13 +2,13 @@
   "index_name": "api-platform",
   "start_urls": [
     {
-      "url": "https://api-platform.com/docs"
-    },
-    {
       "url": "https://api-platform.com/docs/(?P<version>.*?)/",
       "variables": {
         "version": ["master", "2.4", "2.3", "2.2", "2.1"]
       }
+    },
+    {
+      "url": "https://api-platform.com/docs"
     }
   ],
   "sitemap_urls": [


### PR DESCRIPTION
# Pull request motivation(s)
Updating the search configuration for the [API platform website](https://api-platform.com/).
  - The default search is only on the current version.
  - We would like to search by facet according to a version.

## What is the current behaviour?
Currently on the search of the [API platform website](https://api-platform.com/) we are doing research on all versions of the documentation.

## What is the expected behaviour?
We would like 2 new behaviors

1. The default search is only on the current version.
For example here is a url of the current version of the documentation: https://api-platform.com/docs/core/
For the current version we do not have a version parameter in the URL.

2. We would like to search by facet according to a version.
For example here is a url of the 2.3 version of the documentation: https://api-platform.com/docs/v2.3/core/
For a given version, we do have a version parameter in the URL.

@s-pace How can we test this part locally without having to merge the changes in production?

Pull request in [API Platform Website](https://github.com/api-platform/website/pull/111)