### PR TITLE
refactor(availity): updated availity configuration once more

### DIFF
--- a/configs/availity.json
+++ b/configs/availity.json
@@ -24,13 +24,17 @@
   ],
   "stop_urls": ["/examples/"],
   "selectors": {
-    "lvl0": ".header-wrapper h1",
-    "lvl1": ".content-wrapper h2",
-    "lvl2": ".content-wrapper h3",
-    "lvl3": ".content-wrapper h4",
-    "lvl4": ".content-wrapper h5",
-    "lvl5": ".content-wrapper h6",
-    "text": ".h-100.w-100 p, .h-100.w-100 li"
+    "lvl0": {
+      "selector": "ul.navbar-nav span p.text-primary",
+      "default_value": "Documentation"
+    },
+    "lvl1": ".header-wrapper h1",
+    "lvl2": ".content-wrapper h2",
+    "lvl3": ".content-wrapper h3",
+    "lvl4": ".content-wrapper h4",
+    "lvl5": ".content-wrapper h5",
+    "text": ".content-wrapper p, .content-wrapper li, .content-wrapper tbody, .header-wrapper h3"
+
   },
   "conversation_id": [
     "936988941"


### PR DESCRIPTION
## What is the current behavior?
Search is not including the correct `h0` title. Text was including headers even though they should be excluded.

## What is the expected behavior?
Search results should have the `name` or `h0` of the page at the top when searching. The search results `text` property should not include the headings from the `content-wrapper`

## Do you want to request a feature or report a bug?
N/A

## Any other feedback or questions?
Was noticing our search results had some weird duplicates so I checked [apollo's config](https://github.com/algolia/docsearch-configs/blob/master/configs/apollodata.json) again and noticed how they were getting their page title's included from their left sidebar.
