### PR TITLE
Fix BLiP's Help Center url

### DIFF
--- a/configs/zowe.json
+++ b/configs/zowe.json
@@ -49,5 +49,5 @@
     "693711568"
   ],
   "scrap_start_urls": false,
-  "nb_hits": 32128
+  "nb_hits": 38510
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

I have just changed the BLiP's url. The Help Center moved to another url.

### What is the current behaviour?

NA

### What is the expected behaviour?

Now, Docsearch can index content in a correct site.

##### NB: Do you want to request a **feature** or report a **bug**?

NA

##### NB2: Any other feedback / questions ?

NA