### PR TITLE
configs/pingcap.json:  update stop urls

### DIFF
--- a/configs/pingcap.json
+++ b/configs/pingcap.json
@@ -17,8 +17,12 @@
     }
   ],
   "stop_urls": [
-    "/docs/v\\d",
-    "/docs-cn/v\\d"
+    "/docs/v2.1-legacy",
+    "/docs/v2.0",
+    "/docs/v1.0",
+    "/docs-cn/v2.1-legacy",
+    "/docs-cn/v2.0",
+    "/docs-cn/v1.0"
   ],
   "sitemap_urls": [
     "https://pingcap.com/sitemap.xml"


### PR DESCRIPTION
# Pull request motivation(s)
Update the `stop_urls` in config file, so that the docs in other versions can be searched by user

### What is the current behaviour?
The docs in version v2.1 and v3.0 do not show in the search result.

### What is the expected behaviour?
The docs in version v2.1 and v3.0 can be filtered in the search result.

##### NB: Do you want to request a **feature** or report a **bug**?
No

##### NB2: Any other feedback / questions ?
No

@xuechunL @s-pace PTAL. Thanks!