### PR TITLE
Add stop_url for upload_widget_1 page

### DIFF
--- a/configs/cloudinary.json
+++ b/configs/cloudinary.json
@@ -7,6 +7,7 @@
     "https://cloudinary.com/sitemap.xml"
   ],
   "stop_urls": [
+    "https://cloudinary.com/documentation/upload_widget_1",
     "\\?",
     "\\.txt$"
   ],


### PR DESCRIPTION
# Pull request motivation(s)
The upload_widget_1 doc page covers the 1.0 version of the upload widget feature & is provided for those customers still using 1.0. Thus a link to that page is available from new upload_widget (2.0) documentation page for any customers still using old version, but we don't want people finding this page in a search.

### What is the current behaviour?

Currently, searches for upload widget get results for the old page before the new page.

### What is the expected behaviour?

Searches for upload widget should only get results for the /upload_widget page.
Content from upload_widget_1 should not be indexed.

##### NB2: Any other feedback / questions
The page has noindex metadata (even though there is a link to the page from with in our docs).
Does the link from the page override the noindex when you crawl? I would expect the noindex to prevent the page from being indexed even if we don't add the page as a stop_url.
