### PR TITLE
Update wpcontentcrawler.json

### DIFF
--- a/configs/wpcontentcrawler.json
+++ b/configs/wpcontentcrawler.json
@@ -1,6 +1,12 @@
 {
   "index_name": "wpcontentcrawler",
   "start_urls": [
+    {
+      "url": "https://docs.wpcontentcrawler.com/(?P<version>.*?)/",
+      "variables": {
+        "version": ["master", "1.9"]
+      }
+    },
     "https://docs.wpcontentcrawler.com/"
   ],
   "stop_urls": [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)
The search results are displayed from all versions of the documentation regardless of the currently viewed version, causing same contents from different versions appear in the results. I wanted to display the results just for the currently viewed version of the documentation. After this is merged, I will add facet filters using the JavaScript snippet I added to the site, to show results just for the current version.

### What is the current behaviour?
Current behavior is not a bug.

### What is the expected behaviour?
Showing the results just for the current version of the documentation.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?
I am not sure if I updated the file correctly. In this case, `(?P<version>.*?)` will only match `master` and `1.9` and disregard other matches, right? Also, `/master` and `/` actually points to the same version. Could you please tell me if it will be enough to define the same facet filter for both of these URLs, e.g `'facetFilters': ["version:master"]`?
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
