### PR TITLE
Version 4.7 Docs Update

### DIFF
--- a/configs/tabulator.json
+++ b/configs/tabulator.json
@@ -1,7 +1,7 @@
 {
   "index_name": "tabulator",
   "start_urls": [
-    "http://tabulator.info/docs/4.6"
+    "http://tabulator.info/docs/4.7"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

A new version of the documentation for Tabulator has been released to go with the release of version 4.7 of the library. The search is currently pointing to the old docs for version 4.6

### What is the expected behaviour?

This update should point to the correct 4.7 version of the docs
