### PR TITLE
Add 1.15.0 release

### DIFF
--- a/configs/zowe.json
+++ b/configs/zowe.json
@@ -7,6 +7,7 @@
         "version": [
           "stable",
           "active-development",
+          "v1-15-x",
           "v1-14-x",
           "v1-13-x",
           "v1-12-x",


### PR DESCRIPTION
#Pull request motivation(s)

Let algolia crawl the newly-archived v1.15.0 Zowe documentation. 

### What is the current behaviour?

Crawls the stable version and older versions up to v1.14.0.



