### PR TITLE
Update chartjs.json

### DIFF
--- a/configs/chartjs.json
+++ b/configs/chartjs.json
@@ -10,10 +10,10 @@
       }
     },
     {
-      "url": "https://www.chartjs.org/docs/2.9.3/",
+      "url": "https://www.chartjs.org/docs/master/",
       "extra_attributes": {
         "version": [
-          "2.9.3"
+          "master"
         ]
       }
     },
@@ -26,7 +26,7 @@
       }
     },
     "https://www.chartjs.org/docs/",
-    "https://www.chartjs.org/docs/next/getting-started/README"
+    "https://www.chartjs.org/docs/next/index"
   ],
   "sitemap_urls": [
     "https://www.chartjs.org/docs/next/sitemap.xml"


### PR DESCRIPTION
2.9.3 docs are on GitBook and have their own search. `master` docs are hosted on Docusaurus and should use Algolia