### PR TITLE
update strapi

### DIFF
--- a/configs/strapi.json
+++ b/configs/strapi.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://strapi.io/documentation/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://strapi.io/documentation/3.0.0-alpha.x/"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "p.sidebar-heading.open",


### PR DESCRIPTION
want to stop crawling alpha version of the docs

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Update Strapi configuration

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

Crawling alpha version of the docs

### What is the expected behaviour?

Not crawling the alpha version

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
