### PR TITLE
Update hudl_uniform configuration

### DIFF
--- a/configs/hudl_uniform.json
+++ b/configs/hudl_uniform.json
@@ -3,6 +3,9 @@
   "start_urls": [
     "http://uniform.hudl.com/"
   ],
+  "sitemap_urls": [
+    "http://uniform.hudl.com/sitemap.xml"
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": "[class*='--gridMain--'] h2",


### PR DESCRIPTION
# Pull request motivation(s)
Wanted to update to get us more in line with the recommended configuration by adding a sitemap. 
Maintainer url: https://github.com/mfouquet (Hudl organization link at bottom)

Changes made: 
* Added a sitemap.xml url

Tested with another crawler and the sitemap indeed checks out 👍 
