### PR TITLE
CloverDX search - updated selectors for full text and level 0

### DIFF
--- a/configs/cloverdx.json
+++ b/configs/cloverdx.json
@@ -11,7 +11,7 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": "//ul[@class='tree']/li[.//*[contains(@class,'active')]]/a/span",
+      "selector": "//ul[contains(@class,'treemenu-root')]/li[.//*[contains(@class,'active')]]/a/span",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"

--- a/configs/cloverdx.json
+++ b/configs/cloverdx.json
@@ -22,7 +22,7 @@
     "lvl4": "#body-inner h3",
     "lvl5": "#body-inner h4, #body-inner td:first-child",
     "lvl6": "#body-inner h5",
-    "text": "#body-inner p"
+    "text": "#body-inner td, p, pre"
   },
   "selectors_exclude": [
     ".toc",


### PR DESCRIPTION
Updated the selectors for CloverDX search:

* more robust level 0 selector - we think the original didn't work in some cases
* added more elements to the fulltext selector - inside contents of tables (we use them a lot) and preformatted elements (also used often)
