### PR TITLE
updated selectors for LiveChat docs

### DIFF
--- a/configs/livechatinc.json
+++ b/configs/livechatinc.json
@@ -4,6 +4,9 @@
     "https://developers.livechatinc.com/docs/"
   ],
   "stop_urls": [],
+  "sitemap_urls": [
+    "https://developers.livechatinc.com/docs/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": "article h1",
     "lvl1": "article h2",
@@ -17,7 +20,8 @@
   },
   "selectors_exclude": [
     "h1 + p",
-    "h1 + style + p"
+    "h1 + style + p",
+    "style"
   ],
   "conversation_id": [
     "504447721"


### PR DESCRIPTION
# Pull request motivation(s)

We're updating DocSearch config to exclude `<style/>` tags created by Emotion. Also, we're adding sitemap.

### What is the current behaviour?

Style tags got indexed.

<img width="437" alt="Screenshot 2019-09-25 at 15 15 23" src="https://user-images.githubusercontent.com/5114422/65692466-e555a680-e072-11e9-953b-f283f151b9cc.png">

### What is the expected behaviour?

Style tags are excluded from indexing.