### PR TITLE
Add sitemap and facets to d-velopsmartsolutions

### DIFF
--- a/configs/d-velopsmartsolutions.json
+++ b/configs/d-velopsmartsolutions.json
@@ -3,6 +3,9 @@
   "start_urls": [
     "https://docs.d-velopsmartsolutions.com/smartinvoice"
   ],
+  "sitemap_urls": [
+    "https://docs.d-velopsmartsolutions.com/smartinvoice/sitemap.xml"
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": "main h1",
@@ -12,6 +15,9 @@
     "lvl4": "main h5",
     "lvl5": "main h6",
     "text": "main p, main li"
+  },
+  "custom_settings": {
+    "attributesForFaceting": ["language", "version"]
   },
   "conversation_id": [
     "1165924256"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We currently offer different versions of our docs and will offer different languages soon. Currently, the other versions are only reachable via a menu that requires JS to be enabled. They are, however, linked in the sitemap. We also already provide facet info for language and version in our meta tags.

### What is the current behaviour?

Currently, the version and language meta tags are not used. As far as I can tell, the sitemap is also ignored.

### What is the expected behaviour?

Language and version facets are added to the index. Sitemap is used to reach the pages for the other versions (currently only one other version).

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
