### PR TITLE
Update thephpleague_csv.json

### DIFF
--- a/configs/thephpleague_csv.json
+++ b/configs/thephpleague_csv.json
@@ -5,6 +5,7 @@
       "url": "https://csv.thephpleague.com/(?P<version>.*?)/",
       "variables": {
         "version": [
+          "9.0",
           "8.0",
           "7.0"
         ]


### PR DESCRIPTION

# Pull request motivation(s)

Adding the latest stable version 9.0 to league csv documentation

### What is the current behaviour?

the latest stable version, version 9.0 is not indexed by the docsearch engine and thus search is not possible for that version of the library

### What is the expected behaviour?

Version 9.0 should be searchable as well.