### PR TITLE
Moleculer: fix version selection in the config

### DIFF
--- a/configs/moleculer.json
+++ b/configs/moleculer.json
@@ -6,7 +6,7 @@
       "variables": {
         "version": {
           "url": "https://moleculer.services/docs/",
-          "js": "const options=document.querySelector('div.version-selector select').options; const versions=Object.keys(options).map(key=>options[key].text.replace(/\\s*v*/,'')); return JSON.stringify(versions)"
+          "js": "const options=document.querySelector('div.version-selector select').options; const versions=Object.keys(options).map(key=>options[key].getAttribute('value').replace(/\/docs\//,'')); console.log(JSON.stringify(versions))"
         }
       }
     }

--- a/configs/moleculer.json
+++ b/configs/moleculer.json
@@ -6,7 +6,7 @@
       "variables": {
         "version": {
           "url": "https://moleculer.services/docs/",
-          "js": "const options=document.querySelector('div.version-selector select').options; const versions=Object.keys(options).map(key=>options[key].getAttribute('value').replace(/\/docs\//,'')); console.log(JSON.stringify(versions))"
+          "js": "const options=document.querySelector('div.version-selector select').options; const versions=Object.keys(options).map(key=>options[key].getAttribute('value').replace(/\/docs\//,'')); return JSON.stringify(versions)"
         }
       }
     }


### PR DESCRIPTION
# Pull request motivation(s)
The Moleculer 0.14 version documentation is not available with Algoliasearch. This PR fixes it. Using the ˙<option>` values instead of parsing the version from the option text.