### PR TITLE
handsontable: Filter over version

### DIFF
--- a/configs/handsontable.json
+++ b/configs/handsontable.json
@@ -1,15 +1,7 @@
 {
   "index_name": "handsontable",
   "start_urls": [
-    {
-      "url": "https://handsontable.com/docs/(?P<version>.*?)/",
-      "variables": {
-        "version": [
-          "7.1.1",
-          "6.0.0"
-        ]
-      }
-    }
+     "https://handsontable.com/docs/"
   ],
   "stop_urls": [],
   "sitemap_urls": [
@@ -28,7 +20,12 @@
     "text": "article p, article li, article td:last-child"
   },
   "custom_settings": {
-    "separatorsToIndex": "_"
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "tags"
+    ]
   },
   "selectors_exclude": [
     ".edit-doc",


### PR DESCRIPTION
This PR solves #978
cc @budnix

Which version do you want us to index? Which one should not be indexed?

So far, the meta tags are only available on 7.1.1. Is it expected? Could you [provide us a sitemap as explained here](https://community.algolia.com/docsearch/tips.html#use-a-sitemapxml) please?