### PR TITLE
remove version selector from sensu.json

### DIFF
--- a/configs/sensu.json
+++ b/configs/sensu.json
@@ -48,11 +48,7 @@
     "lvl2": "article h3",
     "lvl3": "article h4",
     "lvl4": "article h5",
-    "text": "article p, article li",
-    "version": {
-      "selector": "main .dropdown--versions > a",
-      "global": true
-    }
+    "text": "article p, article li"
   },
   "min_indexed_level": 1,
   "custom_settings": {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->

# Pull request motivation(s)

Following on https://github.com/sensu/sensu-docs/pull/2049, this change removes the `version` selector in favor of a global meta tag.

### What is the current behaviour?

The version selector currently defined in sensu.json causes searches scoped to the latest version of our docs to fail.

### What is the expected behaviour?

Removing this version selector causes docsearch to prefer the "version" meta tag now present in our docs.
