### PR TITLE
Added the Skedulo API guide to docsearch json config file

### DIFF
--- a/configs/skedulo_developer.json
+++ b/configs/skedulo_developer.json
@@ -2,14 +2,17 @@
   "index_name": "skedulo_developer",
   "start_urls": [
     "https://developer.skedulo.com/docs/",
-    "https://developer.skedulo.com/skedulo-api/"
+{
+      "url": "https://developer.skedulo.com/skedulo-api/",
+      "selectors_key": "skedulo-api"
+}
   ],
   "sitemap_urls": [
     "https://developer.skedulo.com/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {
-    "docs": {
+    "default": {
       "lvl0": ".td-content h1",
       "lvl1": ".td-content h2",
       "lvl2": ".td-content h3",
@@ -19,9 +22,12 @@
       "text": ".td-content p, .td-content li"
     },
     "skedulo-api": {
-      "lvl0": ".WxWXp h1",
-      "lvl1": ".ioYTqA h2",
-      "text": ".flfxUM p, .SmuWE span"
+      "lvl0": ".api-content h1",
+      "lvl1": ".api-content h2",
+      "lvl2": ".api-content h3",
+      "lvl3": ".api-content h4",
+      "lvl4": ".api-content h5",
+      "text": ".redoc-markdown p, .redoc-markdown li"
     }
   },
   "conversation_id": [

--- a/configs/skedulo_developer.json
+++ b/configs/skedulo_developer.json
@@ -9,13 +9,20 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".td-content h1",
-    "lvl1": ".td-content h2",
-    "lvl2": ".td-content h3",
-    "lvl3": ".td-content h4",
-    "lvl4": ".td-content h5",
-    "lvl5": ".td-content h6",
-    "text": ".td-content p, .td-content li"
+    "docs": {
+      "lvl0": ".td-content h1",
+      "lvl1": ".td-content h2",
+      "lvl2": ".td-content h3",
+      "lvl3": ".td-content h4",
+      "lvl4": ".td-content h5",
+      "lvl5": ".td-content h6",
+      "text": ".td-content p, .td-content li"
+    },
+    "skedulo-api": {
+      "lvl0": ".WxWXp h1",
+      "lvl1": ".ioYTqA h2",
+      "text": ".flfxUM p, .SmuWE span"
+    }
   },
   "conversation_id": [
     "997238560"

--- a/configs/skedulo_developer.json
+++ b/configs/skedulo_developer.json
@@ -1,7 +1,8 @@
 {
   "index_name": "skedulo_developer",
   "start_urls": [
-    "https://developer.skedulo.com/docs/"
+    "https://developer.skedulo.com/docs/",
+    "https://developer.skedulo.com/skedulo-api/"
   ],
   "sitemap_urls": [
     "https://developer.skedulo.com/sitemap.xml"


### PR DESCRIPTION
We use ReDoc for our API documentation, located under `/skedulo-api/` on our developer site. It would be great if DocSearch could also search this page. 
