### PR TITLE
Add custom setting to facet version

### DIFF
--- a/configs/gooddata.json
+++ b/configs/gooddata.json
@@ -18,11 +18,10 @@
     "lvl4": ".post h4",
     "text": ".post article p, .post article li"
   },
-  "selectors_exclude": [
-    ".hash-link"
-  ],
-  "conversation_id": [
-    "591776394"
-  ],
+  "selectors_exclude": [".hash-link"],
+  "custom_settings": {
+    "attributesForFaceting": ["version"]
+  },
+  "conversation_id": ["591776394"],
   "nb_hits": 3386
 }


### PR DESCRIPTION
Hello, I am creating a PR for adding new config for facet version. I was trying to follow the documentation on Algolia to limit search suggestion to only current version. I have added ` algoliaOptions: {
      facetFilters: ["version: VERSION"]
    }` to the siteConfig.js with no success. It returned no result at all after adding this code. I hope with this PR, the issue will be resolved. If you have a suggestion on how to make it up and working, please let me know and I will edit the PR. Thank you
