### PR TITLE
Update data-driven-forms.json to wait

### DIFF
--- a/configs/data-driven-forms.json
+++ b/configs/data-driven-forms.json
@@ -19,5 +19,5 @@
   ],
   "nb_hits": 3573,
   "js_render": true,
-  "js_wait": 2
+  "js_wait": 1
 }

--- a/configs/data-driven-forms.json
+++ b/configs/data-driven-forms.json
@@ -17,5 +17,7 @@
   "conversation_id": [
     "952910917"
   ],
-  "nb_hits": 3573
+  "nb_hits": 3573,
+  "js_render": true,
+  "js_wait": 2
 }


### PR DESCRIPTION
# Pull request motivation(s)

- DDF documentation page is based on next.js, most of pages are server-side rendered, however there are examples using query parameters to change the content of the page. The query parameter is not available on the first render in next.js so we have to wait until the page is updated.

### What is the current behaviour?

Algolia loads wrong data

### What is the expected behaviour?

Algolia should load updated data

cc @Hyperkid123