### PR TITLE
exclude urls with extension - docsearch seems to not respect the canonical meta tag

### DIFF
--- a/configs/commercetools.json
+++ b/configs/commercetools.json
@@ -2,7 +2,7 @@
   "index_name": "commercetools",
   "start_urls": ["https://docs.commercetools.com"],
   "sitemap_urls": [],
-  "stop_urls": ["/release-notes", "/merchant-center-releases"],
+  "stop_urls": ["/release-notes", "/merchant-center-releases", ".html$"],
   "selectors": {
     "lvl0": {
       "selector": "#site-title",


### PR DESCRIPTION
### What is the current behaviour?

many duplicate entries because content authors tend to write links with .html endings that have to work for compatibility reasons

### What is the expected behaviour?

Crawler or index deduplicates based on the canonical meta tag: 

`<link rel="canonical" href="https://docs.commercetools.com/http-api-types" data-proofer-ignore="">`

Since that does not seem to be respected by the crawler, e.g. on  https://docs.commercetools.com/http-api-types.html#references , this PR is excluding all links ending .html. 

If there is a smarter way to force unique canonicalization based on the meta tag that would be great! 
