### PR TITLE
Temporarily block new SDK reference sub-folder

### DIFF
--- a/configs/cloudinary.json
+++ b/configs/cloudinary.json
@@ -87,6 +87,7 @@
   ],
   "stop_urls": [
     "https://cloudinary.com/documentation/upload_widget_1",
+    "https://cloudinary.com/documentation/sdks/*",
     "\\?",
     "\\.txt$"
   ],


### PR DESCRIPTION
We are releasing a new SDK reference under the folder: documentation/sdks/php/....
(In the future, we'll release other SDK references under documentation/sdks/<language>/ )

The contents of this reference will be displayed in a separate tab from the main docs, and will have a different layout & CSS.

In order to properly handle this new content in our search, we'll need to define selector_keys for that output, and we'll also have to add some code so that any results from that reference will open in a new tab and not in the main doc page tab.

Until we are ready to do that, I think it's best that we just stop the crawler from crawling these subfolders at all.

