### PR TITLE
Update dbt.json

### DIFF
--- a/configs/dbt.json
+++ b/configs/dbt.json
@@ -1,10 +1,10 @@
 {
   "index_name": "dbt",
   "start_urls": [
-    "https://tutorial.getdbt.com/docs/"
+    "https://docs.getdbt.com/docs/"
   ],
   "sitemap_urls": [
-    "https://tutorial.getdbt.com/sitemap.xml"
+    "https://docs.getdbt.com/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

We moved our docs from tutorial.getdbt.com to docs.getdbt.com! We have put a redirect in place for tutorial.getdbt.com --> docs.getdbt.com, but I suspect the index isn't being updated because out search results are looking out of date.

- I am [the maintainer of dbt](https://github.com/fishtown-analytics/dbt/graphs/contributors), [and one of the maintainers of docs.getdbt.com](https://github.com/fishtown-analytics/docs.getdbt.com/graphs/contributors).

### What is the current behaviour?

It looks like our index isn't being updated anymore after the redirect, and I suspect this change will help. Either way, the url reflected in this change is now the correct URL.


##### Any other feedback / questions ?

Let me know if there's any other info I can/should provide here!