### PR TITLE
Update rasa docsearch

### DIFF
--- a/configs/rasa.json
+++ b/configs/rasa.json
@@ -32,13 +32,15 @@
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".main h1",
-    "lvl2": ".main h2",
-    "lvl3": ".main h3",
-    "lvl4": ".main h4",
-    "lvl5": ".main h5",
-    "text": ".main p, .main li"
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
+  "strip_chars": " .,;:#",
   "selectors_exclude": [
     ".announce-bar"
   ],

--- a/configs/rasa.json
+++ b/configs/rasa.json
@@ -14,6 +14,12 @@
       "tags": ["rasa-action-server"]
     }
   ],
+  "sitemap_urls": [
+    "https://rasa.com/docs/rasa/sitemap.xml",
+    "https://rasa.com/docs/rasa-x/sitemap.xml",
+    "https://rasa.com/docs/action-server/sitemap.xml"
+  ],
+  "sitemap_alternate_links": true,
   "stop_urls": [
     "http://rasa.com/docs/.*?/\\d",
     "http://rasa.com/docs/.*?/next",


### PR DESCRIPTION

# Pull request motivation(s)

Original PR: https://github.com/algolia/docsearch-configs/pull/2420

Hi there, my teammate @lunelson and I have been in contact with Sylvain via email to update [Rasa](https://rasa.com/)'s DocSearch index. We've updated our documentation from Sphinx to Docusaurus (v2, the future 🚀 ) and would like to configure an index for 3 different sites:
- https://rasa.com/docs/rasa
- https://rasa.com/docs/rasa-x
- https://rasa.com/docs/action-server

We've been told that we could use [custom tags](https://docsearch.algolia.com/docs/config-file/#using-custom-tags) to achieve this, so here is an attempt at updating our config. I'm preparing PRs on our end to update the frontend widget config to hit the right facet on the right site.

Can you let met know if my updates are right? (I don't have prior knowledge about DocSearch, but I know Algolia products a bit)