### PR TITLE
Update apache_camel.json

### DIFF
--- a/configs/apache_camel.json
+++ b/configs/apache_camel.json
@@ -49,31 +49,29 @@
   ],
   "selectors": {
     "default": {
-      "lvl0": {
-        "selector": "div.nav-panel-explore .version.is-current a",
-        "global": true,
-        "default_value": "Documentation"
-      },
-      "lvl1": "article h1",
-      "lvl2": "article h2",
-      "lvl3": "article h3",
+      "lvl0": "article h1",
+      "lvl1": "article h2",
+      "lvl2": "article h3",
       "text": "article p, article li"
     },
     "antora-pages": {
-      "lvl0": "div.nav-panel-explore .version.is-current a",
-      "lvl1": "div.toolbar ul li:nth-child(1) a",
-      "lvl2": "div.toolbar ul li:nth-child(2) a",
-      "lvl3": "div.toolbar ul li:nth-child(3) a",
-      "lvl4": "div.toolbar ul li:nth-child(4) a",
-      "lvl5": "article h2",
-      "lvl6": "article h3",
+      "lvl0": "div.toolbar ul li:nth-child(1) a",
+      "lvl1": "div.toolbar ul li:nth-child(2) a",
+      "lvl2": "div.toolbar ul li:nth-child(3) a",
+      "lvl3": "div.toolbar ul li:nth-child(4) a",
+      "lvl4": "article h2",
+      "lvl5": "article h3",
+      "lvl6": {
+        "selector": "div.version-menu a.version.is-current",
+        "global": true
+      },
       "text": "article p, article li"
     },
     "blog": {
       "lvl0": {
-        "selector": "div.nav-panel-explore .version.is-current a",
-        "global": true,
-        "default_value": "Blog"
+        "selector": "",
+        "default_value": "Blog",
+        "global": true
       },
       "lvl1": "header a.category:nth-child(1)",
       "lvl2": "header a.category:nth-child(2)",


### PR DESCRIPTION
# Pull request motivation(s)

- We use our own UI for presenting search results, so we had created our config file accordingly. [This commit](https://github.com/algolia/docsearch-configs/commit/77634d58dab0f46f7dfc020a7b7fae1e9b390fe2#diff-a63c497e1db6a7dcc07ef35536d19967) makes our config file a lot more structured, but it interferes with our UI a little. I've understood the motivation behind this commit and am hence making the following changes to improve our config file, while also keeping in mind our custom UI.

### What is the current behaviour?

- We had reserved lvl0 for "version numbers", but in case of "blogs" and default selectors, we are getting "blogs/documentation" as lvl0. I have changed lvl6 to reflect "versions", since only "algolia-pages" selector will have versions. For the rest, I have taken the changes from [this commit](https://github.com/algolia/docsearch-configs/commit/77634d58dab0f46f7dfc020a7b7fae1e9b390fe2#diff-a63c497e1db6a7dcc07ef35536d19967) into account.

### What is the expected behaviour?

- Versions, if present, should be displayed separately on the right side. For this, we want to reserve one level for extracting versions, and check if it's null or not from UI code.

##### NB: Do you want to request a **feature** or report a **bug**?

- No. We just want to improve our config file with these changes.
 
##### NB2: Any other feedback / questions ?

- No.


