### PR TITLE
Update CF workers docs URL

### DIFF
--- a/configs/cloudflare-workers-v2.json
+++ b/configs/cloudflare-workers-v2.json
@@ -1,11 +1,11 @@
 {
   "index_name": "cloudflare-workers-v2",
   "start_urls": [
-    "https://workers.cloudflaredocs.workers.dev"
+    "https://developers.cloudflare.com/workers"
   ],
   "stop_urls": [],
   "sitemap_urls": [
-    "https://workers.cloudflaredocs.workers.dev/sitemap.xml"
+    "https://developers.cloudflare.com/workers/sitemap.xml"
   ],
   "selectors": {
     "lvl0": ".DocsContent h1",


### PR DESCRIPTION
This PR updates the CF Workers docs URL as discussed in #2300 to our final production URL.

@s-pace I noticed that a version of this JSON config was moved into the `disabled` directory — would love to get this merged in before we potentially lose our search behavior!1