### PR TITLE
Update hub index

### DIFF
--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -106,10 +106,11 @@
         "global": true,
         "default_value": "Documentation"
       },
-      "lvl2": "article h2",
-      "lvl3": "article h3",
-      "lvl4": "article h4",
-      "lvl5": "article h5",
+      "lvl2": ".jumbotron p.lead-summary",
+      "lvl3": "article h2",
+      "lvl4": "article h3",
+      "lvl5": "article h4",
+      "lvl6": "article h5",
       "text": "article p, article li"
     },
     "tutorials": {
@@ -151,6 +152,9 @@
     ".section [class^=toctree]",
     "[class*=download-link-note]"
   ],
+  "custom_settings": {
+    "attributeForDistinct": "hierarchy.lvl1"
+  },
   "conversation_id": [
     "672318908"
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

Multiple hub index results are being returned for the same record.

### What is the expected behaviour?

Only 1 record should be returned for each hub result. Preferably, just the record's `lvl1` and `lvl2` info should appear in the results.

##### NB: Do you want to request a **feature** or report a **bug**?

N/A

##### NB2: Any other feedback / questions ?

N/A