### PR TITLE
Update hail_is.json

### DIFF
--- a/configs/hail_is.json
+++ b/configs/hail_is.json
@@ -9,6 +9,7 @@
   "stop_urls": [
     "https://hail.is/docs/0.2/change_log.html",
     "https://hail.is/docs/0.2/index.html",
+    "https://hail.is/docs/0.2/#contents",
     "/_",
     "\\?"
   ],


### PR DESCRIPTION
# Pull request motivation(s)

Don't index https://hail.is/docs/0.2/#contents; it's index.html by another address.

### What is the current behaviour?

Indexing https://hail.is/docs/0.2/#contents

### What is the expected behaviour?

Not indexing https://hail.is/docs/0.2/#contents

##### NB: Do you want to request a **feature** or report a **bug**?
Feature

##### NB2: Any other feedback / questions ?

