### PR TITLE
Update Substrate Configuration

### DIFF
--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -3,10 +3,17 @@
   "start_urls": [
     {
       "url": "https://substrate.dev/rustdocs/",
-      "selectors_key": "rustdocs"
+      "selectors_key": "rustdocs",
+      "page_rank": 50
     },
-    "https://substrate.dev/docs/",
-    "https://substrate.dev"
+    {
+      "url": "https://substrate.dev/docs/",
+      "page_rank": 100
+    },
+    {
+      "url": "https://substrate.dev",
+      "page_rank": 10
+    }
   ],
   "stop_urls": [],
   "selectors": {

--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -1,8 +1,5 @@
 {
   "index_name": "substrate",
-  "js_render": true,
-  "js_wait": 2,
-  "use_anchors": true,
   "start_urls": [
     {
       "url": "https://substrate.dev/rustdocs/",

--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -1,5 +1,8 @@
 {
   "index_name": "substrate",
+  "js_render": true,
+  "js_wait": 2,
+  "use_anchors": true,
   "start_urls": [
     {
       "url": "https://substrate.dev/rustdocs/",
@@ -9,10 +12,6 @@
     "https://substrate.dev"
   ],
   "stop_urls": [],
-  "sitemap_urls": [
-    "https://substrate.dev/sitemap.xml"
-  ],
-  "sitemap_alternate_links": true,
   "selectors": {
     "default": {
       "lvl0": {

--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -7,6 +7,11 @@
       "page_rank": 50
     },
     {
+      "url": "https://substrate.dev/recipes/",
+      "selectors_key": "mdbook",
+      "page_rank": 25
+    },
+    {
       "url": "https://substrate.dev/docs/",
       "page_rank": 100
     },
@@ -37,6 +42,15 @@
       "lvl2": ".docblock h2 a",
       "lvl3": ".docblock h3 a",
       "text": ".docblock li, .docblock p, .content table"
+    },
+    "mdbook": {
+      "lvl0": "h1.menu-title",
+      "lvl1": ".content h1",
+      "lvl2": ".content h2",
+      "lvl3": ".content h3",
+      "lvl4": ".content h4",
+      "lvl5": ".content h5",
+      "text": ".content li, .content p, .content table"
     }
   },
   "selectors_exclude": [


### PR DESCRIPTION
The Substrate Developer Hub is a GitHub Pages based website for documenting Substrate, an open source blockchain development framework.

We use a number of different tools for documentation including:
- [Docusaurus](https://docusaurus.io/) | [[Example]](https://github.com/substrate-developer-hub/substrate-developer-hub.github.io)
- [Docsify](https://docsify.js.org/#/) | [[Example]](https://github.com/substrate-developer-hub/substrate-collectables-workshop)
- [RustDoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) | [[Example]](https://github.com/substrate-developer-hub/rustdocs)
- [MDBook](https://github.com/rust-lang-nursery/mdBook) | [[Example]](https://github.com/substrate-developer-hub/recipes)

These various projects are all "combined together" using the veil of GitHub pages which hosts all of these documentation pages under the shared parent URL `substrate.dev`.

We would like to use Algolia as a cross project search engine for all of our Substrate docs.

This PR removes the `sitemap_urls` and `sitemap_alternate_links` properties since these are not correctly generated for our multiple different projects. Instead, we would like to rely on the Algolia crawler to follow our links to find the various docs under the `substrate.dev` domain.

Further, this PR adds `js_render`, `js_wait`, and `use_anchors` specifically to address the crawling and documentation of [Docsify](https://docsify.js.org/#/), which is a client rendered website which does use `#` urls and may take a second or two to load. I have looked into statically generating these pages, but Docsify does not currently support this. It possible I may move to an alternate solution as a result, but for now, this is what I would like to try.

@JoshOrndorff @s-pace 

https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/145