### PR TITLE
Make the handsontable docs parsable for version higher than 7.0.0

### DIFF
--- a/configs/handsontable.json
+++ b/configs/handsontable.json
@@ -1,17 +1,37 @@
 {
   "index_name": "handsontable",
   "start_urls": [
-    {
-      "url": "https://handsontable.com/docs/(?P<version>.*?)/",
-      "variables": {
-        "version": [
-          "7.1.1",
-          "6.0.0"
-        ]
-      }
-    }
+    "https://handsontable.com/docs/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "/docs/1.14.0",
+    "/docs/1.14.1",
+    "/docs/1.14.2",
+    "/docs/1.14.3",
+    "/docs/1.15.0",
+    "/docs/1.15.1",
+    "/docs/1.16.0",
+    "/docs/1.17.0",
+    "/docs/1.18.0",
+    "/docs/1.18.1",
+    "/docs/2.0.0",
+    "/docs/3.0.0",
+    "/docs/4.0.0",
+    "/docs/5.0.0",
+    "/docs/5.0.1",
+    "/docs/5.0.2",
+    "/docs/6.0.0",
+    "/docs/6.0.1",
+    "/docs/6.1.0",
+    "/docs/6.1.1",
+    "/docs/6.2.0",
+    "/docs/6.2.1",
+    "/docs/6.2.2",
+    "/docs/7.0.0",
+    "/docs/7.0.1",
+    "/docs/7.0.2",
+    "/docs/7.0.3"
+  ],
   "sitemap_urls": [
     "https://handsontable.com/sitemap.xml"
   ],
@@ -28,7 +48,10 @@
     "text": "article p, article li, article td:last-child"
   },
   "custom_settings": {
-    "separatorsToIndex": "_"
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "version"
+    ]
   },
   "selectors_exclude": [
     ".edit-doc",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

I am currently implementing `docsearch` for https://handsontable.com/docs project and I spotted that with current config after new docs release we would have a problem with the non-existent indexed version? the new version would have to be added to "version" key (through PR)? Looking at existing configs it seems that `Jest` documentation works like ours. They don't have hardcoded docs versions so it is resolved automatically by crawler? Correct me if I'm wrong.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

I expect that I don't need to change this configuration file every time the Handsontable version is released. So after deploying a new version of the documentation index will be fulfilled with the content.

And I was instructed to use `faceFilters`.
```
// ...
algoliaOptions: { 'facetFilters': ["version:$VERSION"] }, 
// ...
```

##### NB: Do you want to request a **feature** or report a **bug**?

feature

##### NB2: Any other feedback / questions ?
