### PR TITLE
Update getambassador doc indexing

### DIFF
--- a/configs/getambassador.json
+++ b/configs/getambassador.json
@@ -7,7 +7,9 @@
     "https://www.getambassador.io/user-guide/",
     "https://www.getambassador.io/reference/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://www.getambassador.io/docs/1.*"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "(//*[contains(@class,'Sidebar')][1]//a[contains(//aside/a/@href,@href)])[2]/preceding::button[1]/span[1]",


### PR DESCRIPTION
We've added versioned documentation to the Ambassador website. This change stops indexing of older docs, so that the search will always direct the user to latest.

