### PR TITLE
Remove directory path

### DIFF
--- a/configs/masstransit.json
+++ b/configs/masstransit.json
@@ -1,7 +1,7 @@
 {
   "index_name": "masstransit",
   "start_urls": [
-    "http://masstransit-project.com/MassTransit/"
+    "http://masstransit-project.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
So, when I enable the search, my results are linking to:

`http://masstransit-project.com/MassTransit/MassTransit/getting-started.html`

Which is a double path link. The generated content for VuePress is in /MassTransit, so I'm taking off the extension to hopefully? resolve the issue. If there is another setting to fix it, I haven't found it yet.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
