### PR TITLE
Change littleskin's start_url

### DIFF
--- a/configs/littleskin.json
+++ b/configs/littleskin.json
@@ -1,7 +1,7 @@
 {
   "index_name": "littleskin",
   "start_urls": [
-    "https://littleskin.cn/manual/"
+    "https://manual.littleskin.cn/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Change littleskin's start_url due to the site move.

We moved LittleSkin User Manual to a new site so I updated the configuration.