### PR TITLE
Change reason-react-native url

### DIFF
--- a/configs/reason-react-native.json
+++ b/configs/reason-react-native.json
@@ -1,7 +1,7 @@
 {
   "index_name": "reason-react-native",
   "start_urls": [
-    "https://reasonml-community.github.io/reason-react-native/en/docs/"
+    "https://reason-react-native.github.io/en/docs/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We created our own org & the website is being moved to https://reason-react-native.github.io/
The old one will provide redirections.