### PR TITLE
Update to smooch website

### DIFF
--- a/configs/smooch_v2.json
+++ b/configs/smooch_v2.json
@@ -1,10 +1,10 @@
 {
     "index_name": "smooch",
     "start_urls": [
-      "https://docs.smooch.io/guide/v1/",
+      "https://docs.smooch.io/guide/",
       "https://docs.smooch.io/faq/",
       {
-        "url": "https://docs.smooch.io/rest/v1/",
+        "url": "https://docs.smooch.io/rest/",
         "tags": [
           "api"
         ],
@@ -14,7 +14,10 @@
     "sitemap_urls": [
       "https://docs.smooch.io/sitemap.xml"
     ],
-    "stop_urls": [],
+    "stop_urls": [
+        "https://docs.smooch.io/guide/v1/",
+        "https://docs.smooch.io/rest/v1/"
+    ],
     "selectors": {
       "default": {
         "lvl0": ".markdown h1",
@@ -25,18 +28,12 @@
         "text": ".markdown p, .markdown li"
       },
       "api": {
-        "lvl0": {
-          "selector": "",
-          "global": true,
-          "default_value": "API"
-        },
-        "lvl1": ".content h1.section-header",
-        "lvl2": ".content h1",
-        "lvl3": ".content h2",
-        "lvl4": ".content h3",
-        "lvl5": ".content h4",
-        "lvl6": ".content table td:first-of-type",
-        "text": ".content p, .content li, .content table td:last-child"
+        "lvl0": ".api-content h1",
+        "lvl1": ".api-content h2",
+        "lvl2": ".api-content h3",
+        "lvl3": ".api-content h4",
+        "lvl4": ".api-content h5",
+        "text": ".redoc-markdown p, .redoc-markdown li"
       }
     },
     "selectors_exclude": [
@@ -48,4 +45,4 @@
       "558800630"
     ],
     "nb_hits": 5234
-  }
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->
The website is overgoing a makeover with the addition of v2 of the docs. This PR separates the search results into two: one for the v1 version of the documentation, and one for the v2. This change should ideally go live on Wednesday PM.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Search is the same for v1 and v2 versions of the documentation.

### What is the expected behaviour?
We want to seperate the search. When a user is on a v1 page, they will get a v1 search text, when on a v2 page, the search result will be for v2. 
