### PR TITLE
version metadata in faceting + crawl the whole site

### DIFF
--- a/configs/rosaenlg.json
+++ b/configs/rosaenlg.json
@@ -1,7 +1,7 @@
 {
   "index_name": "rosaenlg",
   "start_urls": [
-    "https://rosaenlg.org/rosaenlg/0.18.10/"
+    "https://rosaenlg.org/"
   ],
   "stop_urls": [],
   "sitemap_urls": [
@@ -15,6 +15,9 @@
     "lvl4": "article h5",
     "lvl5": "article h6",
     "text": "article p, article li"
+  },
+  "custom_settings": {
+    "attributesForFaceting": ["version"]
   },
   "conversation_id": [
     "948916559"


### PR DESCRIPTION
- manage version metadata in faceting
- crawl the whole site, not only a single version

In all my pages, I have also added:
`<meta name="docsearch:version" content="0.18.10" />`

And in the js of each page:
```
docsearch({
	...
	indexName: 'rosaenlg',
	...
	facetFilters: [
	  'version:0.18.10',
	],
	...
});
```