### PR TITLE
Add Zowe versions to search

### DIFF
--- a/configs/zowe.json
+++ b/configs/zowe.json
@@ -7,6 +7,8 @@
         "version": [
           "stable",
           "active-development",
+          "v1-14-x",
+          "v1-13-x",
           "v1-12-x",
           "v1-11-x",
           "v1-10-x",


### PR DESCRIPTION
Pull request motivation(s)
- Adds 2 new doc versions to the search crawler. We recently archived these versions and want them to be searchable. (project: https://github.com/zowe/docs-site) 
- I am a member of the Zowe Squad, maintaining the Zowe Doc Site https://github.com/orgs/zowe/teams/cli/members 

### What is the current behaviour?

v1.13.0 and v1.140 versions are not indexed for search. 

### What is the expected behaviour?

v1.13.0 and v1.140 versions should be indexed for search. 

