### PR TITLE
Update demisto.json

### DIFF
--- a/configs/demisto.json
+++ b/configs/demisto.json
@@ -28,7 +28,8 @@
   "custom_settings": {
     "attributesForFaceting": [
       "anchor",
-      "hierarchy"
+      "hierarchy",
+      "type"
     ]
   },
   "conversation_id": [


### PR DESCRIPTION
Add `type` as an attribute for faceting.


# Pull request motivation(s)
Looking to filter search results by top-level hierarchy `lvl0`. Previously, it was possible to do this by filtering for anchor values matching `__docusaurus`. Since the indexer was changed, this is not possible anymore. However, there is an attribute named `type` which should allow for us to filter results in this way again.

### What is the current behaviour?

Currently results for all hierarchies are returned, including subheadings.

### What is the expected behaviour?

We want only results returned for `lvl0` (no subheadings).

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
