### PR TITLE
Add news pages to search index

### DIFF
--- a/configs/cakeissues.json
+++ b/configs/cakeissues.json
@@ -12,6 +12,10 @@
     {
       "url": "https://cakeissues.net/docs/",
       "page_rank": 5
+    },
+    {
+      "url": "https://cakeissues.net/news/",
+      "page_rank": 0
     }
   ],
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Add news sites to search index.

### What is the current behaviour?

News sites are not in search index

### What is the expected behaviour?

Content from news entries should be searchable

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
