### PR TITLE
refactor(availity): fixed lvl0 config

### DIFF
--- a/configs/availity.json
+++ b/configs/availity.json
@@ -27,7 +27,7 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": "ul.navbar-nav span p.text-primary",
+      "selector": "ul.navbar-nav:first-child:first-child :first-child :first-child",
       "default_value": "Documentation"
     },
     "lvl1": ".header-wrapper h1",


### PR DESCRIPTION
## What is the current behavior?
Search for `lvl0` wasn't consistent.

## What is the expected behavior?
Search for `lvl0` should be displaying appropriate page title.

## Do you want to request a feature or report a bug?
N/A

## Any other feedback or questions?
You guys are awesome! Thank you for the quick reviews. Your search is unparalleled and it saves people a bunch of time searching through docs manually. 

PS. I promise this is the last commit for a while.
