### PR TITLE
update stop_urls

### DIFF
--- a/configs/rasa.json
+++ b/configs/rasa.json
@@ -5,12 +5,10 @@
   ],
   "stop_urls": [
     "http://rasa.com/docs/.*?/\\d",
-    "http://rasa.com/docs/rasa/(?!master)",
+    "http://rasa.com/docs/.*?/master",
     ".rst.txt$",
-    "http://rasa.com/docs/about/$",
     "/_",
-    "/dev/",
-    "/rasa-x/master"
+    "/dev/"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
This PR is to fix #852 . We have updated our sitemap: https://rasa.com/docs/sitemap.xml

### What is the expected behaviour?
We want to scrape all `rasa.com/docs/rasa`, `rasa.com/docs/rasa-x` and `rasa.com/docs/getting-started` links, that don't follow the format `rasa.com/docs/<rasa|rasa-x>/#.#.#/<whatever>` or rasa.com/docs/<rasa|rasa-x>/master/<whatever>. I'm not much of a regex person, so if possible I'd love a sanity check on that!