### PR TITLE
jenkins x config: enable search by language

### DIFF
--- a/configs/jenkins_x.json
+++ b/configs/jenkins_x.json
@@ -1,7 +1,15 @@
 {
   "index_name": "jenkins_x",
   "start_urls": [
-    "https://jenkins-x.io/"
+    {
+      "url": "http://www.example.com/(?P<lang>.*?)/",
+      "variables": {
+        "lang": ["es", "zh"]
+      }
+    },
+    {
+      "url": "https://jenkins-x.io/"
+    }
   ],
   "sitemap_urls": [
     "https://jenkins-x.io/sitemap.xml"

--- a/configs/jenkins_x.json
+++ b/configs/jenkins_x.json
@@ -8,7 +8,12 @@
       }
     },
     {
-      "url": "https://jenkins-x.io/"
+      "url": "https://jenkins-x.io/",
+      "extra_attributes": {
+        "lang": [
+          "en"
+        ]
+        }
     }
   ],
   "sitemap_urls": [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We would like the [Jenkins X documentation site](https://jenkins-x.io/) to be able to search by language, as the site is translated into 3 languages.

### What is the current behaviour?

The [Jenkins X documentation site](https://jenkins-x.io/) is not currently searching by language.

For example, if I search Prow, the top results include the main Prow section within other translations. This is true if I search within the English translation or within the Spanish translation. 

<img width="612" alt="Screenshot 2020-03-31 at 16 39 00" src="https://user-images.githubusercontent.com/15032115/78046047-987ac180-736e-11ea-9898-b2968a5ed047.png">

<img width="602" alt="Screenshot 2020-03-31 at 16 40 20" src="https://user-images.githubusercontent.com/15032115/78046061-9a448500-736e-11ea-9fd8-578cc5ea2543.png">

### What is the expected behaviour?

We would prefer if the search results were prioritised for results matching the language translation of the user.

For example, searches in Spanish would filter for results in Spanish (or at least prioritise them within the search results list)


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

The current PR should enable the desired search functionality for non-English translations. However, the site is currently structured so that English is the default language, therefore there is not a `jenkins-x.io/en/` directory. 

For searches with users on the English translation, I am not sure the PR will change the current functionality. How would we ensure that searches in English are filtered for English language results?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
