### PR TITLE
Update sap-spartacus.json

### DIFF
--- a/configs/sap-spartacus.json
+++ b/configs/sap-spartacus.json
@@ -1,11 +1,11 @@
 {
   "index_name": "sap-spartacus",
   "start_urls": [
-    "https://sap.github.io/cloud-commerce-spartacus-storefront-docs/"
+    "https://sap.github.io/spartacus-docs-v1/"
   ],
   "stop_urls": [],
   "sitemap_urls": [
-    "https://sap.github.io/cloud-commerce-spartacus-storefront-docs/sitemap.xml"
+    "https://sap.github.io/spartacus-docs-v1/sitemap.xml"
   ],
   "selectors": {
     "lvl0": ".archive h1",


### PR DESCRIPTION
I am updating the URL for the site that the search script is pointing to.

I am not sure what URL I can attach that shows I'm a maintainer of this project. I have access to the following URLs, which show I'm a maintainer of both the old site the search was pointing to, and the new site I want to point to now, but I am not sure you will have access to these: 

- https://github.com/orgs/SAP/teams/cloud-commerce-spartacus-storefront-docs-admin/members
- https://github.com/orgs/SAP/teams/spartacus-docs-v1-admin/members

I've (obviously) never submitted a PR here before, so I apologize for not knowing the typical way of sharing information about my maintainer status of the site I'm requesting to make a change for...

If there is any further information that I can provide, please don't hesitate to let me know.
