### PR TITLE
Update intuit_auto.json

### DIFF
--- a/configs/intuit_auto.json
+++ b/configs/intuit_auto.json
@@ -31,7 +31,8 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": ".sidebar-root .lvl0",
+        "selector": "//a[contains(@class, 'sidebar-active')][1]/preceding::p[contains(@class, 'lvl0')][1]",
+        "type": "xpath",
         "global": true,
         "default_value": "Documentation"
       },


### PR DESCRIPTION

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Match only 1 lvl0 heading

### What is the current behaviour?

After my last PR to many things are matching as the lvl0 selector. it matches all lvl0 headings, not just the active one

![Screen Shot 2020-07-06 at 8 56 33 AM](https://user-images.githubusercontent.com/1192452/86613539-9a07e700-bf66-11ea-8cc8-de8ff7b4139e.png)

### What is the expected behaviour?

each search result will match it's sidebar heading and only one of them
