### PR TITLE
Add Proper Sitemap Path to Prysmatic Labs' Prysm

### DIFF
--- a/configs/prysmaticlabs_prysm.json
+++ b/configs/prysmaticlabs_prysm.json
@@ -4,7 +4,7 @@
     "https://docs.prylabs.network/docs/getting-started.html"
   ],
   "sitemap_urls": [
-    "https://docs.prylabs.network/docs/sitemap.xml"
+    "https://docs.prylabs.network/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
This adds a proper sitemap path to Prysmatic Labs' Prysm documentation portal docsearch entry

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Update https://docs.prylabs.network/docs/sitemap.xml to https://docs.prylabs.network/sitemap.xml for a docsearch config for Prysmatic Labs' Prysm

### What is the current behaviour?

Currently, there is no sitemap at https://docs.prylabs.network/docs/sitemap.xml

### What is the expected behaviour?

There is no sitemap entry at https://docs.prylabs.network/docs/sitemap.xml. We are in the process of pushing up a new sitemap to https://docs.prylabs.network/sitemap.xml instead.

##### NB: Do you want to request a **feature** or report a **bug**?


