### PR TITLE
Update scapp_ecdocs.json

### DIFF
--- a/configs/scapp_ecdocs.json
+++ b/configs/scapp_ecdocs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "scapp_ecdocs",
   "start_urls": [
-    "https://ecdocs-vuepress.scapp.io/"
+    "https://docs.entcloud.swisscom.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)
Our URL of the documentation changed slightly.

### What is the current behaviour?
Crawls https://ecdocs-vuepress.scapp.io/

### What is the expected behaviour?
Should crawl https://docs.entcloud.swisscom.com/
