### PR TITLE
Update Triton Documentation start url

### DIFF
--- a/configs/tritonmc_triton.json
+++ b/configs/tritonmc_triton.json
@@ -1,7 +1,7 @@
 {
   "index_name": "tritonmc_triton",
   "start_urls": [
-    "https://triton.rexcantor64.com/documentation"
+    "https://triton.rexcantor64.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
The documentation is no longer under a subdirectory

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
I am the maintainer of this project: https://github.com/tritonmc/triton-website/graphs/contributors

# Pull request motivation(s)
The URL of the project has changed

### What is the current behaviour?
Links from search now return 404
*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
