### PR TITLE
fix: Update start_url for formatjs.io

### DIFF
--- a/configs/formatjs.json
+++ b/configs/formatjs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "formatjs",
   "start_urls": [
-    "https://formatjs.io/guides/"
+    "https://formatjs.io/docs/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We recently launched a redesign so the URL changed. New sitemap: https://formatjs.io/sitemap.xml