### PR TITLE
Fix text index selector for ironcorelabs.com

### DIFF
--- a/configs/ironcorelabs.json
+++ b/configs/ironcorelabs.json
@@ -14,7 +14,7 @@
     "lvl3": "main > div h4",
     "lvl4": "main > div h5",
     "lvl5": "main > div h6",
-    "text": "main > div p, main > div li"
+    "text": "main > div p, main > div .para, main > div li"
   },
   "conversation_id": [
     "1205622950"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->
Most of the text in our docs are in `<div class="para"/>` blocks instead of `<p/>` blocks now.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

The Algolia index is likely missing a lot of the body text in the current version of the site.

### What is the current behaviour?

It is indexing `<p/>` tags for text content.

### What is the expected behaviour?

It should also index `<div class="para"/>` tags.

