### PR TITLE
Update zumasys.json

### DIFF
--- a/configs/zumasys.json
+++ b/configs/zumasys.json
@@ -11,11 +11,11 @@
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".theme-default-content h2",
-    "lvl2": ".theme-default-content h3",
-    "lvl3": ".theme-default-content h4",
-    "lvl4": ".theme-default-content h5",
-    "lvl5": ".theme-default-content h6",
+    "lvl1": ".theme-default-content h1",
+    "lvl2": ".theme-default-content h2",
+    "lvl3": ".theme-default-content h3",
+    "lvl4": ".theme-default-content h4",
+    "lvl5": ".theme-default-content h5",
     "lang": {
       "selector": "/html/@lang",
       "type": "xpath",


### PR DESCRIPTION
Shifting the header associations as most of our docs follow a pattern where the h1 is the article/doc name
Example: https://docs.zumasys.com/jbase/jbc/for-iterator

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Purely looking to change the configuration for our docs.

### What is the current behaviour?

The `h1` tag is not being recognized as the label and it is instead defaulting to "Documentation" as specified in the config.

![image](https://user-images.githubusercontent.com/13155413/94594304-58719a00-023e-11eb-84f4-75a2fdf9175e.png)

### What is the expected behaviour?

We want to include the `h1` items as descriptive items within the search results so I'm assuming this change would get it done.

##### NB: Do you want to request a **feature** or report a **bug**?

N/A

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
