### PR TITLE
Update hackerone.json

### DIFF
--- a/configs/hackerone.json
+++ b/configs/hackerone.json
@@ -33,5 +33,6 @@
   "conversation_id": [
     "535135855"
   ],
-  "nb_hits": 2588
+  "nb_hits": 2588,
+  "use_anchors": false
 }


### PR DESCRIPTION
Our documentation site isn't using `name` or `id` attributes. To avoid appending the wrong anchor, we're disabling it altogether for the time being.