### PR TITLE
Update MLflow search config

### DIFF
--- a/configs/mlflow.json
+++ b/configs/mlflow.json
@@ -2,18 +2,25 @@
   "index_name": "mlflow",
   "start_urls": [
     {
-      "url": "https://mlflow.org/docs/latest/R-api.html",
+      "url": "https://mlflow.org/docs/latest/rest-api.html",
       "page_rank": 1
     },
     {
-      "url": "https://mlflow.org/docs/latest/python_api",
+      "url": "https://mlflow.org/docs/latest/R-api.html",
       "page_rank": 2
     },
     {
-      "url": "https://mlflow.org/docs/latest/",
+      "url": "https://mlflow.org/docs/latest/python_api",
       "page_rank": 3
     },
-    "https://mlflow.org/docs/latest/index.html"
+    {
+      "url": "https://mlflow.org/docs/latest/",
+      "page_rank": 4
+    },
+    {
+      "url": "https://mlflow.org/docs/latest/index.html",
+      "page_rank": 5
+    }
   ],
   "sitemap_urls": [
     "https://mlflow.org/sitemap.xml"
@@ -24,8 +31,14 @@
   ],
   "selectors": {
     "lvl0": "[itemprop='articleBody'] h1",
-    "lvl1": "[itemprop='articleBody'] h2",
-    "lvl2": "[itemprop='articleBody'] dt, [itemprop='articleBody'] h3",
+    "lvl1": {
+      "selector": "//div[@itemprop='articleBody']/div[@id!='r-api' and @id!='rest-api']//h2",
+      "type": "xpath"
+    },
+    "lvl2": {
+      "selector": "//div[@itemprop='articleBody']/div[@id='r-api' or @id='rest-api']//h2 | //div[@itemprop='articleBody']//dt | //div[@itemprop='articleBody']//h3",
+      "type": "xpath"
+    },
     "lvl3": "[itemprop='articleBody'] h4",
     "lvl4": "[itemprop='articleBody'] h5",
     "text": "[itemprop='articleBody'] p, [itemprop='articleBody'] li"
@@ -33,5 +46,5 @@
   "conversation_id": [
     "576106937"
   ],
-  "nb_hits": 7662
+  "nb_hits": 4771
 }


### PR DESCRIPTION
We are updating our search config to differentiate between the `h2` tags on our R API and REST API pages, and the `h2` tags on all other pages. The former should be equally weighted with `dt` and `h3` tags, and the latter should take priority.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Currently, `h2` tags in the R API and REST API pages take priority despite the page-rank setup, because the `h2` selector level is higher than the `dt` and `h3` tags, which correspond to the docstrings from the Python API (which should always be first).

### What is the expected behaviour?

`h2` tags from R/REST APIs be treated equally to `dt`, `h3` from Python API; all other `h2`s take precedence

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
