### PR TITLE
patternfly

### DIFF
--- a/configs/patternfly.json
+++ b/configs/patternfly.json
@@ -6,6 +6,10 @@
       "selectors_key": "getStarted"
     },
     {
+      "url": "https://www.patternfly.org/v4/documentation/",
+      "selectors_key": "documentation"
+    },
+    {
       "url": "https://www.patternfly.org/v4/"
     }
   ],
@@ -19,6 +23,24 @@
   ],
   "selectors": {
     "default": {
+      "lvl0": {
+        "selector": "header nav [aria-current]",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": {
+        "selector": "#page-sidebar li.pf-m-current > a",
+        "global": true,
+        "default_value": "Category"
+      },
+      "lvl2": "main h1",
+      "lvl3": "main h2",
+      "lvl4": "main h3",
+      "lvl5": "main h4",
+      "lvl6": "main h5",
+      "text": "main p, main li, main td"
+    },
+    "documentation": {
       "lvl0": {
         "selector": "#page-sidebar .ws-org-context-switcher-dropdown .pf-c-dropdown__toggle-text",
         "global": true,

--- a/configs/patternfly.json
+++ b/configs/patternfly.json
@@ -20,7 +20,7 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": "header nav [aria-current]",
+        "selector": "#page-sidebar .ws-org-context-switcher-dropdown .pf-c-dropdown__toggle-text",
         "global": true,
         "default_value": "Documentation"
       },
@@ -29,16 +29,11 @@
         "global": true,
         "default_value": "Category"
       },
-      "lvl2": {
-        "selector": "#page-sidebar li [aria-current]",
-        "global": true,
-        "default_value": "Page"
-      },
-      "lvl3": "main h1",
-      "lvl4": "main h2",
-      "lvl5": "main h3",
-      "lvl6": "main h4",
-      "lvl7": "main h5",
+      "lvl2": "main .ws-page-title",
+      "lvl3": "main h2",
+      "lvl4": "main h3",
+      "lvl5": "main h4",
+      "lvl6": "main h5",
       "text": "main p, main li, main td"
     },
     "getStarted": {

--- a/configs/surgio.json
+++ b/configs/surgio.json
@@ -3,7 +3,12 @@
   "start_urls": [
     "https://surgio.royli.dev"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "^(.(?!.*\\.html)).*?/guide/.+$"
+  ],
+  "sitemap_ulrs": [
+    "https://surgio.royli.dev/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "p.sidebar-heading.open",
@@ -36,5 +41,5 @@
     "1013553089"
   ],
   "scrap_start_urls": false,
-  "nb_hits": 893
+  "nb_hits": 713
 }


### PR DESCRIPTION
Update selectors
For level 0, Instead of grabbing "Documentation" from the top tab, it should grab the framework (React/HTML) and display that instead. 
Also remove the previous level 2 selector as it was just duplicated in the main body header