### PR TITLE
(commercetools): add new release note paths to stop_urls

### DIFF
--- a/configs/commercetools.json
+++ b/configs/commercetools.json
@@ -1,11 +1,11 @@
 {
   "index_name": "commercetools",
-  "start_urls": [
-    "https://docs.commercetools.com"
-  ],
+  "start_urls": ["https://docs.commercetools.com"],
   "sitemap_urls": [],
   "stop_urls": [
     "/release-notes",
+    ".*/releases$",
+    ".*/releases/.*",
     "/merchant-center-releases",
     ".html$"
   ],
@@ -21,11 +21,7 @@
     "lvl4": "article h4",
     "text": "article p, article li, article figure, article .lead"
   },
-  "selectors_exclude": [
-    "#toc"
-  ],
-  "conversation_id": [
-    "707863318"
-  ],
+  "selectors_exclude": ["#toc"],
+  "conversation_id": ["707863318"],
   "nb_hits": 12036
 }


### PR DESCRIPTION
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
**Pull request motivation(s)**
We are launching a new implementation of the site that will have changed paths of release notes to be excluded. This adds them.   The new site structure has multiple parts with own release notes so that the `/releases` path can have differing prefixes. 

"proof" that I am the maintainer?  https://www.linkedin.com/in/nikolauskuehn/   or https://github.com/nkuehn (part of the commercetools org) or the fact that I previously contributed to this config too. 

**Note**:  Some lines are just reformatting by prettier.  Would be nice to also accept that change to have less formatting collisions in the future. 