### PR TITLE
Add tags for preview and prod webpage

### DIFF
--- a/configs/gauge.json
+++ b/configs/gauge.json
@@ -2,17 +2,17 @@
   "index_name": "gauge",
   "start_urls": [
     {
-      "url": "https://docs.gauge.org/(?P<version>.*?)/",
-      "variables": {
-        "version": [
-          "master",
-          "latest"
-        ]
-      }
+      "url": "https://docs.gauge.org/",
+      "tags": [
+        "prod"
+      ]
+    },
+        {
+     "url": "https://docs-preview.gauge.org/",
+     "tags": [
+       "preview"
+     ]
     }
-  ],
-  "stop_urls": [
-    "https://docs.gauge.org/0"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
The Gauge website updated to new URLs
```
docs.gauge.org/latest => docs.gauge.org and
docs.gauge.org/master => docs-preview.gauge.org
```
Algolia Search is not working with new website URLs.
Add new start_urls with tags to work Algolia search with the new website.