### PR TITLE
Add sitemap URL

### DIFF
--- a/configs/upslide.json
+++ b/configs/upslide.json
@@ -19,5 +19,6 @@
   "conversation_id": [
     "1156149394"
   ],
-  "nb_hits": 4092
+  "nb_hits": 4092,
+  "sitemap_urls": ["https://support.upslide.net/hc/en-us/article_attachments/360015513240/sitemap.xml"]
 }


### PR DESCRIPTION
# Pull request motivation(s)
Zendesk articles are available through different URLs.
This causes the DocSearch to display duplicates in the search results
I'm hoping to fix this adding this sitemap with only one URL per article.
