### PR TITLE
Add additional start_urls for DITA-OT release notes

### DIFF
--- a/configs/dita-ot.json
+++ b/configs/dita-ot.json
@@ -1,7 +1,9 @@
 {
   "index_name": "dita-ot",
   "start_urls": [
-    "http://www.dita-ot.org/dev/"
+    "http://www.dita-ot.org/dev/",
+    "https://www.dita-ot.org/[0-9]\\.[0-9]/release-notes/",
+    "https://www.dita-ot.org/[0-9]\\.[0-9]/readme/changes/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Index the release notes from prior releases using regular expressions so that variables do need to be maintained or updated.

### What is the current behaviour?
Currently, only the `dev` branch of the documentation is indexed. Some content is only found in release notes of prior releases and this content should be indexed and findable as well.

### What is the expected behaviour?
The expected behavior is that after the release notes pages are indexed that content on those pages is findable and exposed through searches.

Signed-off by: Lief Erickson [lief.erickson@gmail.com](lief.erickson@gmail.com)
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->