### PR TITLE
updated to reflect production url

### DIFF
--- a/configs/hamlet.json
+++ b/configs/hamlet.json
@@ -1,11 +1,11 @@
 {
   "index_name": "hamlet",
   "start_urls": [
-    "https://hamlet-docs.now.sh/docs/",
-    "https://hamlet-docs.now.sh/docs/index"
+    "https://hamlet.io/docs/",
+    "https://hamlet.io/docs/index"
   ],
   "sitemap_urls": [
-    "https://hamlet-docs.now.sh/sitemap.xml"
+    "https://hamlet.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
initial setup of docsearch was on a personal repo of the documentation site for me to present to other project maintainers. Now that I have done so and we've acquired the desired domain, I would like to reconfigure the existing docsearch behaviour to point to our production documentation site. 

Previous repo: [rossmurr4y](https://github.com/rossmurr4y/hamlet-docs)
New repo: [hamlet-io](https://github.com/hamlet-io/docs)

### What is the current behaviour?

Config points at our temporary site at a domain specified by Zeit. Indexing is currently performed on this site.

### What is the expected behaviour?

That docsearch indexing is performed on our production site.

##### NB: Do you want to request a **feature** or report a **bug**?
feature - its just an update to expected behavior.

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
