### PR TITLE
Update mlflow.json to index dt tags

### DIFF
--- a/configs/mlflow.json
+++ b/configs/mlflow.json
@@ -13,7 +13,7 @@
   "selectors": {
     "lvl0": "[itemprop='articleBody'] h1",
     "lvl1": "[itemprop='articleBody'] h2",
-    "lvl2": "[itemprop='articleBody'] h3",
+    "lvl2": "[itemprop='articleBody'] dt, [itemprop='articleBody'] h3",
     "lvl3": "[itemprop='articleBody'] h4",
     "lvl4": "[itemprop='articleBody'] h5",
     "text": "[itemprop='articleBody'] p, [itemprop='articleBody'] li"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

`dt` tags are ignored in MLflow's search indexing. This hampers our documentation as it becomes difficult to find API references for functions and classes, which use are contained within `dt` tags. This similar to the approach taken by `requests3`.

### What is the expected behaviour?

Index `dt` tags, which is not happening right now.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
