### PR TITLE
Attempt: Enable indexing on rustdocs (substrate)

### DIFF
--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -3,7 +3,11 @@
   "start_urls": [
     "https://substrate.dev",
     "https://substrate.dev/docs/",
-    "https://substrate.dev/docs/en/quickstart/installing-substrate"
+    "https://substrate.dev/docs/en/getting-started/",
+    {
+      "url": "https://substrate.dev/rustdocs/v1.0/substrate_service/index.html",
+      "selectors_key": "rustdocs"
+    }
   ],
   "sitemap_urls": [
     "https://substrate.dev/sitemap.xml"
@@ -11,18 +15,27 @@
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
+    "default": {
+      "lvl0": {
+        "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
+        "type": "xpath",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": ".post h1",
+      "lvl2": ".post h2",
+      "lvl3": ".post h3",
+      "lvl4": ".post h4",
+      "lvl5": ".post h5",
+      "text": ".post article p, .post article li"
     },
-    "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "lvl5": ".post h5",
-    "text": ".post article p, .post article li"
+    "rustdocs": {
+      "lvl0": "h1.fqn .in-band",
+      "lvl1": ".docblock h1 a, h2.section-header",
+      "lvl2": ".docblock h2 a",
+      "lvl3": ".docblock h3 a",
+      "text": ".docblock li, .docblock p, .content table",
+    }
   },
   "selectors_exclude": [
     ".hash-link"


### PR DESCRIPTION
# Pull request motivation(s)
Trying to get the [portion of our site generated from rustdoc](https://substrate.dev/rustdocs/v1.0) into the index. 

### What is the current behaviour?
Only docusaurus-based content is indexed.

### What is the expected behaviour?
Rustdoc will also be indexed

##### NB: Do you want to request a **feature** or report a **bug**?
no

##### NB2: Any other feedback / questions ?
Thank you for your outstanding help so far. If you notice anything obvious that will prevent this PR from working, guidance is appreciated.