### PR TITLE
Tabulator Version 4.7 Docs Update

### DIFF
--- a/configs/tabulator.json
+++ b/configs/tabulator.json
@@ -1,7 +1,7 @@
 {
   "index_name": "tabulator",
   "start_urls": [
-    "http://tabulator.info/docs/4.7"
+    "http://tabulator.info/docs/4.8"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
# Pull request motivation(s)


### What is the current behaviour?

A new version of the documentation for Tabulator has been released to go with the release of version 4.8 of the library. The search is currently pointing to the old docs for version 4.7

### What is the expected behaviour?

This update should point to the correct 4.8 version of the docs
