### PR TITLE
Index more doc content element types

### DIFF
--- a/configs/prometheus.json
+++ b/configs/prometheus.json
@@ -11,7 +11,7 @@
     "lvl3": ".doc-content h4",
     "lvl4": ".doc-content h5",
     "lvl5": ".doc-content h6",
-    "text": ".doc-content p, .doc-content li"
+    "text": ".doc-content p, .doc-content li, .doc-content pre, .doc-content table, .doc-content div"
   },
   "custom_settings": {
     "attributesForFaceting": [


### PR DESCRIPTION
Best would maybe be to index anything under ".doc-content" regardless of sub-tag, but I'm not sure if that would cause any problems.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Certain relevant documentation text elements (in divs, tables, etc.) are not indexed, and thus cannot be found via Docsearch.

### What is the expected behaviour?

For those elements to be found :)