### PR TITLE
Update title and description selectors for docs

### DIFF
--- a/configs/pubnub.json
+++ b/configs/pubnub.json
@@ -188,10 +188,10 @@
       }
     },
     "docs": {
-      "lvl0": "h1.page-title",
-      "lvl1": ".content .content h2",
-      "lvl2": ".content .content h3",
-      "lvl3": ".content .content h4",
+      "lvl0": "div.doc-search-title",
+      "lvl1": "div.doc-search-description",
+      "lvl2": "h1.page-title, .content .content h2",
+      "lvl3": ".content .content h3, .content .content h4",
       "lvl4": ".content .content h5, .content .content td:first-child",
       "lvl5": ".content .content h6",
       "text": ".content .content p, .content .content li,  .content .content td:last-child",


### PR DESCRIPTION
The current behavior shows the same content in `title` and `description` of the search results. Have added 2 news fields on the pages so that the title and descriptions are different and what we expect them to be.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
