### PR TITLE
Change Qv2ray documentation domain to qv2ray.net

### DIFF
--- a/configs/qv2ray.json
+++ b/configs/qv2ray.json
@@ -1,7 +1,7 @@
 {
   "index_name": "qv2ray",
   "start_urls": [
-    "https://qv2ray.github.io/"
+    "https://qv2ray.net/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

Hello, recently we changed Qv2ray documentation domain to qv2ray.net. we'd like to update the DocSearch config to reflect the changes.