### PR TITLE
OpenEBS: update start_url for OpenEBS doc search

### DIFF
--- a/configs/openebs.json
+++ b/configs/openebs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "openebs",
   "start_urls": [
-    "https://docs.openebs.io/"
+    "https://docs.openebs.io/docs/next/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
This PR is required in order to restrict the crawler to index the data of the OpenEBS docs website starting from URL `https://docs.openebs.io/docs/next/` only so that when a user searches through the docs, it gets the latest version results only.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>