### PR TITLE
Remove dead link for QuestDB

### DIFF
--- a/configs/questdb.json
+++ b/configs/questdb.json
@@ -1,7 +1,6 @@
 {
   "index_name": "questdb",
   "start_urls": [
-    "https://questdb.io/docs/",
     "https://questdb.io/docs/introduction"
   ],
   "sitemap_urls": [


### PR DESCRIPTION
This PR removes a dead link "https://questdb.io/docs/".