### PR TITLE
Update domain for Filecoin docs

### DIFF
--- a/configs/filecoin.json
+++ b/configs/filecoin.json
@@ -1,7 +1,7 @@
 {
   "index_name": "filecoin",
   "start_urls": [
-    "https://filecoin-docs.netlify.app/"
+    "https://docs.filecoin.io/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
This PR updates the domain for the Filecoin docs site.

# Pull request motivation(s)

Updating the domain for an existing DocSearch account

### What is the current behavior?

Indexing at our old URL, filecoin-docs.netlify.app

### What is the expected behaviour?

Indexing our new URL, docs.filecoin.io


