### PR TITLE
Update centurylink_chi

### DIFF
--- a/configs/centurylink_chi.json
+++ b/configs/centurylink_chi.json
@@ -6,15 +6,16 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "nav > ul > li.-active > a",
+      "selector": "nav > ul > li.-active > div",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".docs-body__content h2",
-    "lvl2": ".docs-body__content h3",
-    "lvl3": ".docs-body__content h4",
-    "lvl4": ".docs-body__content h5",
-    "lvl5": ".docs-body__content h6",
+    "lvl1": ".docs-body__content h1",
+    "lvl2": ".docs-body__content h2",
+    "lvl3": ".docs-body__content h3",
+    "lvl4": ".docs-body__content h4",
+    "lvl5": ".docs-body__content h5",
+    "lvl6": ".docs-body__content h6",
     "text": ".docs-body__content p, .docs-body__content li",
     "version": {
       "selector": "#version-dropdown",


### PR DESCRIPTION
Updated centurylink_chi.json due to changes of documentation layout.
Without this change, the crawler is not indexing properly the selectors lv0, lv1.