### PR TITLE
Update the Saleor config to match Docusaurus 2

### DIFF
--- a/configs/saleor.json
+++ b/configs/saleor.json
@@ -9,18 +9,13 @@
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
-    },
-    "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "lvl5": ".post h5",
-    "text": ".post article p, .post article li"
+    "lvl0": "header h1",
+    "lvl1": "article h2",
+    "lvl2": "article h3",
+    "lvl3": "article h4",
+    "lvl4": "article h5",
+    "lvl5": "article h6",
+    "text": "article p, article li"
   },
   "selectors_exclude": [
     ".hash-link"


### PR DESCRIPTION
# Pull request motivation(s)
Since we're (Saleor) using Docusaurus 2 now, I believe the search configs of the two should match.

### What is the current behaviour?

Currently, the page is not fully indexed.

### What is the expected behaviour?

The page being fully indexed.

##### NB: Do you want to request a **feature** or report a **bug**?

Neither, I'm updating the search config of a project.

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
