### PR TITLE
Remove support for beta version of Strapi.

### DIFF
--- a/configs/strapi.json
+++ b/configs/strapi.json
@@ -4,7 +4,8 @@
     "https://strapi.io/documentation/"
   ],
   "stop_urls": [
-    "https://strapi.io/documentation/3.0.0-alpha.x/"
+    "https://strapi.io/documentation/3.0.0-alpha.x/",
+    "https://strapi.io/documentation/3.0.0-beta.x/"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
I'm Jim CTO & Co-founder of Strapi. 
Since we released the stable version of Strapi, we don't want the beta docs anymore in the search results.
Thank you.

### What is the current behaviour?
The docs of the beta version is indexed.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
