### PR TITLE
Lambda Powertools config - Update stop URL key

### DIFF
--- a/configs/aws-lambda-powertools-python.json
+++ b/configs/aws-lambda-powertools-python.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://awslabs.github.io/aws-lambda-powertools-python"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://awslabs.github.io/aws-lambda-powertools-python/api"
+  ],
   "sitemap_urls": [
     "https://awslabs.github.io/aws-lambda-powertools-python/sitemap.xml"
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Prevent search results for any content under `/api` by updating `stop_url` .

### What is the current behaviour?

Searching for `metrics` currently shows both docs as well as API references: https://awslabs.github.io/aws-lambda-powertools-python

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

Searching for `metrics` shouldn't show any result that leads to `/api/*` ref. 

##### NB: Do you want to request a **feature** or report a **bug**?

Feature

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
