### PR TITLE
impr: Removed attributes-table selector for Aircall Public API documentation

### DIFF
--- a/configs/aircall_developer.json
+++ b/configs/aircall_developer.json
@@ -7,8 +7,8 @@
   "selectors": {
     "lvl0": "h1",
     "lvl1": "h2",
-    "lvl2": ".api-references--content-area--desc-copy h3, .attributes-table > strong",
-    "lvl3": ".api-references--content-area--desc-copy h4, .attributes-table--title",
+    "lvl2": ".api-references--content-area--desc-copy h3",
+    "lvl3": ".api-references--content-area--desc-copy h4",
     "lvl4": ".api-references--content-area--desc-copy h5",
     "lvl5": ".api-references--content-area--desc-copy h6",
     "text": ".api-references--content-area--desc-copy p, .api-references--content-area--desc-copy li, .attributes-table--description"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

In [Aircall Public API documentation](https://developer.aircall.io/api-references/#transfer-a-call).

### What is the current behavior?

When searching for `transfer`, results are from the `.attributes-table` tables.

![image](https://user-images.githubusercontent.com/630714/80650257-a7be5f00-8a41-11ea-87b1-e51224756ef4.png)


### What is the expected behavior?

When searching for `transfer`, user should see the `Transfer a call` as a result, which is an `h3` element.


Thanks team!

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
