### PR TITLE
Fix start urls

### DIFF
--- a/configs/stancl-tenancy.json
+++ b/configs/stancl-tenancy.json
@@ -6,7 +6,7 @@
   ],
   "stop_urls": [],
   "sitemap_urls": [
-    "https://tenancy.samuelstancl.me/sitemap.xml"
+    "https://tenancy.samuelstancl.me/docs/sitemap.xml"
   ],
   "selectors": {
     "lvl0": {

--- a/configs/stancl-tenancy.json
+++ b/configs/stancl-tenancy.json
@@ -1,8 +1,7 @@
 {
   "index_name": "stancl-tenancy",
   "start_urls": [
-    "https://tenancy.samuelstancl.me/docs/v1/",
-    "https://tenancy.samuelstancl.me/docs/v2/"
+    "https://tenancy.samuelstancl.me/docs/"
   ],
   "stop_urls": [],
   "sitemap_urls": [

--- a/configs/stancl-tenancy.json
+++ b/configs/stancl-tenancy.json
@@ -1,8 +1,8 @@
 {
   "index_name": "stancl-tenancy",
   "start_urls": [
-    "https://tenancy.samuelstancl.me/docs/",
-    "https://tenancy.samuelstancl.me/docs/v2/getting-started/"
+    "https://tenancy.samuelstancl.me/docs/v1/",
+    "https://tenancy.samuelstancl.me/docs/v2/"
   ],
   "stop_urls": [],
   "sitemap_urls": [


### PR DESCRIPTION
I removed the `getting-started` because it might change in the future. Hope Algolia is ok with a meta redirect to `getting-started/` on the new URLs.

Also made the first start URL specifically `v1` so that when I change the dynamic redirect, both versions will get indexed.