### PR TITLE
Start crawling at root

### DIFF
--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -1,6 +1,7 @@
 {
   "index_name": "substrate",
   "start_urls": [
+    "https://substrate.dev",
     "https://substrate.dev/docs/",
     "https://substrate.dev/docs/en/quickstart/installing-substrate"
   ],


### PR DESCRIPTION
Search should also index pages like these:
* https://substrate.dev/tutorials/
* https://substrate.dev/recipes/




# Pull request motivation(s)
We would like search to index our entire domain. While much of the content is hosted in docusaurus, we would also like results for non docusaurus content like the links above.

### What is the current behaviour?

Currently only the documentation that lives directly in docusaurus is being indexed by search

### What is the expected behaviour?

The entire domain should be indexed.

##### NB: Do you want to request a **feature** or report a **bug**?

No

##### NB2: Any other feedback / questions ?

Is is possible to crawl subdomains? For example we will eventually serve some content at crates.substrate.dev and would like that indexed as well.