### PR TITLE
Ignore mappers/<component> with no query set

### DIFF
--- a/configs/data-driven-forms.json
+++ b/configs/data-driven-forms.json
@@ -7,7 +7,24 @@
     "https://data-driven-forms.org/hooks/use-field-api",
     "https://data-driven-forms.org/mappers/custom-mapper"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://data-driven-forms.org/mappers/checkbox(?!\\?)",
+    "https://data-driven-forms.org/mappers/checkbox-multiple(?!\\?)",
+    "https://data-driven-forms.org/mappers/date-picker(?!\\?)",
+    "https://data-driven-forms.org/mappers/dual-list-select(?!\\?)",
+    "https://data-driven-forms.org/mappers/field-array(?!\\?)",
+    "https://data-driven-forms.org/mappers/plain-text(?!\\?)",
+    "https://data-driven-forms.org/mappers/radio(?!\\?)",
+    "https://data-driven-forms.org/mappers/select(?!\\?)",
+    "https://data-driven-forms.org/mappers/slider(?!\\?)",
+    "https://data-driven-forms.org/mappers/sub-form(?!\\?)",
+    "https://data-driven-forms.org/mappers/switch(?!\\?)",
+    "https://data-driven-forms.org/mappers/tabs(?!\\?)",
+    "https://data-driven-forms.org/mappers/textarea(?!\\?)",
+    "https://data-driven-forms.org/mappers/text-field(?!\\?)",
+    "https://data-driven-forms.org/mappers/time-picker(?!\\?)",
+    "https://data-driven-forms.org/mappers/wizard(?!\\?)"
+  ],
   "selectors": {
     "lvl0": ".DocSearch-content h1",
     "lvl1": ".DocSearch-content h2",


### PR DESCRIPTION
# Pull request motivation(s)

Data-driven-forms documentation site contains `/mappers/component?mapper=mui` etc. pages with several options that can be set in `?mapper` query. However, Algolia was accessing `/mappers/component` page with no query set, so default results were duplicated:

![image](https://user-images.githubusercontent.com/32869456/92377176-08eaf300-f104-11ea-92f7-b4132b829953.png)

The first result is leading to `/mappers/component` and the second is leading to `/mappers/component?mapper=mui` but it's the same page.

This PR adds these pages (mappers with no query) to the `stop_urls` list to prevent indexing them.

### What is the current behaviour?

Results are duplicated.

### What is the expected behaviour?

Results should not be duplicated.

Tested locally:

![image](https://user-images.githubusercontent.com/32869456/92377720-e0172d80-f104-11ea-93aa-8ab263515612.png)

---

_Note:_

I was trying to write this as 

```json
"stop_urls": [
   {
     "url": "https://data-driven-forms.org/mappers/(?P<component>)(?!\\?)",
     "variables": {
        "component": ["checkbox", "checkbox-multiple", "..." ]
     }
   }
]
```

But it lead to an error when tested locally:

```py
# ./docsearch run config.json 

  File "./docsearch", line 5, in <module>
    run()
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/src/index.py", line 161, in run
    exit(command.run(sys.argv[2:]))
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/src/commands/run_config.py", line 21, in run
    return run_config(args[0])
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/../scraper/src/index.py", line 33, in run_config
    config = ConfigLoader(config)
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/../scraper/src/config/config_loader.py", line 84, in __init__
    self._parse()
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/../scraper/src/config/config_loader.py", line 128, in _parse
    self.start_urls, self.stop_urls)
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/../scraper/src/config/urls_parser.py", line 128, in build_allowed_domains
    all_domains = [get_domain(_) for _ in all_urls]
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/../scraper/src/config/urls_parser.py", line 128, in <listcomp>
    all_domains = [get_domain(_) for _ in all_urls]
  File "/home/rvsianskz/driven-forms/docsearch-scraper/cli/../scraper/src/config/urls_parser.py", line 122, in get_domain
    return urlparse(url).netloc
  File "/usr/local/lib/python3.6/urllib/parse.py", line 367, in urlparse
    url, scheme, _coerce_result = _coerce_args(url, scheme)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 123, in _coerce_args
    return _decode_args(args) + (_encode_result,)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 107, in _decode_args
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 107, in <genexpr>
    return tuple(x.decode(encoding, errors) if x else '' for x in args)
AttributeError: 'collections.OrderedDict' object has no attribute 'decode'
```