### PR TITLE
Update hail_is.json

### DIFF
--- a/configs/hail_is.json
+++ b/configs/hail_is.json
@@ -12,7 +12,7 @@
     "lvl2": ".section h3",
     "lvl3": ".section h4",
     "lvl4": ".section h5",
-    "lvl5": ".section dl dt .descname",
+    "lvl5": ".section dl dt",
     "text": ".section p, .section li"
   },
   "strip_chars": " .,;:#",

--- a/configs/hail_is.json
+++ b/configs/hail_is.json
@@ -12,7 +12,7 @@
     "lvl2": ".section h3",
     "lvl3": ".section h4",
     "lvl4": ".section h5",
-    "lvl5": ".section h6",
+    "lvl5": ".section dl dt .descname",
     "text": ".section p, .section li"
   },
   "strip_chars": " .,;:#",


### PR DESCRIPTION
Attempt at indexing method names

We have sphinx doc structure that looks like this (you may check https://hail.is/docs/0.2/functions/index.html for more examples).
<img width="853" alt="Screenshot 2020-06-08 23 00 43" src="https://user-images.githubusercontent.com/5543229/84101455-fe716e00-a9db-11ea-8c5e-8d56c4f1266c.png">

Namely, in a .section, we may find

```
.section
   h1/h2/h3/h4
   dl
     dt
```
Children of `<dt>` contain the nearest anchor tag to the relevant results, most of the time.

Currently, the config only indexes the h1/h2/h3/h4, so matches always link to the nearest h1/h2/h3/h4, which reduces the relevance of the link. I would like to link to the nearest `dt`.

This config is untested; in particular, not sure if the selector should read `dl > dt` or the `dl > dt > .descname` (where the .descname element is the one that contains the method name; I think we want the selector that can be linked to via an id, which is `dt`)

### What is the current behaviour?

Links to relevant matches are to the nearest h1/h2/h3/h4

### What is the expected behaviour?

Should link to the nearest method block.

So for instance, instead of linking to https://hail.is/docs/0.2/hail.Table.html#Table when searching for something that matches "add_index", I want to link to https://hail.is/docs/0.2/hail.Table.html#hail.Table.add_index

##### NB: Do you want to request a **feature** or report a **bug**?

Feature
