### PR TITLE
Update Availity Configuration

### DIFF
--- a/configs/availity.json
+++ b/configs/availity.json
@@ -1,21 +1,37 @@
 {
   "index_name": "availity",
   "start_urls": [
-    "https://availity.github.io/",
-    "https://availity.github.io/availity-workflow/"
+    {
+      "url": "https://availity.github.io/availity-react",
+      "page_rank": 3
+    },
+    {
+      "url": "https://availity.github.io/availity-workflow",
+      "page_rank": 2
+    },
+    {
+      "url": "https://availity.github.io/sdk-js",
+      "page_rank": 2
+    },
+    {
+      "url": "https://availity.github.io/gatsby-theme-availity",
+      "page_rank": 1
+    },
+    {
+      "url": "https://availity.github.io/availity-uikit",
+      "page_rank": 2
+    }
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".h-100.w-100 h1",
-    "lvl1": ".h-100.w-100 h2",
-    "lvl2": ".h-100.w-100 h3",
-    "lvl3": ".h-100.w-100 h4",
-    "lvl4": ".h-100.w-100 h5",
-    "lvl5": ".h-100.w-100 h6",
+    "lvl0": ".header-wrapper h1",
+    "lvl1": ".content-wrapper h2",
+    "lvl2": ".content-wrapper h3",
+    "lvl3": ".content-wrapper h4",
+    "lvl4": ".content-wrapper h5",
+    "lvl5": ".content-wrapper h6",
     "text": ".h-100.w-100 p, .h-100.w-100 li"
   },
-  "conversation_id": [
-    "936988941"
-  ],
+  "conversation_id": ["936988941"],
   "nb_hits": 274
 }


### PR DESCRIPTION
## What is the current behavior?
Search results are returning title including the summary.

## What is the expected behavior?
Search results should not index the `summary` provided on pages in the `.page-header h3`

## Do you want to request a feature or report a bug?
N/A

## Any other feedback or questions?
I updated our doc sites just today to keep the title and summary of the pages separate so they are not indexed together. This PR makes sure that we are not indexing the summary any longer. Check [apollo's config](https://github.com/algolia/docsearch-configs/blob/master/configs/apollodata.json) for how they do theirs, we follow their gatsby docs very similarly.
