### PR TITLE
Update images_weserv.json

### DIFF
--- a/configs/images_weserv.json
+++ b/configs/images_weserv.json
@@ -22,6 +22,8 @@
     }
   },
   "selectors_exclude": [
+    "span.param",
+    "span.badge"
   ],
   "custom_settings": {
     "attributesForFaceting": [


### PR DESCRIPTION
# Pull request motivation

This PR adds the `span.param` and `span.badge` CSS selectors to `selectors_exclude` array. 

### What is the current behaviour?

Consider this header:
![cache-control](https://user-images.githubusercontent.com/12746591/64184685-21c72580-ce6c-11e9-9a98-8b24c2d55e3a.png)

DocSearch also indexes the `&maxage=` and `New!` badges, which we obviously don't want to index.

### What is the expected behaviour?

From the above example, we only want to index the `Cache-Control` text.

##### NB: Do you want to request a **feature** or report a **bug**?

N/A

##### NB2: Any other feedback / questions ?

N/A