### PR TITLE
Remove sitemapindex.xml from the config for oroinc

### DIFF
--- a/configs/oroinc.json
+++ b/configs/oroinc.json
@@ -4,9 +4,6 @@
     "https://doc.oroinc.com/"
   ],
   "stop_urls": [],
-  "sitemap_urls": [
-    "https://doc.oroinc.com/sitemapindex.xml"
-  ],
   "selectors": {
     "lvl0": {
       "selector": ".wy-menu li.toctree-l1.current > a",


### PR DESCRIPTION
# Pull request motivation(s)
We have discontinued use of `sitemapindex.xml` file. We are generating sitemap.xml only for the base version of our doc (https://doc.oroinc.com/backend/).
We don't generate sitemap.xml files for other versions (e.g. https://doc.oroinc.com/master/backend/)

### What is the current behaviour?

We are expecting than not all pages are indexed right now.
For example:
1. Open https://doc.oroinc.com/backend/bundles/platform/NavigationBundle/
2. Type "OroNavigationBundle" in the "Search documentation" input at the top of the page.

:x: There are no any results, but https://doc.oroinc.com/backend/bundles/platform/NavigationBundle/ should be found.

I guess it's because docsearch uses simtemapindex.xml that doesn't exist anymore and not indexing all pages. But it's only guesses.

### What is the expected behaviour?

All pages should be indexed.
STR from the above should work.