### PR TITLE
Update evervault docs url

### DIFF
--- a/configs/evervault.json
+++ b/configs/evervault.json
@@ -1,7 +1,7 @@
 {
   "index_name": "evervault",
   "start_urls": [
-    "https://evervault-docs.netlify.app/"
+    "https://docs.evervault.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

### What is the current behaviour?

The previous `start_url` was the preview one from Netlify, this change points to the production version of the documentation.

### What is the expected behaviour?

It should now point to the production version of the docs.

New URL Preview: https://docs.evervault.com/

##### NB2: Any other feedback / questions ?

Question: how do I make sure that the index runs again?