### PR TITLE
add stop_urls to stackery.json

### DIFF
--- a/configs/stackery.json
+++ b/configs/stackery.json
@@ -9,6 +9,8 @@
   "sitemap_alternate_links": true,
   "stop_urls": [
     "https://docs.stackery.io/docs/next",
+    "https://docs.stackery.io/docs/4.0.2",
+    "https://docs.stackery.io/docs/4.0.1",
     "https://docs.stackery.io/docs/4.0.0",
     "https://docs.stackery.io/docs/3.13.4",
     "https://docs.stackery.io/docs/3.12.2",


### PR DESCRIPTION
Exclude two more versioned URLs to our stop_urls as a stop-gap to unnecessary indexing while we work on a more permanent solution.

We're running over record limits on versioned docs via docusaurus that we don't need to have indexed. This PR is intended to exclude new versions while we work on a more permanent solution. 