### PR TITLE
Update httpie.json to reflect docs URL change

### DIFF
--- a/configs/httpie.json
+++ b/configs/httpie.json
@@ -1,20 +1,17 @@
 {
   "index_name": "httpie",
-  "start_urls": [
-    "http://httpie.org/docs"
-  ],
-  "stop_urls": [
-    "http://httpie.org/docs/+"
-  ],
+  "start_urls": ["https://httpie.org/docs"],
+  "stop_urls": ["https://httpie.org/docs/"],
   "selectors": {
-    "lvl0": "#doc-wrap h2",
-    "lvl1": "#doc-wrap h3",
-    "lvl2": "#doc-wrap h4",
+    "lvl0": {
+      "selector": "",
+      "default_value": "Documentation"
+    },
+    "lvl1": "#doc-wrap h2",
+    "lvl2": "#doc-wrap h3",
+    "lvl3": "#doc-wrap h4",
     "text": "#doc-wrap p, #doc-wrap li, #doc-wrap .code-block"
   },
-  "js_render": true,
-  "conversation_id": [
-    "289903050"
-  ],
-  "nb_hits": 5030
+  "conversation_id": ["289903050"],
+  "nb_hits": 457
 }

--- a/configs/httpie.json
+++ b/configs/httpie.json
@@ -1,10 +1,10 @@
 {
   "index_name": "httpie",
   "start_urls": [
-    "http://httpie.org/doc"
+    "http://httpie.org/docs"
   ],
   "stop_urls": [
-    "http://httpie.org/doc/+"
+    "http://httpie.org/docs/+"
   ],
   "selectors": {
     "lvl0": "#doc-wrap h2",


### PR DESCRIPTION
# Pull request motivation(s)

HTTPie documentation has been moved from `httpie.org/doc` to `httpie.org/docs`.  

---

### What is the current behaviour?

After the URL change, `stop_urls` in the config are ignored, and all docs versions (`https://httpie.org/docs` + `https://httpie.org/docs/*`) are searched simultaneously:

<img width=350 src=https://user-images.githubusercontent.com/326885/95060686-e1834800-06fa-11eb-9f80-190c7d1807a3.png>

---

### What is the expected behaviour?

We want to search only in the latest stable version of the docs, which is exactly at `https://httpie.org/docs`
