### PR TITLE
Add another URL selector to GitLab

### DIFF
--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -30,6 +30,16 @@
       "extra_attributes": {
         "product": "GitLab Runner"
       }
+    },
+    {
+      "url": "https://docs.gitlab.com/charts/",
+      "selectors_key": "charts",
+      "tags": [
+        "charts"
+      ],
+      "extra_attributes": {
+        "product": "GitLab Helm Charts"
+      }
     }
   ],
   "stop_urls": [


### PR DESCRIPTION
This adds another URL selector to the GitLab config.