### PR TITLE
Update miragejs to search full site

### DIFF
--- a/configs/miragejs.json
+++ b/configs/miragejs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "miragejs",
   "start_urls": [
-    "https://miragejs.com/docs/",
+    "https://miragejs.com/",
     "https://miragejs.com/docs/getting-started/introduction"
   ],
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation

Currently Algolia crawls only "/docs", but the currently the full miragejs.com is documentation, and "/docs" are just the guides. We need to also crawl "/api" and "/quickstarts"!
