### PR TITLE
Exclude badges from Tachiyomi results

### DIFF
--- a/configs/tachiyomi.json
+++ b/configs/tachiyomi.json
@@ -27,7 +27,8 @@
     }
   },
   "selectors_exclude": [
-    ".table-of-contents"
+    ".table-of-contents",
+    ".badge"
   ],
   "custom_settings": {
     "attributesForFaceting": [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Follow-up to #1909, this removes `.badge` from the results.

### What is the current behaviour?

Badges shows up in the results.

### What is the expected behaviour?

The above is expected, thus I change it with this PR.

##### NB: Do you want to request a **feature** or report a **bug**?
N/A

##### NB2: Any other feedback / questions ?
N/A

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
