### PR TITLE
Add support for iOS and macOS API doc in PSPDFKit config

### DIFF
--- a/configs/pspdfkit.json
+++ b/configs/pspdfkit.json
@@ -23,11 +23,27 @@
         "kdoc"
       ],
       "selectors_key": "android"
+    },
+    {
+      "url": "https://pspdfkit.com/api/ios/",
+      "tags": [
+        "ios"
+      ],
+      "selectors_key": "ios"
+    },
+    {
+      "url": "https://pspdfkit.com/api/macos/",
+      "tags": [
+        "macos"
+      ],
+      "selectors_key": "macos"
     }
   ],
   "stop_urls": [
     "https://pspdfkit.com/api/android/javadoc/reference/packages.html",
-    "package-summary.html"
+    "package-summary.html",
+    "https://pspdfkit.com/api/ios/index.html",
+    "https://pspdfkit.com/api/macos/index.html"
   ],
   "selectors": {
     "default": {
@@ -53,11 +69,26 @@
       "lvl3": "#jd-content h4",
       "lvl4": "#jd-content h5",
       "text": "#jd-content p, #jd-content li"
+    },
+    "ios": {
+      "lvl0": ".main-content h1",
+      "lvl1": ".main-content h2",
+      "lvl2": ".main-content h3",
+      "lvl3": ".main-content .item .token",
+      "text": ".main-content p"
+    },
+    "macos": {
+      "lvl0": ".main-content h1",
+      "lvl1": ".main-content h2",
+      "lvl2": ".main-content h3",
+      "lvl3": ".main-content .item .token",
+      "text": ".main-content p"
     }
   },
   "selectors_exclude": [
     ".web-seealso-subsection",
-    ".web-seealso-list li"
+    ".web-seealso-list li",
+    ".main-content .aside-title"
   ],
   "conversation_id": [
     "665157930"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

This updates the PSPDFKit configuration file.

We want to add DocSearch support for our [iOS](https://pspdfkit.com/api/ios/) and [macOS](https://pspdfkit.com/api/macos/) API documentation.

This PR adds the new URLs next to our existing setup for Web and Android and sets up the proper selectors.