### PR TITLE
Update sitemap file for 3.0.0 version

### DIFF
--- a/configs/wso2.json
+++ b/configs/wso2.json
@@ -15,7 +15,8 @@
   },
   "sitemap_urls": [
     "https://apim.docs.wso2.com/en/latest/sitemap.xml",
-    "https://apim.docs.wso2.com/en/next/sitemap.xml"
+    "https://apim.docs.wso2.com/en/next/sitemap.xml",
+    "https://apim.docs.wso2.com/en/3.0.0/sitemap.xml"
   ],
   "conversation_id": [
     "1070576193"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Algolia Search is not working for newly created doc version [3.0.0](https://apim.docs.wso2.com/en/3.0.0/)

### What is the expected behaviour?

Add the doc version 3.0.0 sitemap file to get the 3.0.0 doc content indexed

(https://apim.docs.wso2.com/en/3.0.0/sitemap.xml)

Fix for https://github.com/wso2/docs-apim/issues/1053
