### PR TITLE
Add /misc/ paths to STOP_URLS

### DIFF
--- a/configs/scapp_ecdocs.json
+++ b/configs/scapp_ecdocs.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://docs.entcloud.swisscom.com/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "^.*\/misc\/.*$"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "p.sidebar-heading.open",


### PR DESCRIPTION

# Pull request motivation(s)

Added /misc/ paths to STOP_URLS by adding the regexp ^.*\/misc\/.*$

### What is the current behaviour?

Paths in /misc/ might be crawled if the cralwer finds a link to them.

### What is the expected behaviour?

We want all paths below /misc/ to not appear in search.


