### PR TITLE
nus-cs2103-ay1920s1.json: add tag se-book-adapted

### DIFF
--- a/configs/nus-cs2103-ay1920s1.json
+++ b/configs/nus-cs2103-ay1920s1.json
@@ -16,10 +16,10 @@
       ]
     },
     {
-      "url": "https://nus-cs2103-ay1920s1.github.io/website/programming/",
-      "selectors_key": "programming",
+      "url": "https://nus-cs2103-ay1920s1.github.io/website/se-book-adapted/",
+      "selectors_key": "se-book-adapted",
       "tags": [
-        "programming"
+        "se-book-adapted"
       ]
     },
     "https://nus-cs2103-ay1920s1.github.io/website/"
@@ -58,18 +58,19 @@
       "lvl5": ".website-content h5",
       "text": ".website-content p, .website-content li, .website-content .table td"
     },
-    "programming": {
+    "se-book-adapted": {
       "lvl0": {
         "selector": "",
         "global": true,
-        "default_value": "Programming Textbook"
+        "default_value": "Textbook"
       },
       "lvl1": ".website-content h1",
-      "lvl2": ".website-content h3",
-      "lvl3": ".website-content h4",
-      "lvl4": ".website-content h5",
-      "lvl5": ".website-content h6",
-      "text": ".website-content p, .website-content li, .website-content .table td"
+      "lvl2": ".website-content h2",
+      "lvl3": ".website-content h3",
+      "lvl4": ".website-content h4",
+      "lvl5": ".website-content h5",
+      "lvl6": ".website-content h6",
+      "text": ".website-content panel p, .website-content panel li, .website-content panel .table td"
     },
     "schedule": {
       "lvl0": {


### PR DESCRIPTION
### What is the expected behaviour?

https://nus-cs2103-ay1920s1.github.io/website/se-book-adapted/ to be captured under a separate tag `se-book-adapted`

It will replace the `programming` tag as it is no longer needed.


