### PR TITLE
Update selector for new layout

### DIFF
--- a/configs/testarchitect.json
+++ b/configs/testarchitect.json
@@ -9,12 +9,12 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": ".sectionBreadcrumb > a:first-child",
+      "selector": ".sectionBreadcrumb > a:first-of-type",
       "global": true,
       "default_value": "Documentation"
     },
     "lvl1": {
-      "selector": ".sectionBreadcrumb > a:last-child",
+      "selector": ".sectionBreadcrumb > a:last-of-type",
       "global": true,
       "default_value": "Documentation"
     },


### PR DESCRIPTION
An image for was added to the breadcrumb menu so the last-child now longs sees the final link. I've updated it to last-of-type to fix. I also changed it for first-of-type the lvl0 to avoid this happening again if there are any other similar changes.