### PR TITLE
Split documenation to 2 variants, added sitemaps

### DIFF
--- a/configs/payara.json
+++ b/configs/payara.json
@@ -7,7 +7,7 @@
   "sitemap_urls": [
     "http://docs.payara.fish/community/sitemap.xml",
     "http://docs.payara.fish/enterprise/sitemap.xml"
-  ]
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": "article h1",

--- a/configs/payara.json
+++ b/configs/payara.json
@@ -1,8 +1,13 @@
 {
   "index_name": "payara",
   "start_urls": [
-    "https://docs.payara.fish/"
+    "https://docs.payara.fish/community/",
+    "https://docs.payara.fish/enterprise/"
   ],
+  "sitemap_urls": [
+    "http://docs.payara.fish/community/sitemap.xml",
+    "http://docs.payara.fish/enterprise/sitemap.xml"
+  ]
   "stop_urls": [],
   "selectors": {
     "lvl0": "article h1",


### PR DESCRIPTION
Payara now has 2 variants of documentation, for 2 different Payara editions.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Payara has split the documentation to Community and Enterprise for 2 different editions. I'm a maintainer of Payara documentation (see https://github.com/payara/Payara-Community-Documentation/graphs/contributors). We also added sitemap generation for each edition by Antora.


##### NB2: Any other feedback / questions ?

We split the documentation a month ago, and the crawler indexed new versions in both editions correctly after a few days. After we released a new version of both editions last week, these new versions haven't been indexed in 4 days and we don't see any log in the Apache access log from Algolia crawler since 17th July (more than 6 days).