### PR TITLE
Move back `scoop-docs`

### DIFF
--- a/configs/scoop-docs.json
+++ b/configs/scoop-docs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "scoop-docs",
   "start_urls": [
-    "https://scoop-docs.netlify.app/docs/"
+    "https://scoop-docs.now.sh/docs/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Revert #1660
Due to various reasons, I'm migrating Scoop Docs back to `now.sh`.