### PR TITLE
Update apollodata.json stop_urls

### DIFF
--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -16,7 +16,11 @@
     }
   ],
   "stop_urls": [
-    "index\\.html"
+    "index\\.html",
+    "https://www.apollographql.com/docs/angular/",
+    "https://www.apollographql.com/docs/android/",
+    "https://www.apollographql.com/docs/scala/",
+    "https://www.apollographql.com/docs/graphql-subscriptions/"
   ],
   "selectors": {
     "default": {

--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "https://www.apollographql.com/docs/",
     {
-      "url": "https://www.apollographql.com/docs/platform/",
+      "url": "https://www.apollographql.com/docs/graph-manager/",
       "page_rank": 3
     },
     {


### PR DESCRIPTION
This branch excludes the ScalaJS, Android, Angular, and GraphQL subscriptions docsets from our search results.