### PR TITLE
Update graphene-python to only search the graphene-project

### DIFF
--- a/configs/graphene_python.json
+++ b/configs/graphene_python.json
@@ -1,11 +1,7 @@
 {
   "index_name": "graphene_python",
   "start_urls": [
-    "http://docs.graphene-python.org/en/latest/",
-    "http://docs.graphene-python.org/projects/django/en/latest/",
-    "http://docs.graphene-python.org/projects/sqlalchemy/en/latest/",
-    "http://docs.graphene-python.org/projects/gae/en/latest/",
-    "http://graphene-mongo.readthedocs.io/en/latest/"
+    "http://docs.graphene-python.org/en/latest/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation
https://github.com/algolia/docsearch-configs/pull/1787 updated the search config so that it only searched the latest version of the docs. However it also included multiple extra libraries in the search which makes the search results a lot worse.

### What is the current behaviour?

Searching for "objecttype" in the graphene docs only returns values for the graphene-django docs.

<img width="677" alt="Screenshot 2020-03-16 16 21 36" src="https://user-images.githubusercontent.com/691952/76779195-dd193100-67a2-11ea-929a-79d7f2f3c855.png">


### What is the expected behaviour?

Return results from the graphene project only.
