### PR TITLE
openebs: change start-url entry for openebs

### DIFF
--- a/configs/openebs.json
+++ b/configs/openebs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "openebs",
   "start_urls": [
-    "https://docs.openebs.io/"
+    "https://docs.openebs.io/docs/next"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
This PR is for changing the start_urls entry supported for openebs docs search.

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>
