### PR TITLE
Arrow: exclude elements with header-link class

### DIFF
--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -29,6 +29,7 @@
     }
   },
   "selectors_exclude": [
+    ".header-link",
     ".doc-content td:last-child a",
     ".doc-content td:last-child code",
     ".doc-content p:first-child"


### PR DESCRIPTION
# Pull request motivation(s)

### What is the current behaviour?

`Option` page appears twice in search results:

* https://arrow-kt.io/docs/0.10/apidocs/arrow-core-data/arrow.core/-option/index.html
* https://arrow-kt.io/docs/0.10/apidocs/arrow-core-data/arrow.core/-option/index.html#option

because of:

```
<h1 id="option">
    Option
     <a class="header-link" href="#option"><i class="fa fa-link"></i></a>
</h1>
```

so this PR adds `header-link` class in `selectors_exclude` section.

##### Any other feedback / questions ?

Thank you in advance!