### PR TITLE
Update dgraph.json from docs.dgraph.io to dgraph.io/docs.

### DIFF
--- a/configs/dgraph.json
+++ b/configs/dgraph.json
@@ -2,16 +2,16 @@
   "index_name": "dgraph",
   "start_urls": [
     {
-      "url": "https://docs.dgraph.io/(?P<version>.*?)/",
+      "url": "https://dgraph.io/docs/(?P<version>.*?)/",
       "variables": {
         "version": {
-          "url": "https://docs.dgraph.io/",
+          "url": "https://dgraph.io/docs",
           "js": "var versions = $('select.version-selector option').map(function(i, e) { return $(e).text(); }).toArray(); return JSON.stringify(versions);"
         }
       }
     },
     {
-      "url": "https://docs.dgraph.io/",
+      "url": "https://dgraph.io/docs",
       "extra_attributes": {
         "version": "latest"
       }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

The Dgraph documentation website moved from https://docs.dgraph.io to https://dgraph.io/docs. While the former now 301 redirects to the latter, it doesn't look like the index is updated anymore for the new docs site. The hope is that updating this config fixes that.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

1. Go to https://dgraph.io/docs
2. Search for "Using Kubernetes"
    ![image](https://user-images.githubusercontent.com/2251820/78628305-9f12a880-7848-11ea-8a1e-a5a17c38a67e.png)
3. The search result says "Using Kubernetes (v1.8.4)", but the header is now called "Using Kubernetes" (without the version number in the header).
4. Clicking the search result doesn't work since it's for the old link.

### What is the expected behaviour?

The docs search box should show results relevant for the particular `<version>` of the docs (as matched by the URL pattern `https://dgraph.io/docs/(?P<version>.*?)/`).

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
