### PR TITLE
Update lightr location

### DIFF
--- a/configs/lightr.json
+++ b/configs/lightr.json
@@ -90,5 +90,4 @@
       "url",
       "url_without_anchor"
     ]
-  }
 }

--- a/configs/lightr.json
+++ b/configs/lightr.json
@@ -90,4 +90,5 @@
       "url",
       "url_without_anchor"
     ]
+  }
 }

--- a/configs/lightr.json
+++ b/configs/lightr.json
@@ -2,21 +2,21 @@
   "index_name": "lightr",
   "start_urls": [
     {
-      "url": "https://bisaloo.github.io/lightr/index.html",
+      "url": "https://docs.ropensci.org/lightr/index.html",
       "selectors_key": "homepage",
       "tags": [
         "homepage"
       ]
     },
     {
-      "url": "https://bisaloo.github.io/lightr/reference",
+      "url": "https://docs.ropensci.org/lightr/reference",
       "selectors_key": "reference",
       "tags": [
         "reference"
       ]
     },
     {
-      "url": "https://bisaloo.github.io/lightr/articles",
+      "url": "https://docs.ropensci.org/lightr/articles",
       "selectors_key": "articles",
       "tags": [
         "articles"
@@ -30,7 +30,7 @@
     "/articles/index.html"
   ],
   "sitemap_urls": [
-    "https://bisaloo.github.io/lightr/sitemap.xml"
+    "https://docs.ropensci.org/lightr/sitemap.xml"
   ],
   "selectors": {
     "homepage": {
@@ -90,6 +90,5 @@
       "url",
       "url_without_anchor"
     ]
-  },
-  "nb_hits": 242
+  }
 }


### PR DESCRIPTION
`lightr` docs have moved from https://bisaloo.github.io/lightr/ to https://docs.ropensci.org/lightr/ and this PR reflects this change.