### PR TITLE
Fix url of result pages

### DIFF
--- a/configs/botfront.json
+++ b/configs/botfront.json
@@ -1,8 +1,7 @@
 {
   "index_name": "botfront",
   "start_urls": [
-    "https://docs.botfront.io",
-    "https://botfront.io/docs"
+    "https://botfront.io"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Currently, a `/docs` element is added to the result page. If the page url is `https://botfront.io/docs/rasa/nlu/training-adding-data/#add-training-data`, clicking on a result will link to `https://botfront.io/docs/docs/rasa/nlu/training-adding-data/#add-training-data`.
I suppose it's because the start_url appends a `/docs` to the hostname

Also, I removed the `docs.botfront.io` site which does not exist anymore

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
