### PR TITLE
Update thorntech.json with production URL

### DIFF
--- a/configs/thorntech.json
+++ b/configs/thorntech.json
@@ -1,13 +1,13 @@
 {
   "index_name": "thorntech",
   "start_urls": [
-    "https://help2.thorntech.com/docs/",
-    "https://help2.thorntech.com/docs/sftp-gateway-2.0/getting-started-with-sftp-gateway-2.0/",
-    "https://help2.thorntech.com/docs/sftp-gateway-classic/initial-setup/",
-    "https://help2.thorntech.com/docs/sftp-gateway-azure/azure-getting-started/"
+    "https://help.thorntech.com/docs/",
+    "https://help.thorntech.com/docs/sftp-gateway-2.0/getting-started-with-sftp-gateway-2.0/",
+    "https://help.thorntech.com/docs/sftp-gateway-classic/initial-setup/",
+    "https://help.thorntech.com/docs/sftp-gateway-azure/azure-getting-started/"
   ],
   "sitemap_urls": [
-    "https://help2.thorntech.com/sitemap.xml"
+    "https://help.thorntech.com/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
Changed from the pre-production URL to our production URL.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behavior?

Crawl the pre-production URL to populate the search feature for testing.

### What is the expected behavior?

Crawl the production URL. 

### Request
I would like to request that the crawler be run at PR approval so that customers will be taken to the production URL based pages from search results.  

Currently, a customer can visit help.thorntech.com and navigate doc pages, but if they search for a topic the result will take them to the help2.thorntech.com doc page. 

Thank you.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
