### PR TITLE
Add custom setting for GitLab versions

### DIFF
--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -56,6 +56,7 @@
   ],
   "only_content_level": true,
   "custom_settings": {
+    "attributesForFaceting": ["version:master"],
     "attributesToRetrieve": [
       "hierarchy",
       "content",


### PR DESCRIPTION
This will hopefully enable versioning for the GitLab docs. I added the meta tags as described in https://community.algolia.com/docsearch/required-configuration.html#introduces-global-information-as-meta-tags.

This is the change as @s-pace suggested in https://gitlab.com/gitlab-org/gitlab-docs/issues/182#note_215826952 :)