### PR TITLE
nus-cs2103-ay1920s1.json: update URLs

### DIFF
--- a/configs/nus-cs2103-ay1920s1.json
+++ b/configs/nus-cs2103-ay1920s1.json
@@ -2,27 +2,27 @@
   "index_name": "nus-cs2103-ay1920s1",
   "start_urls": [
     {
-      "url": "https://nus-cs2103-ay1920s1.github.io/website/schedule/timeline.html",
+      "url": "https://nus-cs2103-ay1920s2.github.io/website/schedule/timeline.html",
       "selectors_key": "schedule",
       "tags": [
         "schedule"
       ]
     },
     {
-      "url": "https://nus-cs2103-ay1920s1.github.io/website/admin/",
+      "url": "https://nus-cs2103-ay1920s2.github.io/website/admin/",
       "selectors_key": "admin",
       "tags": [
         "admin"
       ]
     },
     {
-      "url": "https://nus-cs2103-ay1920s1.github.io/website/se-book-adapted/",
+      "url": "https://nus-cs2103-ay1920s2.github.io/website/se-book-adapted/",
       "selectors_key": "se-book-adapted",
       "tags": [
         "se-book-adapted"
       ]
     },
-    "https://nus-cs2103-ay1920s1.github.io/website/"
+    "https://nus-cs2103-ay1920s2.github.io/website/"
   ],
   "stop_urls": [
     "printable",


### PR DESCRIPTION
This search index is for a course website of a university. The URL of the site is changing as we move to a new semester. I thought it is more efficient to update the previous semester's settings with the new URL rather than create a new index altogether. Not sure if this is the right approach though 🤔 