### PR TITLE
Update yoast_developer.json

### DIFF
--- a/configs/yoast_developer.json
+++ b/configs/yoast_developer.json
@@ -6,8 +6,11 @@
   "stop_urls": [
     "https://developer.yoast.com/blog/?(.*)?"
   ],
+  "sitemap_urls": [
+    "https://developer.yoast.com/sitemap.xml"
+  ],
   "selectors": {
-    "lvl0": "[aria-current='page']",
+    "lvl0": "header h1",
     "lvl1": "article h2",
     "lvl2": "article h3",
     "lvl3": "article h4",
@@ -15,6 +18,7 @@
     "lvl5": "article h6",
     "text": "article p, article li"
   },
+  "strip_chars": " .,;:#",
   "conversation_id": [
     "1082863669"
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Updates the config to point to the sitemap, use the proper h1 tag and strip out characters we don't want in the results.

### What is the current behaviour?

* The configuration points to the `aria-current` property, whereas the `h1` tag is far more likely to be present *and* be what the user is searching for.
* Hash bangs show up in search results, which we don't want.
* The sitemap is currently not being referenced.

### What is the expected behaviour?

That the above points are more in line with the default Docusaurus V2 configuration, which is what our configuration is based on, thus is the desired / expected behavior.