### PR TITLE
fix(rasa): Force crawling sitemap, bump nbHits

### DIFF
--- a/configs/rasa.json
+++ b/configs/rasa.json
@@ -20,6 +20,7 @@
     "https://rasa.com/docs/action-server/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
+  "force_sitemap_urls_crawling": true,
   "stop_urls": [
     "http://rasa.com/docs/.*?/\\d",
     "http://rasa.com/docs/.*?/next",
@@ -55,5 +56,5 @@
   "conversation_id": [
     "1024327491"
   ],
-  "nb_hits": 8731
+  "nb_hits": 13402
 }


### PR DESCRIPTION
# Pull request motivation(s)
Fixing Rasa's docs crawling.

### What is the current behaviour?

Crawling `rasa` only results in very few hits.

### What is the expected behaviour?

Getting all matching pages according to the config, most of which are coming from the sitemap.

##### NB: Do you want to request a **feature** or report a **bug**?
Bug (Fix)
