### PR TITLE
Modify datalogic start_urls and sitemap_urls

### DIFF
--- a/configs/datalogic.json
+++ b/configs/datalogic.json
@@ -1,10 +1,10 @@
 {
   "index_name": "datalogic",
   "start_urls": [
-    "https://www.datalogic.dev/"
+    "https://datalogic.github.io/"
   ],
   "sitemap_urls": [
-    "https://www.datalogic.dev/sitemap.xml"
+    "https://datalogic.github.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

 Unfortunately, we had to discard using the old `datalogic.dev` domain name for internal reasons and will be using `datalogic.github.io` for the project going forward.

### What is the current behaviour?

Algolia search links to pages under www.datalogic.dev URL that are no longer available, resulting in "site can't be reached" errors.

### What is the expected behaviour?

Algolia search links to live pages under datalogic.github.io

##### NB: Do you want to request a **feature** or report a **bug**?

feature

##### NB2: Any other feedback / questions ?

No
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
