### PR TITLE
Add "1.10" version variable to wpcontentcrawler.json

### DIFF
--- a/configs/wpcontentcrawler.json
+++ b/configs/wpcontentcrawler.json
@@ -6,7 +6,8 @@
       "variables": {
         "version": [
           "master",
-          "1.9"
+          "1.9",
+          "1.10"
         ]
       }
     },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Adding a new version to the version variable

### What is the current behaviour?
Nothing is wrong with the current behavior.

### What is the expected behaviour?
Making the search cover the new version as well.

##### NB: Do you want to request a **feature** or report a **bug**?
None of them.

##### NB2: Any other feedback / questions ?
The search is really awesome.
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
