### PR TITLE
Remove specific selectors for API

### DIFF
--- a/configs/openproject.json
+++ b/configs/openproject.json
@@ -31,16 +31,6 @@
       "lvl4": "[role='main'] h5",
       "lvl5": "[role='main'] h6",
       "text": "[role='main'] p, [role='main'] li"
-    },
-    "api": {
-      "lvl0": "#op-api-content header h1",
-      "lvl1": "#op-api-content .panel h1",
-      "lvl2": "#op-api-content .panel h2",
-      "lvl3": "#op-api-content .panel h3, #op-api-content td:first-child",
-      "lvl4": "#op-api-content .panel h4",
-      "lvl5": "#op-api-content .panel h5",
-      "lvl6": "#op-api-content .panel h6",
-      "text": "#op-api-content p, #op-api-content li, #op-api-content td:nth-child(2)"
     }
   },
   "keep_tags": [


### PR DESCRIPTION
We migrated the API documentation from a single-page build coming from blueprint into separate pages which now follow the same structure as the other pages. This means we need to remove the specific selectors in order to allow API content to be found again.
