### PR TITLE
Update typegraphql domain

### DIFF
--- a/configs/typegraphql.json
+++ b/configs/typegraphql.json
@@ -1,8 +1,8 @@
 {
   "index_name": "typegraphql",
   "start_urls": [
-    "https://typegraphql.ml/docs/",
-    "https://typegraphql.ml/docs/introduction.html"
+    "https://typegraphql.com/docs/",
+    "https://typegraphql.com/docs/introduction.html"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

The domain for the TypeGraphQL docs has been changed from `.ml` to `.com`:
https://twitter.com/typegraphql/status/1238191584845484033

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

It opens the search results for the old, not working domain.

### What is the expected behaviour?

Docs search should just work.

##### NB: Do you want to request a **feature** or report a **bug**?

Report a bug with a quick fix 😉 

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
