### PR TITLE
change url to teddytags.now.sh

### DIFF
--- a/configs/teddy.json
+++ b/configs/teddy.json
@@ -1,7 +1,7 @@
 {
   "index_name": "teddy",
   "start_urls": [
-    "https://teddy.js.org/docs"
+    "https://teddytags.now.sh/docs"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

* Since the documentation site is being changed to https://teddytags.now.sh/docs, so an update is needed to do the needful
### What is the current behaviour?
Docsearch is crawling the deprecated site.

### What is the expected behaviour?
After merging the PR, DocSearch should crawl https://teddytags.now.sh/docs.

##### NB: Do you want to request a **feature** or report a **bug**?
No

##### NB2: Any other feedback / questions ?
No
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
