### PR TITLE
Remove iOS API reference pages from Apollo docsearch

### DIFF
--- a/configs/apollodata.json
+++ b/configs/apollodata.json
@@ -29,6 +29,7 @@
     "https://www.apollographql.com/docs/scala/",
     "https://www.apollographql.com/docs/graphql-tools/",
     "https://www.apollographql.com/docs/graphql-subscriptions/",
+    "https://www.apollographql.com/docs/ios/api/",
     "https:\\/\\/www\\.apollographql\\.com\\/docs/[A-Za-z0-9_-]+\\/v[0-9]+\\.",
     "https:\\/\\/www\\.apollographql\\.com\\/docs/v[0-9]+\\."
   ],


### PR DESCRIPTION
(The number of distinct iOS API reference pages is very high and watering down overall result quality)