### PR TITLE
Update and rename salestimhelpcenter.json to salestimdeveloperhub.json

### DIFF
--- a/configs/salestimdeveloperhub.json
+++ b/configs/salestimdeveloperhub.json
@@ -1,7 +1,7 @@
 {
-  "index_name": "salestimhelpcenter",
+  "index_name": "salestimdeveloperhub",
   "start_urls": [
-    "https://help.salestim.com/"
+    "https://developers.salestim.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
moving our site from help.Salestim.com to developers.salestim.com