### PR TITLE
Update centurylink_chi

### DIFF
--- a/configs/centurylink_chi.json
+++ b/configs/centurylink_chi.json
@@ -6,7 +6,7 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "nav > ul > li.-active > div",
+      "selector": "aside.docs-body__aside > nav > ul > li.-active > div",
       "global": true,
       "default_value": "Documentation"
     },


### PR DESCRIPTION
We had to make changes in lvl0 selector because with current lvl0 selector search results have duplicated category title.
Due to having duplicated `<nav>` element in DOM (for mobile and portrait views), we have realized that lvl0 causes duplication in the dropdown search bar. So we had to make the lvl0 selector more specific in order to avoid duplication.

![Screenshot 2019-12-05 at 16 17 30](https://user-images.githubusercontent.com/25136131/70248134-c9f5ce80-177a-11ea-8a9b-fdae9f07925d.png)
