### PR TITLE
Changed url for ezplatform personalization doc

### DIFF
--- a/configs/ezplatform_ezpersonalization.json
+++ b/configs/ezplatform_ezpersonalization.json
@@ -2,7 +2,7 @@
   "index_name": "ezplatform_ezservices",
   "start_urls": [
     {
-      "url": "https://doc.ezplatform.com/projects/ezservices/(?P<lang>.*?)/(?P<version>.*?)/",
+      "url": "https://doc.ezplatform.com/projects/ezpersonalization/(?P<lang>.*?)/(?P<version>.*?)/",
       "variables": {
         "lang": [
           "en"


### PR DESCRIPTION
Changed url for ezplatform personalization doc:
https://doc.ezplatform.com/projects/ezservices/
to
https://doc.ezplatform.com/projects/ezpersonalization/

reference: https://github.com/ezsystems/ezpersonalization-documentation/pull/25