### PR TITLE
nus-cs2103-ay1920s1.json: tweak stop_urls

### DIFF
--- a/configs/nus-cs2103-ay1920s1.json
+++ b/configs/nus-cs2103-ay1920s1.json
@@ -28,8 +28,7 @@
     "printable",
     "\\d/index.html",
     "schedule/index\\.html",
-    "print\\.html$",
-    "/schedule/"
+    "print\\.html$"
   ],
   "selectors": {
     "default": {


### PR DESCRIPTION
Remove /schedule/ from stop_urls so that pages such as the 
following will be indexed.
https://nus-cs2103-ay1920s1.github.io/website/schedule/week2/topics.html

Not sure if this is the right way to go about it though 🤔 