### PR TITLE
Remove styling content from search results of Expo

### DIFF
--- a/configs/expo.json
+++ b/configs/expo.json
@@ -20,6 +20,9 @@
     "lvl5": "h5[data-heading=\"true\"]",
     "text": "p[data-text=\"true\"], div[data-text=\"true\"], ul[data-text=\"true\"], ol[data-text=\"true\"], blockquote[data-text=\"true\"], pre[data-text=\"true\"]"
   },
+  "selectors_exclude": [
+    "style"
+  ],
   "min_indexed_level": 1,
   "conversation_id": [
     "569512966"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We recently upgraded to Emotion v10, but we accidentally included the styling content in the search results.

### What is the current behaviour?

If you search for `keyboard` on [docs.expo.io](docs.expo.io), you get something like this:

![Screenshot 2020-09-28 at 21 06 00](https://user-images.githubusercontent.com/1203991/94474790-6b4c8600-01ce-11eb-9449-adae40e4ea9c.png)


### What is the expected behaviour?

This should remove the extraneous content.


##### NB: Do you want to request a **feature** or report a **bug**?

A bug


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
