### PR TITLE
Add language and version attributes for faceting

### DIFF
--- a/configs/wso2.json
+++ b/configs/wso2.json
@@ -19,5 +19,11 @@
   "conversation_id": [
     "1070576193"
   ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "language",
+      "version"
+    ]
+  },
   "nb_hits": 15044
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Can't search from different versions of the documentation

### What is the expected behaviour?

We currently have API Manager (APIM) 3.0.0[1], 3.1.0[2] docs spaces and the /next[3] always points to the bleeding edge version documentation, when we do a release, /next -> becomes the released version (i:e 3.2.0 )  and /next will continue to have latest docs content.

If I switch from APIM 3.0.0 to APIM 3.1.0 doc space, and search something from that page, I should only see the results from APIM 3.1.0 document space.

##### NB: Do you want to request a **feature** or report a **bug**?

Configuration change

##### NB2: Any other feedback / questions ?

As per the instruction in here https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags , to address https://github.com/wso2/docs-apim/issues/838 issue
