### PR TITLE
MLflow - update python vs. R api ranking

### DIFF
--- a/configs/mlflow.json
+++ b/configs/mlflow.json
@@ -1,14 +1,28 @@
 {
   "index_name": "mlflow",
   "start_urls": [
-    "https://mlflow.org/docs/latest/",
-    "https://mlflow.org/docs/latest/index.html"
+    {
+      "url": "https://mlflow.org/docs/latest/index.html",
+    },
+    {
+      "url": "https://mlflow.org/docs/latest/",
+      "page_rank": 3
+    },
+    {
+      "url": "https://mlflow.org/docs/latest/python_api"
+      "page_rank": 2
+    },
+    {
+      "url": "https://mlflow.org/docs/latest/R-api.html",
+      "page_rank": 1
+    }
   ],
   "sitemap_urls": [
     "https://mlflow.org/sitemap.xml"
   ],
   "stop_urls": [
-    "/java_api/"
+    "/java_api/",
+    "/_modules/"
   ],
   "selectors": {
     "lvl0": "[itemprop='articleBody'] h1",


### PR DESCRIPTION
Move python API results up the ranking against R API results.
Additionally, stop indexing `/_modules/`, which link to source code pastes.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Python API results are always listed lower than R API results.

### What is the expected behaviour?

As use of the Python API is more common than use of the R API, we would like to re-order these.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
