### PR TITLE
cockroachlabs: do not scrape start urls

### DIFF
--- a/configs/cockroachlabs.json
+++ b/configs/cockroachlabs.json
@@ -32,6 +32,7 @@
     "text": ".post-content p, .post-content li"
   },
   "only_content_level": true,
+  "scrape_start_urls": false,
   "selectors_exclude": [
     "h2#whats-next",
     "h2#whats-next ~ ul",


### PR DESCRIPTION
# Pull request motivation(s)
* addresses: https://github.com/cockroachdb/docs/issues/5179

### What is the current behaviour?
Docs landing page being returned in search results that include search term which happens to appear in link on landing page

@jseldess 