### PR TITLE
Change to production URL

### DIFF
--- a/configs/near.json
+++ b/configs/near.json
@@ -1,10 +1,10 @@
 {
   "index_name": "near",
   "start_urls": [
-    "https://docs-3bgv.onrender.com/"
+    "https://docs.nearprotocol.com/"
   ],
   "sitemap_urls": [
-    "https://docs-3bgv.onrender.com/sitemap.xml"
+    "https://docs.nearprotocol.com/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
Changing to production URL for site docs.nearprotocol.com. I didn't understand that this would be a manual process on your part. I appreciate y'all setting this up :). If I understand correctly, this should update from crawler running in about 24 hours or so automatically.

### What is the current behaviour?
Links in docs search take user to the staging url which I provided in application. 
*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
 I'd like the results to stay within the docs portal domain.

