### PR TITLE
Add Windows tag back to PSPDFKit config

### DIFF
--- a/configs/pspdfkit.json
+++ b/configs/pspdfkit.json
@@ -37,6 +37,13 @@
         "macos"
       ],
       "selectors_key": "macos"
+    },
+    {
+      "url": "https://pspdfkit.com/api/windows/",
+      "tags": [
+        "windows"
+      ],
+      "selectors_key": "windows"
     }
   ],
   "stop_urls": [
@@ -44,7 +51,7 @@
     "package-summary.html",
     "https://pspdfkit.com/api/ios/index.html",
     "https://pspdfkit.com/api/macos/index.html",
-    "https://pspdfkit.com/api/windows/"
+    "https://pspdfkit.com/api/windows/index.html"
   ],
   "selectors": {
     "default": {
@@ -81,6 +88,12 @@
       "lvl0": ".main-content h1",
       "lvl1": ".main-content h3",
       "lvl2": ".main-content .item .token",
+      "text": ".main-content p"
+    },
+    "windows": {
+      "lvl0": ".main-content h1",
+      "lvl1": ".main-content h3",
+      "lvl2": ".main-content h4",
       "text": ".main-content p"
     }
   },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Adding the Windows docs back to the PSPDFKit config with a few improvements.

Not sure if this is the place, plus not a bug, but any suggestions as for the following scenario?

![image](https://user-images.githubusercontent.com/29930410/94495528-67b60080-01c8-11eb-9e27-74e873931881.png)

![image](https://user-images.githubusercontent.com/29930410/94495738-e4e17580-01c8-11eb-9ccb-587ceb5bd608.png)

Properties is taken at `"lvl1": ".main-content h3"`. Ideally our results would only be for `"lvl2": ".main-content h4"`, ie the actual properties. I couldn't figure out a way of having the `h3` not show itself. 

Don't think `min_indexed_level` makes sense here as we do want to have that level indexed, and it'd affect all of our current configs, which is not ideal as the html varies.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
