### PR TITLE
Add specific selectors for API files

### DIFF
--- a/configs/openproject.json
+++ b/configs/openproject.json
@@ -5,6 +5,10 @@
       "url": "https://docs.openproject.org/release-notes/",
       "selectors_key": "release-notes"
     },
+    {
+      "url": "https://docs.openproject.org/api/",
+      "selectors_key": "api"
+    },
     "https://docs.openproject.org"
   ],
   "stop_urls": [
@@ -35,7 +39,14 @@
       "lvl3": ".article-content h5",
       "lvl4": ".article-content h6",
       "text": ".article-content p, .article-content li:not([id])"
-    }
+    },
+     "api": {
+      "lvl0": ".article-content h1",
+      "lvl1": ".article-content h2",
+      "lvl2": ".article-content h3",
+      "lvl3": ".article-content h4",
+      "text": ".article-content p, .article-content li:not([id])"
+     }
   },
   "keep_tags": [
     "code"


### PR DESCRIPTION
For all files located under https://docs.openproject.org/api/ only headers up to level 4 should be taken into account. Otherwise all API code examples will be shown in result list as they start with
`<h5> Headers </h5>`.
<img width="431" alt="Bildschirmfoto 2020-01-22 um 10 02 28" src="https://user-images.githubusercontent.com/7457313/72891954-b1834880-3d15-11ea-8025-4366af3e17e3.png">
