### PR TITLE
Update Cloudflare Workers docs URL

### DIFF
--- a/configs/workers-cloudflare.json
+++ b/configs/workers-cloudflare.json
@@ -1,13 +1,13 @@
 {
   "index_name": "workers-cloudflare",
   "start_urls": [
-    "https://workers.cloudflare.com/docs"
+    "https://developers.cloudflare.com/workers"
   ],
   "stop_urls": [
-    "https://workers.cloudflare.com/docs/archive"
+    "https://developers.cloudflare.com/workers/archive"
   ],
   "sitemap_urls": [
-    "https://workers.cloudflare.com/sitemap.xml"
+    "https://developers.cloudflare.com/workers/sitemap.xml"
   ],
   "selectors": {
     "lvl0": "#body-inner h1",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

Hi there! We've updated the location of our docs - this PR updates the URLs in our docsearch config.

### What is the current behaviour?

Requests go to our old docs location, and are immediately redirected to the new location.

### What is the expected behaviour?

The URLs in docsearch are updated, skipping the need to go to the original URLs and redirect to the new location.

##### NB: Do you want to request a **feature** or report a **bug**?

n/a

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

Quick question – we've had some issues with our docsearch where it's referencing outdated versions of pages when searching. An example of this is searching `cf`, where the third result points at text that is no longer on the associated page. I originally started working on this config again to try and resolve that, before realizing that the URLs were out-of-date. Will changing the URLs cause a re-index to remove the old content? Included a picture to show the behavior I'm talking about (notice that the content shown in search isn't on the current page, which is the associated search result page)

<img width="1057" alt="Screen Shot 2019-10-11 at 9 56 28 AM" src="https://user-images.githubusercontent.com/922353/66661993-9597e300-ec0d-11e9-8d3b-d0b56a7c408b.png">
