### PR TITLE
Better search for titles on Konvajs docs

### DIFF
--- a/configs/konvajs.json
+++ b/configs/konvajs.json
@@ -25,7 +25,7 @@
         "global": true,
         "default_value": "Chapter"
       },
-      "lvl2": "[itemprop='articleBody'] h1",
+      "lvl2": "h1",
       "lvl3": "[itemprop='articleBody'] h2",
       "lvl4": "[itemprop='articleBody'] h3",
       "lvl5": "[itemprop='articleBody'] h4",


### PR DESCRIPTION
That fix should enable better search for h1 titles since they are not inside a post content.

Maintainer of Kovnva https://github.com/konvajs/site/commits/master