### PR TITLE
Updates support for multiple versions of Sprout plugin docs 

### DIFF
--- a/configs/sprout_barrelstrengthdesign.json
+++ b/configs/sprout_barrelstrengthdesign.json
@@ -1,11 +1,19 @@
 {
   "index_name": "sprout_barrelstrengthdesign",
   "start_urls": [
-    "https://sprout.barrelstrengthdesign.com/docs/"
+    {
+      "url": "https://sprout.barrelstrengthdesign.com/docs/",
+      "selectors_key": "latest"
+    },
+    {
+      "url": "https://sprout.barrelstrengthdesign.com/docs/craft-v2/",
+      "selectors_key": "craft-v2"
+    }
   ],
   "stop_urls": [],
   "sitemap_urls": [
-    "https://sprout.barrelstrengthdesign.com/sitemap.xml"
+    "https://sprout.barrelstrengthdesign.com/docs/sitemap.xml",
+    "https://sprout.barrelstrengthdesign.com/docs/craft-v2/sitemap.xml
   ],
   "selectors": {
     "lvl0": {

--- a/configs/sprout_barrelstrengthdesign.json
+++ b/configs/sprout_barrelstrengthdesign.json
@@ -3,11 +3,11 @@
   "start_urls": [
     {
       "url": "https://sprout.barrelstrengthdesign.com/docs/",
-      "selectors_key": "latest"
+      "tags": ["latest"]
     },
     {
       "url": "https://sprout.barrelstrengthdesign.com/docs/craft-v2/",
-      "selectors_key": "craft-v2"
+      "tags": ["craft-v2"]
     }
   ],
   "stop_urls": [],

--- a/configs/sprout_barrelstrengthdesign.json
+++ b/configs/sprout_barrelstrengthdesign.json
@@ -13,7 +13,7 @@
   "stop_urls": [],
   "sitemap_urls": [
     "https://sprout.barrelstrengthdesign.com/docs/sitemap.xml",
-    "https://sprout.barrelstrengthdesign.com/docs/craft-v2/sitemap.xml
+    "https://sprout.barrelstrengthdesign.com/docs/craft-v2/sitemap.xml"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
- Adds support for craft-v2 version of docs
- Updates start_urls
- Updates sitemap_urls
- Attempts to add selector_keys