### PR TITLE
Move `scoop-docs`

### DIFF
--- a/configs/scoop-docs.json
+++ b/configs/scoop-docs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "scoop-docs",
   "start_urls": [
-    "https://scoop-docs.now.sh/docs/"
+    "https://scoop-docs.netlify.com/docs/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We are now hosting Scoop Docs on Netlify, which requires a new URL setup.