### PR TITLE
Update hail_is.json

### DIFF
--- a/configs/hail_is.json
+++ b/configs/hail_is.json
@@ -24,7 +24,8 @@
   },
   "selectors_exclude": [
     ".viewcode-link",
-    ".headerlink"
+    ".headerlink",
+    ".admonition-title"
   ],
   "strip_chars": " .,;:#",
   "conversation_id": [


### PR DESCRIPTION

# Pull request motivation(s)
.admonition-title contains a generic "warning" or similar title; not relevant to documentation search

### What is the current behaviour?
.admonition-title content is indexed

### What is the expected behaviour?
Should not be

##### NB: Do you want to request a **feature** or report a **bug**?
Feature
##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
