### PR TITLE
Index more cert-manager versions

### DIFF
--- a/configs/cert-manager.json
+++ b/configs/cert-manager.json
@@ -5,6 +5,7 @@
       "url": "https://cert-manager.io/(?P<version>.*?)/",
       "variables": {
         "version": [
+          "next-docs",
           "docs",
           "v0.12-docs",
           "v0.13-docs",

--- a/configs/cert-manager.json
+++ b/configs/cert-manager.json
@@ -7,7 +7,8 @@
         "version": [
           "docs",
           "v0.12-docs",
-          "v0.13-docs"
+          "v0.13-docs",
+          "v0.14-docs"
         ]
       }
     }


### PR DESCRIPTION
# Pull request motivation(s)
Index more versions on cert-manager.io

### What is the current behaviour?
v0.14 and next are not indexed.
*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*
