### PR TITLE
update expo to use sitemap

### DIFF
--- a/configs/expo.json
+++ b/configs/expo.json
@@ -3,6 +3,9 @@
   "start_urls": [
     "https://docs.expo.io/"
   ],
+  "sitemap_urls": [
+    "https://docs.expo.io/sitemap.xml"
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We were having some issues with the crawlers, we implemented a sitemap with all pages available. That should help indexing everything again 😄 


### What is the current behaviour?

All pages under `/versions/**` aren't indexed, with the exception for `/versions/latest/**` (because we link to this version from the other indexed pages)

### What is the expected behaviour?

The sitemap should provide the crawler with all paths it should index.

##### NB: Do you want to request a **feature** or report a **bug**?

It's a bugfix 😄 

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

Is there a way to add the sitemap's `<priority>` tags to the indexed pages, under the `weight.page_rank` for example? With that we should be able to fine tune our search results even more! 😄 
