### PR TITLE
Remove 🔗 character from index

### DIFF
--- a/configs/honeycomb.json
+++ b/configs/honeycomb.json
@@ -20,5 +20,6 @@
   "conversation_id": [
     "428594718"
   ],
+  "strip_chars": "🔗",    
   "nb_hits": 5327
 }


### PR DESCRIPTION
When we added link icons, these made it into the index.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->



<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Our site recently changed to use 🔗  as an anchor link. This is useful for users; not so much for search. Let's take it out! Heres' an example of how it looks today:

![image](https://user-images.githubusercontent.com/3173714/87833351-7ed98900-c83c-11ea-9ede-5e6831ac1c35.png)

### What is the current behaviour?

Current behavior previews the icon. We're able to hide it on the site by wrapping in a span <display=hidden> but that gets eaten by algolia

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

Don't render that icon. Easiest way is to just skip the character in our config

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
