### PR TITLE
Update qtpromise which uses a new VuePress version

### DIFF
--- a/configs/qtpromise.json
+++ b/configs/qtpromise.json
@@ -10,12 +10,12 @@
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".content h1",
-    "lvl2": ".content h2",
-    "lvl3": ".content h3",
-    "lvl4": ".content h4",
-    "text": ".content p, .content li",
-    "lvl5": ".content h5",
+    "lvl1": ".content__default h1",
+    "lvl2": ".content__default h2",
+    "lvl3": ".content__default h3",
+    "lvl4": ".content__default h4",
+    "lvl5": ".content__default h5",
+    "text": ".content__default p, .content__default li",
     "lang": {
       "selector": "/html/@lang",
       "type": "xpath",


### PR DESCRIPTION
After [upgrading VuePress to version 1.2.0](https://github.com/simonbrunel/qtpromise/blob/master/package.json#L16), the search doesn't update anymore. This PR submits similar changes as 5460916c1f91b0bdc661d5e7bce8aac882577742.

Docs preview: https://qtpromise.netlify.com/qtpromise/getting-started.html
Docs repo: https://github.com/simonbrunel/qtpromise/tree/master/docs