### PR TITLE
Swap Bold Penguin docs to prod DNS

### DIFF
--- a/configs/boldpenguin_developers.json
+++ b/configs/boldpenguin_developers.json
@@ -1,10 +1,10 @@
 {
   "index_name": "boldpenguin_developers",
   "start_urls": [
-    "https://developers.dev.boldpenguin.com/docs/"
+    "https://developers.boldpenguin.com/docs/"
   ],
   "sitemap_urls": [
-    "https://developers.dev.boldpenguin.com/sitemap.xml"
+    "https://developers.boldpenguin.com/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We have completed our build work on our documentation and are ready for Docsearch to start crawling the production site.

### What is the current behaviour?

Docsearch is crawling https://developers.dev.boldpenguin.com

### What is the expected behaviour?

Docsearch starts crawling https://developers.boldpenguin.com

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
