### PR TITLE
Apollodata: Add graphql-tools to stop URLs

### DIFF
--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -20,6 +20,7 @@
     "https://www.apollographql.com/docs/angular/",
     "https://www.apollographql.com/docs/android/",
     "https://www.apollographql.com/docs/scala/",
+    "https://www.apollographql.com/docs/graphql-tools/",
     "https://www.apollographql.com/docs/graphql-subscriptions/"
   ],
   "selectors": {


### PR DESCRIPTION
This branch adds /graphql-tools path to our list of stop URLs (an oversight in the last change we made to this option)