### PR TITLE
Fix Wooclap's docsearch config

### DIFF
--- a/configs/wooclap.json
+++ b/configs/wooclap.json
@@ -33,6 +33,7 @@
     },
     {
       "url": "https://docs.wooclap.com/",
+      "selectors_key": "faq",
       "tags": [
         "faq"
       ]

--- a/configs/wooclap.json
+++ b/configs/wooclap.json
@@ -32,15 +32,7 @@
       ]
     },
     {
-      "url": "https://docs.wooclap.com/faq-(?P<lang>[a-z]{2}?)",
-      "selectors_key": "faq",
-      "variables": {
-        "lang": [
-          "en",
-          "es",
-          "fr"
-        ]
-      },
+      "url": "https://docs.wooclap.com/",
       "tags": [
         "faq"
       ]
@@ -91,7 +83,7 @@
       "lvl6": "main section h6",
       "text": "main section p, main section li",
       "lang": {
-        "selector": "/html/@lang",
+        "selector": "substring(//div[contains(@class,'breadcrumb')]/div[2]/a/text(), string-length(//div[contains(@class,'breadcrumb')]/div[2]/a/text()) - 2, 2), /html/@lang",
         "type": "xpath",
         "global": true
       }


### PR DESCRIPTION
The software generating our FAQ (https://docs.wooclap.com/) recently changed the way they exposed the language code information. This means we now have to extract it from the DOM in a non-trivial way instead of the URL. 

I wrote an XPATH expression that should extract the language code successfully.

- Are language selector rules applies sequentially?
e.g: If a selector has results for rule n°1 and rule n°2, which result will be taken into account n°1 or n°2?

- Does the language code casing matter?
The expression returns an uppercased version of the string and the `lower-case()` function is only available in XPath v2 which is not widely available for browsers (not sure about DocSearch).