### PR TITLE
Arrow - Just one "start url"

### DIFF
--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -1,7 +1,7 @@
 {
   "index_name": "arrow",
   "start_urls": [
-    "https://arrow-kt.io
+    "https://arrow-kt.io"
   ],
   "stop_urls": [
     "https://arrow-kt.io/docs/0.9",

--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -1,10 +1,7 @@
 {
   "index_name": "arrow",
   "start_urls": [
-    "https://arrow-kt.io/docs/0.10/core/",
-    "https://arrow-kt.io/docs/0.10/fx/",
-    "https://arrow-kt.io/docs/0.10/optics/dsl/",
-    "https://arrow-kt.io/docs/0.10/aql/intro/"
+    "https://arrow-kt.io
   ],
   "stop_urls": [
     "https://arrow-kt.io/docs/0.9",


### PR DESCRIPTION
# Pull request motivation(s)

### What is the current behaviour?

Some pages that appear in `sitemap.xml` are not being found like https://arrow-kt.io/docs/0.10/apidocs/arrow-core-data/arrow.core/-option/index.html. As `stop_urls` are working, let's use just one "start url" to find them.

### What is the expected behaviour?

When looking for `Option`, it's expected to find https://arrow-kt.io/docs/0.10/apidocs/arrow-core-data/arrow.core/-option/index.html which has `Option` on header level 1 before the current results when `Option` appears on text.

Thank you very much!