### PR TITLE
Update URL

### DIFF
--- a/configs/photosynq.json
+++ b/configs/photosynq.json
@@ -1,10 +1,10 @@
 {
   "index_name": "photosynq",
   "start_urls": [
-    "https://help.photosynq.org"
+    "https://help.photosynq.com"
   ],
   "sitemap_urls": [
-    "https://help.photosynq.org/sitemap.xml"
+    "https://help.photosynq.com/sitemap.xml"
   ],
   "stop_urls": [
     "/downloads/"


### PR DESCRIPTION
URL has changed from help.photosynq.org to help.photosynq.com