### PR TITLE
nus-cs2113-ay1920s2.json: add another start URL

### DIFF
--- a/configs/nus-cs2113-ay1920s2.json
+++ b/configs/nus-cs2113-ay1920s2.json
@@ -22,7 +22,8 @@
         "se-book-adapted"
       ]
     },
-    "https://nus-cs2113-ay1920s2.github.io/website/"
+    "https://nus-cs2113-ay1920s2.github.io/website/",
+    "https://nus-cs2113-ay1920s2.github.io/website/coding-standards/java/basic.html"
   ],
   "stop_urls": [
     "printable",


### PR DESCRIPTION
This page doesn't appear in search results. I'm adding it as a start URL to see if that helps.