### PR TITLE
chore: update Dinero.js documentation URL

### DIFF
--- a/configs/dinerojs.json
+++ b/configs/dinerojs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "dinerojs",
   "start_urls": [
-    "https://sarahdayan.github.io/dinero.js"
+    "https://dinerojs.com"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
The Dinero.js documentation moved to a custom domain. This PR updates the `start_urls` so DocSearch targets the right website.
