### PR TITLE
Updated collab.json for TeamForge 20.0 release

### DIFF
--- a/configs/collab.json
+++ b/configs/collab.json
@@ -2,6 +2,12 @@
   "index_name": "collab",
   "start_urls": [
     {
+      "url": "http://docs.collab.net/teamforge200/",
+      "tags": [
+        "teamforge200"
+      ]
+    },    
+    {
       "url": "http://docs.collab.net/teamforge193/",
       "tags": [
         "teamforge193"


### PR DESCRIPTION
added new docs for TeamForge 20.0 at http://docs.collab.net/teamforge200/