### PR TITLE
Update chromatic.json

### DIFF
--- a/configs/chromatic.json
+++ b/configs/chromatic.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "https://www.chromatic.com/docs/"
   ],
-  "stop_urls": ["chromatic(?!\.com\/docs)"],
+  "stop_urls": ["chromatic(\\?!\\.com\\/docs)"],
   "selectors": {
     "lvl0": {
       "selector": "//*[contains(@class,'sidebar-nav')]//*[contains(@class,'active')]/preceding::*[contains(@class,'title')][1]",

--- a/configs/chromatic.json
+++ b/configs/chromatic.json
@@ -1,9 +1,9 @@
 {
   "index_name": "chromatic",
   "start_urls": [
-    "https://docs.chromatic.com"
+    "https://www.chromatic.com/docs/"
   ],
-  "stop_urls": [],
+  "stop_urls": ["chromatic(?!\.com\/docs)"],
   "selectors": {
     "lvl0": {
       "selector": "//*[contains(@class,'sidebar-nav')]//*[contains(@class,'active')]/preceding::*[contains(@class,'title')][1]",


### PR DESCRIPTION
Would like to update DocSearch to reflect moving our docs from a subdomain to a path. Would like to prevent the crawler from indexing the marketing site outside of the /docs/ subpath and have included a `stop_urls` entry to do so. This is my first time configuring DocSearch so I would appreciate it if you let me know if I got the syntax wrong. Thank you!