### PR TITLE
Add new facetFilter

### DIFF
--- a/configs/tribeserver.json
+++ b/configs/tribeserver.json
@@ -26,7 +26,7 @@
   ],
   "custom_settings": {
     "attributesForFaceting": [
-      "lang"
+      "lang", "location"
     ]
   },
   "strip_chars": " .,;:#",


### PR DESCRIPTION
Hi Sylvain,
After the last changes, I could see the search results were populated. Thanks.
I want to try facet filtering on an attribute, "location". I've added a meta tag to each page:
<meta name="docsearch:location" content="coventry-university-group,cu-coventry,coventry-university">
I'll need to add this to the facetFilters in the search component - but is there anything else I need to do to make this work?
Thanks
Rich