### PR TITLE
Increase hitsPerPage

### DIFF
--- a/configs/touchgfx.json
+++ b/configs/touchgfx.json
@@ -27,5 +27,6 @@
   "conversation_id": [
     "1119277578"
   ],
-  "nb_hits": 19745
+  "nb_hits": 19745,
+  "hitsPerPage": 10
 }


### PR DESCRIPTION
We want to try an increase in the number of hits shown in the dropdown. Not sure if this is the correct place to put the new new "hitsPerPage".

# Pull request motivation(s)

Sometimes we don't get the search results we expect due to the number of hits only being 5. We went to try out 10 to see if it resolves the issue.

Not sure which URL you need to confirm that I am maintainer, but I'll be happy to provide info.

### What is the current behaviour?

5 hits are shown in the dropdown.

### What is the expected behaviour?

10 hits are shown in the dropdown.

##### NB: Do you want to request a **feature** or report a **bug**?

Feature.
