### PR TITLE
Remove /changelog/ from indexing in artsy_palette

### DIFF
--- a/configs/artsy_palette.json
+++ b/configs/artsy_palette.json
@@ -6,7 +6,9 @@
   "sitemap_urls": [
     "https://palette.artsy.net/sitemap.xml"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "/changelog/"
+  ],
   "selectors": {
     "lvl0": ".DocSearch-content h1",
     "lvl1": ".DocSearch-content h2",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We'd like to exclude the `/changelog/` url from indexing at artsy.palette.net.

### What is the current behaviour?

The `/changelog/` url is included in our search results.

### What is the expected behaviour?

The `/changelog/` url should be excluded from our search results.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

I _think_ this is what I need to do to get this URL excluded; please let me know if there's another method that's preferred!

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
