### PR TITLE
Hide Twill v1 docs from DocSearch

### DIFF
--- a/configs/twill.json
+++ b/configs/twill.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://twill.io/docs/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://twill.io/docs/1.x"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "p.sidebar-heading.open",


### PR DESCRIPTION
## PR motivations

Collaborate with @s-pace on the necessary changes to deploy DocSeach on Twill's production documentation.

### What is the current behaviour?

When testing https://github.com/area17/twill/pull/639/, I realized all search results were coming from our /docs/1.x page instead of the currently canonical /docs page. It probably makes sense as the current configuration doesn't prevent those pages from being indexed.

### What is the expected behaviour?

Any page under /docs/1.x should not appear in search.
