### PR TITLE
Updated doc.opentap.io docsearch configuration

### DIFF
--- a/configs/opentap.json
+++ b/configs/opentap.json
@@ -15,7 +15,7 @@
     "lvl3": ".theme-default-content h3",
     "lvl4": ".theme-default-content h4",
     "lvl5": ".theme-default-content h5",
-    "text": ".theme-default-content p, .theme-default-content li",
+    "text": ".theme-default-content p, .theme-default-content li, .theme-default-content table, .theme-default-content code",
     "lang": {
       "selector": "/html/@lang",
       "type": "xpath",


### PR DESCRIPTION
Updated the configuration to include selectors for table and code.

# Pull request motivation(s)
Currently the docsearch search integration on https://docs.opentap.io does not work with tables and code.


### What is the current behaviour?
Currently the docsearch crawler does not capture `<table>` or `<code>` elements. E.g. tables and code does not work on https://docs.opentap.io/Developer%20Guide/Test%20Step/.


### What is the expected behaviour?
Expect the docsearch crawler to include `<table>` or `<code>` elements.
