### PR TITLE
Add faceting by language to bold_

### DIFF
--- a/configs/bold_.json
+++ b/configs/bold_.json
@@ -23,6 +23,9 @@
     "lvl5": "main h5",
     "text": "main p, main li"
   },
+  "custom_settings": {
+    "attributesForFaceting": ["language"]
+  },
   "conversation_id": [
     "840239858"
   ],


### PR DESCRIPTION
Change configuration to consider the `<meta name="docsearch:language" ... />` tags
