### PR TITLE
Update colony.json

### DIFF
--- a/configs/colony.json
+++ b/configs/colony.json
@@ -24,6 +24,42 @@
       "tags": [
         "colonyjs"
       ]
+    },
+    {
+      "url": "http://docs.colony.io/colonystarter/docs-overview/",
+      "tags": [
+        "colonystarter"
+      ]
+    },
+    {
+      "url": "https://docs.colony.io/colonystarter/",
+      "tags": [
+        "colonystarter"
+      ]
+    },
+    {
+      "url": "http://docs.colony.io/purser/docs-overview/",
+      "tags": [
+        "purser"
+      ]
+    },
+    {
+      "url": "https://docs.colony.io/purser/",
+      "tags": [
+        "purser"
+      ]
+    },
+    {
+      "url": "http://docs.colony.io/tailor/docs-overview/",
+      "tags": [
+        "tailor"
+      ]
+    },
+    {
+      "url": "https://docs.colony.io/tailor/",
+      "tags": [
+        "tailor"
+      ]
     }
   ],
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

Update `colony.json` configuration to include additional project urls.

Closes JoinColony/JoinColony.github.io#40

### What is the current behaviour?

The `colony.json` configuration is missing projects that we would like to make available to search.

### What is the expected behaviour?

The `colony.json` configuration includes all projects that we would like to make available to search.
