### PR TITLE
Prefect: Add a stop_url regex for preventing indexing archived API documentation

### DIFF
--- a/configs/prefect.json
+++ b/configs/prefect.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "http://docs.prefect.io"
   ],
-  "stop_urls": ["/api\/([0-9]+\.[0-9]+\.[0-9]+)\/.*"],
+  "stop_urls": ["/api\\/([0-9]+\\.[0-9]+\\.[0-9]+)\\/.*"],
   "selectors": {
     "lvl0": "[class*='content '] h1",
     "lvl1": "[class*='content '] h2",

--- a/configs/prefect.json
+++ b/configs/prefect.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "http://docs.prefect.io"
   ],
-  "stop_urls": [],
+  "stop_urls": ["/api\/([0-9]+\.[0-9]+\.[0-9]+)\/.*"],
   "selectors": {
     "lvl0": "[class*='content '] h1",
     "lvl1": "[class*='content '] h2",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
We archive our historical API documentation, which presents a large number of duplicate matches in our search.  This PR should prevent the indexing of our old versioned API docs.

### What is the current behaviour?
Duplicate search results.

### What is the expected behaviour?
Not to crawl, e.g., https://docs.prefect.io/api/0.6.5/

Thanks!