### PR TITLE
Fix start_urls for payid documentation

### DIFF
--- a/configs/payid.json
+++ b/configs/payid.json
@@ -1,8 +1,7 @@
 {
   "index_name": "payid",
   "start_urls": [
-    "https://docs.payid.org/docs/",
-    "https://docs.payid.org/docs/payid-overview"
+    "https://docs.payid.org/"
   ],
   "sitemap_urls": [
     "https://docs.payid.org/sitemap.xml"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
The documentation indexing has not been updating based on our new content so I investigated and realized we changed the start url of our project and that doesn't match the config here.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*
Search results are inaccurate to current content


### What is the expected behaviour?
Search results are accurate to new content

##### NB: Do you want to request a **feature** or report a **bug**?
No

##### NB2: Any other feedback / questions ?
Nope
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
