### PR TITLE
fix(kong): remove .content prefix from lvl1

### DIFF
--- a/configs/getkong.json
+++ b/configs/getkong.json
@@ -21,7 +21,7 @@
       "global": true,
       "default_value": "Kong"
     },
-    "lvl1": ".content h1",
+    "lvl1": "h1",
     "lvl2": ".content h2",
     "lvl3": ".content h3",
     "lvl4": ".content h4",


### PR DESCRIPTION
Content changed on the kong docs.

From https://github.com/Kong/docs.konghq.com/pull/2033