### PR TITLE
pytorch: distinc over url_without_anchor

### DIFF
--- a/configs/pytorch.json
+++ b/configs/pytorch.json
@@ -153,8 +153,11 @@
     "[class*=download-link-note]",
     ".detail-arrow"
   ],
+  "custom_settings": {
+    "attributeForDistinct": "url_without_anchor"
+  },
   "conversation_id": [
     "672318908"
   ],
-  "nb_hits": 19465
+  "nb_hits": 19455
 }


### PR DESCRIPTION
[Demo available here](http://ds_pytorch_hub.surge.sh)

closes #1017