### PR TITLE
Packet.com has moved to metal.equinix.com

### DIFF
--- a/configs/packet.json
+++ b/configs/packet.json
@@ -1,9 +1,8 @@
 {
   "index_name": "packet",
   "start_urls": [
-    "https://www.packet.com/developers/docs/",
-    "https://www.packet.com/developers/api/",
-    "https://www.packet.com/resources/guides/"
+    "https://metal.equinix.com/developers/docs/",
+    "https://metal.equinix.com/developers/api/",
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Packet was acquired by Equinix and we have relaunched under Equinix Metal at metal.equinix.com
