### PR TITLE
Fix #1898

### DIFF
--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -2,14 +2,14 @@
   "index_name": "arrow",
   "start_urls": [
     {
-      "url": "https://arrow-kt.io/docs/apidocs/",
+      "url": "https://arrow-kt.io/docs/current/apidocs/",
       "tags": [
         "api"
       ],
       "selectors_key": "api"
     },
-    "https://arrow-kt.io/docs/0.10/",
-    "https://arrow-kt.io/docs/0.10/core/"
+    "https://arrow-kt.io/docs/current/",
+    "https://arrow-kt.io/docs/current/core/"
   ],
   "stop_urls": [
     "https://arrow-kt.io/docs/arrow/data/nonemptylist/"
@@ -24,6 +24,7 @@
         "global": true,
         "default_value": "Documentation"
       },
+      "lvl0": ".doc-content h1",
       "lvl1": ".doc-content h2",
       "lvl2": ".doc-content h3",
       "lvl3": ".doc-content h4",


### PR DESCRIPTION
# Pull request motivation(s)

Fix #1898
- Remove hard-coded version `0.10`
- Add `h1` header

https://arrow-kt.io/sitemap.xml has been updated to have `/current/` as well instead of `/0.10/` on URLs.

### What is the current behaviour?

`Option` on a header with level `1` is not being found.

### What is the expected behaviour?

Getting `Option` results when looking for `Option`. Just `Optional` and `OptionT` now.

##### NB2: Any other feedback

Thank you so much @s-pace for his kind assistance :+1: