### PR TITLE
Update demisto.json

### DIFF
--- a/configs/demisto.json
+++ b/configs/demisto.json
@@ -24,6 +24,11 @@
   "selectors_exclude": [
     ".hash-link"
   ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "anchor"
+    ]
+  },
   "conversation_id": [
     "1106052758"
   ],


### PR DESCRIPTION
Allow filtering by "anchor" attribute

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


Our site has a large number of docs (over 1K) and we are interested in only returning search results for specific anchor values. 

# Pull request motivation(s)


### What is the current behaviour?

Current behavior is that results matching all anchors are returned, including subheaders.

### What is the expected behaviour?

We would like to return only anchors matching "__docusaurus" but currently the "anchor" attribute is not a facet.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
