### PR TITLE
Modified ChilliCream config to address blog posts

### DIFF
--- a/configs/chillicream.json
+++ b/configs/chillicream.json
@@ -1,30 +1,37 @@
 {
   "index_name": "chillicream",
   "start_urls": [
-    "https://chillicream.com/docs/"
+    {
+      "url": "https://chillicream.com/docs/",
+      "tags": [
+        "docs"
+      ]
+    },
+    {
+      "url": "https://chillicream.com/blog/",
+      "selectors_key": "blog",
+      "tags": [
+        "blog"
+      ]
+    }
   ],
   "sitemap_urls": [
     "https://chillicream.com/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
-  "selectors": {
-    "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
-    },
-    "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "lvl5": ".post h5",
-    "text": ".post article p, .post article li"
-  },
-  "selectors_exclude": [
-    ".hash-link"
+  "stop_urls": [
+    "/blog/tags/"
   ],
+  "selectors": {
+    "lvl0": "article h1",
+    "lvl1": "article h2",
+    "lvl2": "article h3",
+    "lvl3": "article h4",
+    "lvl4": "article h5",
+    "lvl5": "article h6",
+    "text": "article p, article li"
+  },
+  "selectors_exclude": [],
   "custom_settings": {
     "attributesForFaceting": [
       "language",

--- a/configs/chillicream.json
+++ b/configs/chillicream.json
@@ -31,7 +31,6 @@
     "lvl5": "article h6",
     "text": "article p, article li"
   },
-  "selectors_exclude": [],
   "custom_settings": {
     "attributesForFaceting": [
       "language",

--- a/configs/chillicream.json
+++ b/configs/chillicream.json
@@ -9,7 +9,6 @@
     },
     {
       "url": "https://chillicream.com/blog/",
-      "selectors_key": "blog",
       "tags": [
         "blog"
       ]


### PR DESCRIPTION
- Changed selectors to address our new website (gatsby site; not docusaurus anymore) which is currently under development and is going to be published within the next one or two weeks. The dev version can be found [here](https://chillicream.github.io/hotchocolate/).
- Added another start_url to address also blog posts for indexing.