### PR TITLE
Update graphene-python to search only in latest docs

### DIFF
--- a/configs/graphene_python.json
+++ b/configs/graphene_python.json
@@ -1,7 +1,11 @@
 {
   "index_name": "graphene_python",
   "start_urls": [
-    "http://docs.graphene-python.org/"
+    "http://docs.graphene-python.org/en/latest/",
+    "http://docs.graphene-python.org/projects/django/en/latest/",
+    "http://docs.graphene-python.org/projects/sqlalchemy/en/latest/",
+    "http://docs.graphene-python.org/projects/gae/en/latest/",
+    "http://graphene-mongo.readthedocs.io/en/latest/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

Update graphene-python to search only in latest docs

### What is the current behaviour?

Right now, multiple versions of the document are being indexed. This can mislead users (see attached screenshot)

<img width="1680" alt="Screenshot 2020-03-14 17 41 34" src="https://user-images.githubusercontent.com/188257/76687646-0c813f80-65e3-11ea-8fd3-c3ae4a754188.png">


*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

We would like only to see the latest docs.
