### PR TITLE
Update stop_urls to exclude the internal wiki page

### DIFF
--- a/configs/extly.json
+++ b/configs/extly.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "https://www.extly.com/docs"
   ],
-  "stop_urls": [],
+  "stop_urls": ["wiki"],
   "sitemap_urls": [
     "https://www.extly.com/docs/sitemap.xml"
   ],


### PR DESCRIPTION

# Pull request motivation(s)

DocSearch is currently indexing our internal wiki. So, we need to update the `stop_urls` setting to exclude the internal wiki page.

### What is the current behaviour?

DocSearch is currently indexing our internal wiki.

### What is the expected behaviour?

DocSearch excludes the wiki from the indexing process.

##### NB: Do you want to request a **feature** or report a **bug**?

No, just configuration of extly.json.

##### NB2: Any other feedback / questions ?

No, thank you.
