### PR TITLE
updating FamilySearch config with new location of docs

### DIFF
--- a/configs/familysearch_frontier.json
+++ b/configs/familysearch_frontier.json
@@ -1,9 +1,14 @@
 {
   "index_name": "familysearch_frontier",
   "start_urls": [
-    "https://www.familysearch.org/frontier/docs/"
+    "https://www.familysearch.org/frontier/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://www.familysearch.org/frontier/app-react/",
+    "https://www.familysearch.org/frontier/legacy/",
+    "https://www.familysearch.org/frontier/status/",
+    "https://www.familysearch.org/frontier/catalog/"
+  ],
   "selectors": {
     "lvl0": "[class*='Page__Container'] h1",
     "lvl1": "[class*='Page__Container'] h2",


### PR DESCRIPTION
We made some changes to where our docs are located, so updating the start_urls and made sure to include the stop_urls for endpoints we don't want searched.

