### PR TITLE
fix: doc website not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ DocSearch is made of 3 repositories:
   a Docker image
 
 
-[1]: https://docsearch.algolia.com/docs/
+[1]: https://docsearch.algolia.com/
 [2]: https://docsearch.algolia.com/docs/config-file
 [3]: https://github.com/algolia/docsearch
 [4]: https://github.com/algolia/docsearch-configs


### PR DESCRIPTION
The main website documentation return page not found  [https://docsearch.algolia.com/docs](https://docsearch.algolia.com/docs), I believe that the correct page should be [https://docsearch.algolia.com/](https://docsearch.algolia.com/)
