### PR TITLE
Update data-driven-forms to crawl all submenus

### DIFF
--- a/configs/data-driven-forms.json
+++ b/configs/data-driven-forms.json
@@ -2,7 +2,10 @@
   "index_name": "data-driven-forms",
   "start_urls": [
     "https://data-driven-forms.org/",
-    "https://data-driven-forms.org/renderer/development-setup"
+    "https://data-driven-forms.org/components/renderer",
+    "https://data-driven-forms.org/schema/introduction",
+    "https://data-driven-forms.org/hooks/use-field-api",
+    "https://data-driven-forms.org/mappers/custom-mapper"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
### Pull request motivation(s)

Data-driven-forms page is split into several sub menus, that you need first to open to see all the links.

### What is the current behaviour?

Algolia does does not open submenus, so it does not crawl all pages as submenus have to be opened to reveal all links.

### What is the expected behaviour?

Page automatically opens a submenu when users hit some page from that section, so each one of starts url should start with different submenus opened and the whole page should be covered.