### PR TITLE
docs.bitsrc.io moved to a new domain docs.bit.dev

### DIFF
--- a/configs/bitsrc.json
+++ b/configs/bitsrc.json
@@ -1,15 +1,15 @@
 {
   "index_name": "bitsrc",
   "start_urls": [
-    "https://docs.bitsrc.io/"
+    "https://docs.bit.dev/"
   ],
   "stop_urls": [
     "/docs/docs/",
-    "docs/bitsrc.io",
+    "docs/bit.dev",
     ".com",
-    ".io/bitsrc.io",
-    ".io/docs.bitsrc.io/",
-    ".io/tutorial/bitsrc.io",
+    ".dev/bit.dev",
+    ".dev/docs.bit.dev/",
+    ".dev/tutorial/bit.dev",
     "/logs$"
   ],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

We've migrated from docs.bitsrc.io to docs.bit.dev, so i want to update the crawler.