### PR TITLE
Update expo.json (add v34.0.0 docs, remove v29.0.0 and older)

### DIFF
--- a/configs/expo.json
+++ b/configs/expo.json
@@ -1,18 +1,16 @@
 {
   "index_name": "expo",
   "start_urls": [
+    "https://docs.expo.io/",
     {
       "url": "https://docs.expo.io/versions/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "v26.0.0",
-          "v27.0.0",
-          "v28.0.0",
-          "v29.0.0",
           "v30.0.0",
           "v31.0.0",
           "v32.0.0",
           "v33.0.0",
+          "v34.0.0",
           "latest",
           "unversioned"
         ]


### PR DESCRIPTION
Expo SDK 34 docs with URLs like https://docs.expo.io/versions/v34.0.0/ have been added, and docs for versions 29 and older have been removed. Also added the base domain as a start URL.
