### PR TITLE
Update and rename 3playground.json to three-playground.json

### DIFF
--- a/configs/three-playground.json
+++ b/configs/three-playground.json
@@ -1,5 +1,5 @@
 {
-  "index_name": "3playground",
+  "index_name": "three-playground",
   "start_urls": [
     "https://www.3playground.com/"
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)

I believe there is a naming issue right now where the request to match the index name will not recognize 3playground because it starts with a number. I'd like to request this pull request be accepted so I can test and make sure that this is not the reason why my results are not showing up

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

**Screenshot of request - index doesn't match the name **
<img width="1020" alt="Screen Shot 2019-11-25 at 1 23 50 PM" src="https://user-images.githubusercontent.com/49687222/69567344-2856cc00-0f87-11ea-9733-ba46fd8bd9d2.png">

### What is the expected behaviour?
Expected behavior is that the index in the request matches the index name in the configuration file.

##### NB: Do you want to request a **feature** or report a **bug**?
Yes, would like to report a bug

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
