### PR TITLE
Fix bloomreach-feed config for elasticpath unified index

### DIFF
--- a/configs/elasticpath_unified.json
+++ b/configs/elasticpath_unified.json
@@ -58,7 +58,7 @@
     {
       "url": "https://documentation.elasticpath.com/elasticpath_bloomreach-feed/docs/",
       "tags": [
-        "elasticpath_bloomreach-feed"
+        "bloomreach-feed"
       ]
     }
   ],
@@ -72,7 +72,7 @@
     "https://documentation.elasticpath.com/account-management/sitemap.xml",
     "https://documentation.elasticpath.com/commerce/sitemap.xml",
     "https://documentation.elasticpath.com/cloudops-kubernetes/sitemap.xml",
-    "https://documentation.elasticpath.com/elasticpath_bloomreach-feed/sitemap.xml"
+    "https://documentation.elasticpath.com/bloomreach-feed/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],
@@ -105,3 +105,4 @@
   ],
   "nb_hits": 56899
 }
+


### PR DESCRIPTION
The elasticpath_unified.json allows searching through multiple
individual documentation sites. The bloomreach-feed configuration
in this unified index seemed incorrect. The sitemap source was
definitely wrong.

Fixed the sitemap source for the bloomreach-feed. Also, set the
tag following other configurations in this file.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
