### PR TITLE
update expo for usage with docsearch meta tags

### DIFF
--- a/configs/expo.json
+++ b/configs/expo.json
@@ -1,19 +1,6 @@
 {
   "index_name": "expo",
   "start_urls": [
-    {
-      "url": "https://docs.expo.io/versions/(?P<version>.*?)/",
-      "variables": {
-        "version": [
-          "v34.0.0",
-          "v35.0.0",
-          "v36.0.0",
-          "v37.0.0",
-          "latest",
-          "unversioned"
-        ]
-      }
-    },
     "https://docs.expo.io/"
   ],
   "stop_urls": [],
@@ -34,5 +21,8 @@
   "conversation_id": [
     "569512966"
   ],
+  "custom_settings": {
+    "attributesForFaceting": ["version"]
+  },
   "nb_hits": 40888
 }


### PR DESCRIPTION
# Pull request motivation(s)

Hi Algolia! We want to tweak our implementation with Docsearch a bit. Because we had some issues in the past with restructuring docs and releasing new features, we want to switch to docsearch meta tags. That way, we can dynamically add the proper facets and filter them 😄 

We already deployed the [docs](https://docs.expo.io) with the `<meta name="docsearch:version" content="..."/>`-tags, [see this PR](https://github.com/expo/expo/pull/8075).

### What is the current behaviour?

- We need to manually update if we release a new version
- Non-versioned docs doesn't have the version facet, and we can't filter on "pages without facets"

### What is the expected behaviour?

- Releasing new versions without the explicit configuration here (prone to human error)
- Non-versioned docs should have a facet so we can query this with an explicit API version

##### NB: Do you want to request a **feature** or report a **bug**?

I guess it's a feature.

##### NB2: Any other feedback / questions ?

Once this PR lands, can we also get a reindex? After that, we will go forward with the search settings ([PR](https://github.com/expo/expo/pull/8192)) and deploy this.

Thanks for the Docsearch program, it helps us and our users so much 😄 