### PR TITLE
Excluding some pages from index to avoid duplicates in search

### DIFF
--- a/configs/adioma-infographopedia.json
+++ b/configs/adioma-infographopedia.json
@@ -4,7 +4,9 @@
     "https://infographopedia.adioma.com/"
   ],
   "stop_urls": [
-    "/example/"
+    "/example/",
+    "/function/",
+    "/chart-definitions"
   ],
   "sitemap_urls": [
     "https://infographopedia.adioma.com/sitemap.xml"


### PR DESCRIPTION
Excluding pages to avoid redundant results when you search for charts on the "Chart list" and "Functions" pages.



### What is the current behavior?

Right now it's showing irrelevant results (marked in red).
![Screen Shot 2019-09-04 at 12 57 13 PM](https://user-images.githubusercontent.com/742796/64536149-3f3f3800-d321-11e9-84b6-cbda8b318056.png)
This happens because chart names are mentioned both on landing pages ("/", "chart-definitions", "function/*") and in each article.


### What is the expected behavior?

Search suggestion box should suggest articles like /bar-chart, /pie-chart or their variations like /bar-chart#stacked-bar-chart, not pointing to chart list page.


