### PR TITLE
Moved salesforce vscode docs domain

### DIFF
--- a/configs/salesforce_vscode.json
+++ b/configs/salesforce_vscode.json
@@ -3,7 +3,7 @@
   "start_urls": [],
   "stop_urls": [],
   "sitemap_urls": [
-    "https://forcedotcom.github.io/salesforcedx-vscode/sitemap.xml"
+    "https://developer.salesforce.com/tools/vscode/sitemap.xml"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
The salesforce vs code docs site has moved to a new domain.