### PR TITLE
Update flarum

### DIFF
--- a/configs/flarum.json
+++ b/configs/flarum.json
@@ -1,7 +1,7 @@
 {
   "index_name": "flarum",
   "start_urls": [
-    "https://flarum.org/docs/"
+    "https://docs.flarum.org/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Flarum docs has changed location from https://flarum.org/docs/ to https://docs.flarum.org

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Flarum Dev/Operations wanting to make sure that our docs continue to get crawled properly.

##### NB2: Any other feedback / questions ?
Thanks for providing this awesome service!