### PR TITLE
Update Substrate Search Config

### DIFF
--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -4,12 +4,12 @@
     {
       "url": "https://substrate.dev/rustdocs/",
       "selectors_key": "rustdocs",
-      "page_rank": 50
+      "page_rank": 25
     },
     {
       "url": "https://substrate.dev/recipes/",
       "selectors_key": "mdbook",
-      "page_rank": 25
+      "page_rank": 50
     },
     {
       "url": "https://substrate.dev/docs/",
@@ -20,7 +20,9 @@
       "page_rank": 10
     }
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "print.html"
+  ],
   "selectors": {
     "default": {
       "lvl0": {

--- a/configs/substrate.json
+++ b/configs/substrate.json
@@ -2,9 +2,13 @@
   "index_name": "substrate",
   "start_urls": [
     {
-      "url": "https://substrate.dev/rustdocs/",
-      "selectors_key": "rustdocs",
-      "page_rank": 25
+      "url": "https://substrate.dev/docs/",
+      "page_rank": 100
+    },
+    {
+      "url": "https://substrate.dev/tutorials/",
+      "selectors_key": "tutorial-catalog",
+      "page_rank": 75
     },
     {
       "url": "https://substrate.dev/recipes/",
@@ -12,8 +16,9 @@
       "page_rank": 50
     },
     {
-      "url": "https://substrate.dev/docs/",
-      "page_rank": 100
+      "url": "https://substrate.dev/rustdocs/",
+      "selectors_key": "rustdocs",
+      "page_rank": 25
     },
     {
       "url": "https://substrate.dev",
@@ -53,6 +58,15 @@
       "lvl4": ".content h4",
       "lvl5": ".content h5",
       "text": ".content li, .content p, .content table"
+    },
+    "tutorial-catalog": {
+      "lvl0": "h1.projectTitle",
+      "lvl1": ".mainContainer h1",
+      "lvl2": ".mainContainer h2",
+      "lvl3": ".mainContainer h3",
+      "lvl4": ".mainContainer h4",
+      "lvl5": ".mainContainer h5",
+      "text": ".mainContainer li, .mainContainer p"
     }
   },
   "selectors_exclude": [


### PR DESCRIPTION
This adds "print.html" to the stop urls in order to avoid pages like:

```
https://substrate.dev/recipes/print.html#dessert-
```

Which has a nasty popup.

This also adds the `/tutorials/` page to search index