### PR TITLE
Add stop url for release notes

### DIFF
--- a/configs/redislabs.json
+++ b/configs/redislabs.json
@@ -7,7 +7,7 @@
   "sitemap_urls": [
     "https://docs.redislabs.com/latest/sitemap.xml"
   ],
-  "stop_urls": [],
+  "stop_urls": ["release-notes\/.+\/?"],
   "selectors": {
     "lvl0": {
       "selector": ".menu .parent> a",


### PR DESCRIPTION



<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We need to remove the release notes pages from the search index. Thanks!

### What is the current behaviour?

Too many irrelevant results due to indexed release notes.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

We don't want release notes pages showing up. It's fine to allow the release notes landing page, which this regexp does not prevent.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
