### PR TITLE
Update ory.json

### DIFF
--- a/configs/ory.json
+++ b/configs/ory.json
@@ -1,26 +1,44 @@
 {
   "index_name": "ory",
   "start_urls": [
-    "https://www.ory.sh/docs"
+    {
+      "url": "https://www.ory.sh/docs/",
+      "tags": [
+        "docs"
+      ]
+    },
   ],
-  "stop_urls": [],
+  "sitemap_urls": [
+    "https://ory.sh/docs/sitemap.xml"
+  ],
+  "stop_urls": [
+    "https://www.ory.sh/docs/deprecated/.*",
+  ],
   "selectors": {
     "lvl0": {
-      "selector": "//nav//li[contains(@class,'active')]/preceding::li[contains(@class,'header')][1]",
+      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".markdown-section h1",
-    "lvl2": ".markdown-section h2",
-    "lvl3": ".markdown-section h3",
-    "lvl4": ".markdown-section h4",
-    "lvl5": ".markdown-section h5",
-    "text": ".markdown-section p, .markdown-section li"
+    "lvl1": ".post h1",
+    "lvl2": ".post h2",
+    "lvl3": ".post h3",
+    "lvl4": ".post h4",
+    "lvl5": ".post h5",
+    "lvl6": ".post h6",
+    "text": ".post article p, .post article li"
   },
   "selectors_exclude": [
-    "#toc"
+    ".hash-link"
   ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "tags"
+    ]
+  },
   "conversation_id": [
     "704914956"
   ],

--- a/configs/ory.json
+++ b/configs/ory.json
@@ -1,13 +1,18 @@
 {
   "index_name": "ory",
   "start_urls": [
-     "https://www.ory.sh/docs/"
+     {
+       "url": "https://www.ory.sh/docs",
+       "tags": [
+         "docs"
+       ]
+     }
   ],
   "sitemap_urls": [
     "https://ory.sh/docs/sitemap.xml"
   ],
   "stop_urls": [
-    "https://www.ory.sh/docs/deprecated/.*",
+    "https://www.ory.sh/docs/deprecated/.*"
   ],
   "selectors": {
     "lvl0": {

--- a/configs/ory.json
+++ b/configs/ory.json
@@ -1,12 +1,7 @@
 {
   "index_name": "ory",
   "start_urls": [
-    {
-      "url": "https://www.ory.sh/docs/",
-      "tags": [
-        "docs"
-      ]
-    },
+     "https://www.ory.sh/docs/"
   ],
   "sitemap_urls": [
     "https://ory.sh/docs/sitemap.xml"


### PR DESCRIPTION
The search index returns only outdated results. Since we're using docusaurus, I more or less copied values from https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus.json and excluded the missing/broken/outdated results. It would be great if a re-indexing could occur as all search results are currently broken for us.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->
