### PR TITLE
Add Windows docs to PSPDFKit config

### DIFF
--- a/configs/pspdfkit.json
+++ b/configs/pspdfkit.json
@@ -37,13 +37,21 @@
         "macos"
       ],
       "selectors_key": "macos"
+    },
+    {
+      "url": "https://pspdfkit.com/api/windows/",
+      "tags": [
+        "windows"
+      ],
+      "selectors_key": "windows"
     }
   ],
   "stop_urls": [
     "https://pspdfkit.com/api/android/javadoc/reference/packages.html",
     "package-summary.html",
     "https://pspdfkit.com/api/ios/index.html",
-    "https://pspdfkit.com/api/macos/index.html"
+    "https://pspdfkit.com/api/macos/index.html",
+    "https://pspdfkit.com/api/windows/index.html"
   ],
   "selectors": {
     "default": {
@@ -80,6 +88,11 @@
       "lvl0": ".main-content h1",
       "lvl1": ".main-content h3",
       "lvl2": ".main-content .item .token",
+      "text": ".main-content p"
+    },
+    "windows": {
+      "lvl0": ".main-content h1",
+      "lvl1": ".main-content h4",
       "text": ".main-content p"
     }
   },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Adding support for our [Windows docs](https://pspdfkit.com/api/windows/) to the PSPDFKit configuration file.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
