### PR TITLE
featurepeek: Update start_urls value

### DIFF
--- a/configs/featurepeek.json
+++ b/configs/featurepeek.json
@@ -1,7 +1,7 @@
 {
   "index_name": "featurepeek",
   "start_urls": [
-    "https://docs.featurepeek.com/docs/"
+    "https://docs.featurepeek.com/"
   ],
   "sitemap_urls": [
     "https://docs.featurepeek.com/sitemap.xml"


### PR DESCRIPTION
I have set `docsUrl` to `''`, so there is no longer a `docs` directory in my URL structure.