### PR TITLE
Add 1.8.x  to Zowe search

### DIFF
--- a/configs/zowe.json
+++ b/configs/zowe.json
@@ -8,6 +8,7 @@
           "stable",
           "active-development",
           "latest",
+          "v1-8-x",
           "v1-7-x",
           "v1-6-x",
           "v1-5-x",


### PR DESCRIPTION
# Pull request motivation(s)

Adding new version to our Zowe Docs site. 

### What is the current behaviour?

Searches all current versions. 

### What is the expected behaviour?

Searches all prior versions + the new 1.8 version. 