### PR TITLE
Updated versions for svgjs.com

### DIFF
--- a/configs/svgjs.json
+++ b/configs/svgjs.json
@@ -1,7 +1,14 @@
 {
   "index_name": "svgjs",
   "start_urls": [
-    "http://svgjs.com/"
+    "http://svgjs.com/docs/2.7",
+    "http://svgjs.com/docs/3.0",
+    "http://svgjs.com/docs/3.1",
+  ],
+  "sitemap_urls": [
+    "https://svgjs.com/docs/2.7/sitemap/",
+    "https://svgjs.com/docs/3.0/sitemap/",
+    "https://svgjs.com/docs/3.1/sitemap/"
   ],
   "stop_urls": [],
   "selectors": {

--- a/configs/svgjs.json
+++ b/configs/svgjs.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "http://svgjs.com/docs/2.7",
     "http://svgjs.com/docs/3.0",
-    "http://svgjs.com/docs/3.1",
+    "http://svgjs.com/docs/3.1"
   ],
   "sitemap_urls": [
     "https://svgjs.com/docs/2.7/sitemap/",


### PR DESCRIPTION
This PR updates the config for the svg.js docs. I added different versions of the doc a month ago and that made agolia stop crawling the non-current versions.

I added sitemap urls and multiple start urls.
Is this correct this way? Or is only one of both needed?
