### PR TITLE
Fix #1898. Simplify configuration

### DIFF
--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -1,18 +1,7 @@
 {
   "index_name": "arrow",
   "start_urls": [
-    {
-      "url": "https://arrow-kt.io/docs/apidocs/",
-      "tags": [
-        "api"
-      ],
-      "selectors_key": "api"
-    },
-    "https://arrow-kt.io/docs/0.10/",
-    "https://arrow-kt.io/docs/0.10/core/"
-  ],
-  "stop_urls": [
-    "https://arrow-kt.io/docs/arrow/data/nonemptylist/"
+    "https://arrow-kt.io"
   ],
   "sitemap_urls": [
     "https://arrow-kt.io/sitemap.xml"
@@ -23,18 +12,6 @@
         "selector": ".active .core",
         "global": true,
         "default_value": "Documentation"
-      },
-      "lvl1": ".doc-content h2",
-      "lvl2": ".doc-content h3",
-      "lvl3": ".doc-content h4",
-      "lvl4": ".doc-content h5",
-      "text": ".doc-content p, .doc-content li"
-    },
-    "api": {
-      "lvl0": {
-        "selector": "",
-        "global": true,
-        "default_value": "API Docs"
       },
       "lvl1": ".doc-content h1, .doc-content h2",
       "lvl2": ".doc-content h3",


### PR DESCRIPTION
# Pull request motivation(s)

Another try after #1906

- Just one selector key (default).
- Just one URL

https://arrow-kt.io/sitemap.xml has been updated in order not to have version references on URLs.

### What is the current behaviour?

`Option` on a header with level `1` is not being found.

### What is the expected behaviour?

Getting `Option` results when looking for `Option`. Just `Optional` and `OptionT` now.

##### NB2: Any other feedback

Thank you so much @s-pace for his kind assistance :+1: