### PR TITLE
Update custom faceting attributes

### DIFF
--- a/configs/prometheus.json
+++ b/configs/prometheus.json
@@ -15,7 +15,7 @@
   },
   "custom_settings": {
     "attributesForFaceting": [
-      "prometheus-version"
+      "prometheus-version", "include"
     ]
   },
   "selectors_exclude": [


### PR DESCRIPTION
We want to use the "include" facet (generated by meta tags) for deciding which pages to include in the search index.
The "prometheus-version" tag needs to be kept for the transition, but can be removed later, once we switch the site to using "include"
(after it is indexed).