### PR TITLE
fix: wait for JavaScript render and use anchors

### DIFF
--- a/configs/eslint.json
+++ b/configs/eslint.json
@@ -51,6 +51,5 @@
   },
   "scrap_start_urls": false,
   "js_render": true,
-  "use_anchors": true,
   "nb_hits": 17888
 }

--- a/configs/eslint.json
+++ b/configs/eslint.json
@@ -50,5 +50,7 @@
     }
   },
   "scrap_start_urls": false,
+  "js_render": true,
+  "use_anchors": true,
   "nb_hits": 17888
 }


### PR DESCRIPTION
# Pull request motivation(s)

The goal of this PR is to indicate that the ESLint website renders anchor information at runtime, and for it to wait until JavaScript is done rendering before scraping the pages.

### What is the current behaviour?

The ESLint website uses JavaScript to generate anchors at runtime for headings. This results in DocSearch not currently indexing all anchors properly, and defaulting to `#top` (the header's id).

![Capture d’écran 2020-07-16 à 15 30 20](https://user-images.githubusercontent.com/5370675/87678166-e929f500-c77a-11ea-88d6-a3750ae6bea9.png)

### What is the expected behaviour?

DocSearch should wait until JavaScript is done executing, so that the HTML contains proper anchors for headings before scraping it.

cc @nzakas