### PR TITLE
Add new Cloudflare Workers search index

### DIFF
--- a/configs/workers-cloudflare-v2.json
+++ b/configs/workers-cloudflare-v2.json
@@ -1,0 +1,15 @@
+{
+  "index_name": "workers-cloudflare-v2",
+  "start_urls": ["https://workers.cloudflaredocs.workers.dev"],
+  "stop_urls": [],
+  "sitemap_urls": ["https://workers.cloudflaredocs.workers.dev/sitemap.xml"],
+  "selectors": {
+    "lvl0": ".DocsContent h1",
+    "lvl1": ".DocsContent h2",
+    "lvl2": ".DocsContent h3",
+    "lvl3": ".DocsContent h4",
+    "lvl4": ".DocsContent h5",
+    "lvl5": ".DocsContent h6",
+    "text": ".DocsContent p, .DocsContent li"
+  }
+}

--- a/configs/workers-cloudflare-v2.json
+++ b/configs/workers-cloudflare-v2.json
@@ -1,8 +1,12 @@
 {
   "index_name": "workers-cloudflare-v2",
-  "start_urls": ["https://workers.cloudflaredocs.workers.dev"],
+  "start_urls": [
+    "https://workers.cloudflaredocs.workers.dev"
+  ],
   "stop_urls": [],
-  "sitemap_urls": ["https://workers.cloudflaredocs.workers.dev/sitemap.xml"],
+  "sitemap_urls": [
+    "https://workers.cloudflaredocs.workers.dev/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": ".DocsContent h1",
     "lvl1": ".DocsContent h2",
@@ -11,5 +15,8 @@
     "lvl4": ".DocsContent h5",
     "lvl5": ".DocsContent h6",
     "text": ".DocsContent p, .DocsContent li"
-  }
+  },
+  "conversation_id": [
+    "1253962701"
+  ]
 }

--- a/configs/workers-cloudflare.json
+++ b/configs/workers-cloudflare.json
@@ -1,14 +1,8 @@
 {
   "index_name": "workers-cloudflare",
-  "start_urls": [
-    "https://developers.cloudflare.com/workers"
-  ],
-  "stop_urls": [
-    "https://developers.cloudflare.com/workers/archive"
-  ],
-  "sitemap_urls": [
-    "https://developers.cloudflare.com/workers/sitemap.xml"
-  ],
+  "start_urls": ["https://developers.cloudflare.com/workers"],
+  "stop_urls": ["https://developers.cloudflare.com/workers/archive"],
+  "sitemap_urls": ["https://developers.cloudflare.com/workers/sitemap.xml"],
   "selectors": {
     "lvl0": "#body-inner h1",
     "lvl1": "#body-inner h2",
@@ -18,8 +12,6 @@
     "lvl5": "#body-inner h6",
     "text": "#body-inner p, #body-inner li"
   },
-  "conversation_id": [
-    "869270550"
-  ],
+  "conversation_id": ["869270550"],
   "nb_hits": 2716
 }

--- a/configs/workers-cloudflare.json
+++ b/configs/workers-cloudflare.json
@@ -1,8 +1,14 @@
 {
   "index_name": "workers-cloudflare",
-  "start_urls": ["https://developers.cloudflare.com/workers"],
-  "stop_urls": ["https://developers.cloudflare.com/workers/archive"],
-  "sitemap_urls": ["https://developers.cloudflare.com/workers/sitemap.xml"],
+  "start_urls": [
+    "https://developers.cloudflare.com/workers"
+  ],
+  "stop_urls": [
+    "https://developers.cloudflare.com/workers/archive"
+  ],
+  "sitemap_urls": [
+    "https://developers.cloudflare.com/workers/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": "#body-inner h1",
     "lvl1": "#body-inner h2",
@@ -12,6 +18,8 @@
     "lvl5": "#body-inner h6",
     "text": "#body-inner p, #body-inner li"
   },
-  "conversation_id": ["869270550"],
+  "conversation_id": [
+    "869270550"
+  ],
   "nb_hits": 2716
 }


### PR DESCRIPTION
Hi there! We're updating the Cloudflare Workers documentation this week, and will be replacing the existing URLs (https://developers.cloudflare.com/workers) with a totally new structure. 

This PR addresses that issue by making a new config/index, called `workers-cloudflare-v2`. We'll ultimately deprecate the current index, so I'll probably be back in a week or so to remove that file with another PR.

I'm unsure if we're allowed to add files without going through the submission flow on the site, but because we're planning to release our docs tomorrow, I'm hoping that this is OK!

cc-ing some of my coworkers to review this work – @adamschwartz @davidtsong @rita3ko