### PR TITLE
Update start URL and sitemaps

### DIFF
--- a/configs/wso2.json
+++ b/configs/wso2.json
@@ -1,7 +1,7 @@
 {
   "index_name": "wso2",
   "start_urls": [
-    "https://apim.docs.wso2.com/en/latest"
+    "https://apim.docs.wso2.com/"
   ],
   "stop_urls": [],
   "selectors": {
@@ -14,7 +14,8 @@
     "lvl5": ".md-content__inner h6"
   },
   "sitemap_urls": [
-    "https://apim.docs.wso2.com/en/sitemap.xml"
+    "https://apim.docs.wso2.com/en/latest/sitemap.xml",
+    "https://apim.docs.wso2.com/en/next/sitemap.xml"
   ],
   "conversation_id": [
     "1070576193"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Algolia has indexed only the **/latest** latest version of the docs since we have given the URL for latest docs when applying for algolia search.

### What is the expected behaviour?

Need to have separate doc search for each version of the product documentation (https://github.com/wso2/docs-apim/issues/838), Hence changed the starting URL to document root

versions are differentiated by path param in the URL

i:e

- https://apim.docs.wso2.com/en/next/
- https://apim.docs.wso2.com/en/latest/
- https://apim.docs.wso2.com/en/3.0.0/

recently sent a PR to add facet search settings https://github.com/algolia/docsearch-configs/pull/1792
but because **start_urls** had only the /lates docs, Algolia has indexed only the latest version doc content

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
