### PR TITLE
update start urls, set page rank and selector of lvl0

### DIFF
--- a/configs/pingcap.json
+++ b/configs/pingcap.json
@@ -2,18 +2,52 @@
   "index_name": "pingcap",
   "start_urls": [
     {
-      "url": "https://pingcap.com/docs-cn/",
+      "url": "https://pingcap.com/docs-cn/v3.0/",
       "selectors_key": "docs_cn",
       "tags": [
         "cn"
-      ]
+      ],
+      "page_rank": 1
     },
     {
-      "url": "https://pingcap.com/docs/",
+      "url": "https://pingcap.com/docs-cn/dev/",
+      "selectors_key": "docs_cn",
+      "tags": [
+        "cn"
+      ],
+      "page_rank": 2
+    },
+    {
+      "url": "https://pingcap.com/docs-cn/v2.1/",
+      "selectors_key": "docs_cn",
+      "tags": [
+        "cn"
+      ],
+      "page_rank": 3
+    },
+    {
+      "url": "https://pingcap.com/docs/v3.0/",
       "selectors_key": "docs",
       "tags": [
         "en"
-      ]
+      ],
+      "page_rank": 1
+    },
+    {
+      "url": "https://pingcap.com/docs/v3.0/",
+      "selectors_key": "docs",
+      "tags": [
+        "en"
+      ],
+      "page_rank": 2
+    },
+    {
+      "url": "https://pingcap.com/docs/v2.1/",
+      "selectors_key": "docs",
+      "tags": [
+        "en"
+      ],
+      "page_rank": 3
     }
   ],
   "stop_urls": [
@@ -38,7 +72,7 @@
     },
     "docs_cn": {
       "lvl0": {
-        "selector": "",
+        "selector": "button#dropdownMenuButton",
         "global": true,
         "default_value": "文档"
       },
@@ -50,7 +84,7 @@
     },
     "docs": {
       "lvl0": {
-        "selector": "",
+        "selector": "button#dropdownMenuButton",
         "global": true,
         "default_value": "Documentation"
       },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

1. Update the start URLs with versions
2. Make the page rank of v3.0 docs be highest
3. Update the selectors of `lvl0` in `docs_cn` and `docs`

### What is the current behaviour?

1. There is no `lvl0` in selectors `docs_cn` and `docs`
2. The filtered docs are not sorted by version.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

1. The docs in v3.0 rank first in the search result, following by the dos in version dev and v2.1
2. The docs will be sorted by version.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?


@s-pace @xuechunL  PTAL