### PR TITLE
Add stop_url regex that catches versioned docs

### DIFF
--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -28,7 +28,8 @@
     "https://www.apollographql.com/docs/android/",
     "https://www.apollographql.com/docs/scala/",
     "https://www.apollographql.com/docs/graphql-tools/",
-    "https://www.apollographql.com/docs/graphql-subscriptions/"
+    "https://www.apollographql.com/docs/graphql-subscriptions/",
+    "https://www.apollographql.com/([\w-]+)/v(\d+\.[\d-\w]+)/"
   ],
   "selectors": {
     "default": {


### PR DESCRIPTION
@algolia I was confused looking at some of the examples of others using regular expressions in their stop/start URLs and seeing unescaped `.` chars amongst other regex syntax. I'm fairly sure this will accomplish what I'm trying to do—exclude versioned URLs from our search result—but I'd love it if someone who knows better than me could have a look and let me know if I'm doing this right.

You can see how I built this regex and the test strings that I used here: https://regex101.com/r/9mpEXr/1

I'm just confused about how I should be escaping things _other_ than my regex bits, like slashes and periods.