### PR TITLE
Fix site url for bloomreach-feed in elasticpath config

### DIFF
--- a/configs/elasticpath_unified.json
+++ b/configs/elasticpath_unified.json
@@ -56,7 +56,7 @@
       ]
     },
     {
-      "url": "https://documentation.elasticpath.com/elasticpath_bloomreach-feed/docs/",
+      "url": "https://documentation.elasticpath.com/bloomreach-feed/docs/",
       "tags": [
         "bloomreach-feed"
       ]


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

The URL of the doc site for bloomreach feed in elasticpath_unified index was incorrect. Fixed the URL. This change was missed from PR #1640 

### What is the current behaviour?


### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
