### PR TITLE
Update qctrl.json

### DIFF
--- a/configs/qctrl.json
+++ b/configs/qctrl.json
@@ -5,13 +5,13 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": "main.DocSearch-content h1",
-    "lvl1": "main.DocSearch-content h2",
-    "lvl2": "main.DocSearch-content h3",
-    "lvl3": "main.DocSearch-content h4",
-    "lvl4": "main.DocSearch-content h5",
-    "lvl5": "main.DocSearch-content h6",
-    "text": "main.DocSearch-content p, main.DocSearch-content li, main.DocSearch-content figcaption"
+    "lvl0": ".DocSearch-content h1",
+    "lvl1": ".DocSearch-content h2",
+    "lvl2": ".DocSearch-content h3",
+    "lvl3": ".DocSearch-content h4",
+    "lvl4": ".DocSearch-content h5",
+    "lvl5": ".DocSearch-content h6",
+    "text": ".DocSearch-content p, .DocSearch-content li"
   },
   "conversation_id": [
     "644148907"


### PR DESCRIPTION
Removed the requirement for the `DocSearch-content` class attribute value to be attached to a `main` tag.