### PR TITLE
viewar - update "start_url" to new documentation page

### DIFF
--- a/configs/viewar.json
+++ b/configs/viewar.json
@@ -5,12 +5,12 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".markdown-section h1",
-    "lvl1": ".markdown-section h2",
-    "lvl2": ".markdown-section h3",
-    "lvl3": ".markdown-section h4",
-    "lvl4": ".markdown-section h5",
-    "text": ".markdown-section p, .markdown-section li"
+    "lvl0": ".post h1",
+    "lvl1": ".post h2",
+    "lvl2": ".post h3",
+    "lvl3": ".post h4",
+    "lvl4": ".post h5",
+    "text": ".post p, .post li"
   },
   "conversation_id": [
     "559708091"

--- a/configs/viewar.json
+++ b/configs/viewar.json
@@ -1,7 +1,7 @@
 {
   "index_name": "viewar",
   "start_urls": [
-    "https://viewar.gitbooks.io/sdk-documentation"
+    "https://viewar.github.io/documentation/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)
As writing with DocSearch Support, they pointed out, that viewar is already registered.
Since we changed from github to docusaurus, i updated the "start_url" for viewar.

##### NB2: Any other feedback / questions ?
If we have to update one of the id's in this config, please provide some infomarmation.