### PR TITLE
Arrow - reduce search results

### DIFF
--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -4,7 +4,7 @@
     "https://arrow-kt.io/docs/core/",
     "https://arrow-kt.io/docs/fx/",
     "https://arrow-kt.io/docs/optics/dsl/",
-    "https://arrow-kt.io/docs/aql/intro/",
+    "https://arrow-kt.io/docs/aql/intro/"
   ],
   "stop_urls": [
     "https://arrow-kt.io/docs/0.9",

--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -1,7 +1,18 @@
 {
   "index_name": "arrow",
   "start_urls": [
-    "https://arrow-kt.io"
+    "https://arrow-kt.io/docs/core/",
+    "https://arrow-kt.io/docs/fx/",
+    "https://arrow-kt.io/docs/optics/dsl/",
+    "https://arrow-kt.io/docs/aql/intro/",
+  ],
+  "stop_urls": [
+    "https://arrow-kt.io/docs/0.9",
+    "https://arrow-kt.io/docs/next/core/",
+    "https://arrow-kt.io/docs/next/fx/",
+    "https://arrow-kt.io/docs/next/optics/dsl/",
+    "https://arrow-kt.io/docs/next/aql/intro/",
+    "!index.html"
   ],
   "sitemap_urls": [
     "https://arrow-kt.io/sitemap.xml"
@@ -15,9 +26,9 @@
       },
       "lvl1": ".doc-content h1, .doc-content h2",
       "lvl2": ".doc-content h3",
-      "lvl3": ".doc-content h4, .doc-content td:first-child",
+      "lvl3": ".doc-content h4",
       "lvl4": ".doc-content h5",
-      "text": ".doc-content p, .doc-content li, .doc-content td:last-child"
+      "text": ".doc-content p, .doc-content li"
     }
   },
   "selectors_exclude": [


### PR DESCRIPTION
# Pull request motivation(s)

### What is the current behaviour?

`sitemap` was believed to provide the pages that must be indexed. However:

> Your website should have an updated sitemap. This is key to let our crawler know what should be updated. Do not worry, we will still crawl your website and discover embedded hyperlinks to find your great content.

So #1907 is providing a lot of search results that are not desired.

### What is the expected behaviour?

Just `index.html` pages should be indexed. Does `!index.html` work for it as a candidate of `stop_urls`? We want to skip pages like: `option.html`, `field.html`, etc.

Thanks in advance!
