### PR TITLE
Reverting recent Bubble Manual change

### DIFF
--- a/configs/bubble_manual.json
+++ b/configs/bubble_manual.json
@@ -1,7 +1,7 @@
 {
   "index_name": "bubble_manual",
   "start_urls": [
-    "https://manual.bubble.io/"
+    "https://manual.bubble.is/"
   ],
   "stop_urls": [],
   "selectors": {
@@ -19,5 +19,5 @@
   "conversation_id": [
     "326927328"
   ],
-  "nb_hits": 1369
+  "nb_hits": 1067
 }


### PR DESCRIPTION
Sylvain just helped us update the config files for the Bubble Manual, but unfortunately this has caused the entire navigation of the site to break. We tried debugging it, but there might be problems stemming from the fact that we're on legacy Gitbooks + using a 3rd party plugin to get Algolia Docsearch. So, we'd like to try reverting everything to how it was earlier today to see if the problem is fixed. (The original issue we reached out to Support with is minor enough that we're willing to go without fixing it.)

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
