### PR TITLE
feat: update opencerts.json configuration

### DIFF
--- a/configs/opencerts.json
+++ b/configs/opencerts.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://docs.opencerts.io"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "^https://docs.opencerts.io/v1"
+  ],
   "selectors": {
     "lvl0": ".markdown-body h1",
     "lvl1": ".markdown-body h2",


### PR DESCRIPTION
add https://docs.opencerts.io/v1 in stop_urls so that the content is not indexed

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
The content under /v1 is indexed which is not what we want.

### What is the current behaviour?
We mainly want the content of /docs to be indexed. (Rest is ok although, we really want to not index /v1)


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
