### PR TITLE
Update configuration for brew_nodenv

### DIFF
--- a/configs/brew_nodenv.json
+++ b/configs/brew_nodenv.json
@@ -2,7 +2,44 @@
   "index_name": "brew_nodenv",
   "start_urls": [
     {
-      "url": "https://nodenv.github.io/formulae/",
+      "url": "https://nodenv.github.io/formulae/analytics/",
+      "selectors_key": "analytics",
+      "tags": [
+        "analytics"
+      ],
+      "extra_attributes": {
+        "site": [
+          "formulae"
+        ]
+      }
+    },
+    {
+      "url": "https://nodenv.github.io/formulae/docs/",
+      "selectors_key": "formulae_docs",
+      "tags": [
+        "formulae_docs"
+      ],
+      "extra_attributes": {
+        "site": [
+          "formulae"
+        ]
+      }
+    },
+    {
+      "url": "https://nodenv.github.io/formulae/formula/",
+      "selectors_key": "formula",
+      "tags": [
+        "formula"
+      ],
+      "extra_attributes": {
+        "site": [
+          "formulae"
+        ]
+      }
+    },
+    {
+      "url": "https://nodenv.github.io/formulae/cask/",
+      "selectors_key": "cask",
       "tags": [
         "cask",
         "formula"

--- a/configs/brew_nodenv.json
+++ b/configs/brew_nodenv.json
@@ -55,7 +55,6 @@
     "https://nodenv.github.io/formulae/sitemap.xml"
   ],
   "stop_urls": [
-    "https://brew.sh/blog/",
     "\\.json"
   ],
   "selectors": {

--- a/configs/brew_nodenv.json
+++ b/configs/brew_nodenv.json
@@ -58,22 +58,96 @@
     "\\.json"
   ],
   "selectors": {
-    "lvl0": {
-      "selector": "",
-      "global": true,
-      "default_value": "Cask"
+    "default": {
+      "lvl0": "#wrap h1",
+      "lvl1": "#wrap h2",
+      "lvl2": "#wrap h3",
+      "lvl3": "#wrap h4",
+      "lvl4": "#wrap h5",
+      "lvl5": "#wrap h6",
+      "text": "#wrap p, #wrap li",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en"
+      }
     },
-    "lvl1": "#wrap h2",
-    "lvl2": "#wrap h3",
-    "lvl3": "#wrap h4",
-    "lvl4": "#wrap h5",
-    "lvl5": "#wrap h6",
-    "text": "#wrap p, #wrap li",
-    "lang": {
-      "selector": "/html/@lang",
-      "type": "xpath",
-      "global": true,
-      "default_value": "en"
+    "formula": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Formulae"
+      },
+      "lvl1": "#wrap h2",
+      "lvl2": "#wrap h3",
+      "lvl3": "#wrap h4",
+      "lvl4": "#wrap h5",
+      "lvl5": "#wrap h6",
+      "text": "#default p:nth-child(-n+4)",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en"
+      }
+    },
+    "cask": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Cask"
+      },
+      "lvl1": "#wrap h2",
+      "lvl2": "#wrap h3",
+      "lvl3": "#wrap h4",
+      "lvl4": "#wrap h5",
+      "lvl5": "#wrap h6",
+      "text": "#wrap p, #wrap li",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en"
+      }
+    },
+    "formulae_docs": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "JSON API documentation"
+      },
+      "lvl1": "#wrap h2",
+      "lvl2": "#wrap h3",
+      "lvl3": "#wrap h4",
+      "lvl4": "#wrap h5",
+      "lvl5": "#wrap h6",
+      "text": "#default p:nth-child(-n+4)",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en"
+      }
+    },
+    "analytics": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Analytics data"
+      },
+      "lvl1": "#wrap h2",
+      "lvl2": "#wrap h3",
+      "lvl3": "#wrap h4",
+      "lvl4": "#wrap h5",
+      "lvl5": "#wrap h6",
+      "text": "#wrap td:not(.number-data)",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en"
+      }
     }
   },
   "custom_settings": {


### PR DESCRIPTION
The search for the nodenv formulae site needed some tweaking to have it match the homebrew index.

# Pull request motivation(s)

Current index was showing all results as "Cask". ( I believe this was due to misconfigured selectors) Also, it was including duplicate results. (I believe this was because the start-urls were not limited in scope as much as they should have been.)
### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*
![image](https://user-images.githubusercontent.com/119972/79290602-8e8ead80-7e9a-11ea-9ff8-9f97f52ba571.png)

This screenshot was taking on the main Formula page so it should have shown Formula instead of Cask. Also, it shows duplicate entries. (The urls for each duplicate indicate that they _are_ unique. 1 each is for the main formula, the other for the linux formula. The change of the start-urls in this PR should address that.)

Also, the same search results were being displayed regardless if the page was analytics, formula or formula_docs. This PR addresses that as well.

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

