### PR TITLE
Add version facet, use production URL

### DIFF
--- a/configs/silverstripe_userhelp.json
+++ b/configs/silverstripe_userhelp.json
@@ -1,7 +1,7 @@
 {
   "index_name": "silverstripe_userhelp",
   "start_urls": [
-    "https://ss-userhelp.netlify.com/"
+    "https://userhelp.silverstripe.org/"
   ],
   "stop_urls": [],
   "selectors": {
@@ -16,5 +16,10 @@
   "conversation_id": [
     "1035381396"
   ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "version"
+    ]
+  },  
   "nb_hits": 1460
 }


### PR DESCRIPTION
We've gone live with this site. Can use correct URL.