### PR TITLE
Update nuance-mix.json to fine-tune results

### DIFF
--- a/configs/nuance-mix.json
+++ b/configs/nuance-mix.json
@@ -1,10 +1,16 @@
 {
   "index_name": "nuance-mix",
   "start_urls": [
-    "https://mix.nuance.com/v3/documentation/"
+    "https://mix.nuance.com/v3/documentation/",
+    "https://mix.nuance.com/v3/documentation/nlu-trsx-app-spec/",
+    "https://mix.nuance.com/v3/documentation/dialog-app-spec/",
+    "https://mix.nuance.com/v3/documentation/technical-requirements/",
+    "https://mix.nuance.com/v3/documentation/languages/",
+    "https://mix.nuance.com/v3/documentation/glossary/"
   ],
   "stop_urls": [
-    "/$"
+    "/$",
+    "https://mix.nuance.com/v3/documentation/mix-datapack/v6_x/"
   ],
   "selectors": {
     "text": ".content p, .content li",
@@ -21,5 +27,8 @@
   "conversation_id": [
     "1076829139"
   ],
+  "custom_settings": {
+    "separatorsToIndex": "_"
+  }
   "nb_hits": 4317
 }

--- a/configs/nuance-mix.json
+++ b/configs/nuance-mix.json
@@ -29,6 +29,6 @@
   ],
   "custom_settings": {
     "separatorsToIndex": "_"
-  }
+  },
   "nb_hits": 4317
 }


### PR DESCRIPTION
Some of the doc sections are not linked to from the main page, so they are not showing in the results. Adding them to the start_urls section.

Also removed an older version we don't want to see and added a setting so that field names (such as asr_result) get picked up correctly. 