### PR TITLE
Adds the tsconfig reference to the typescript search db

### DIFF
--- a/configs/typescriptlang.json
+++ b/configs/typescriptlang.json
@@ -12,6 +12,10 @@
     {
       "url": "https://www.typescriptlang.org/docs/",
       "page_rank": 1
+    },
+    {
+      "url": "https://www.typescriptlang.org/tsconfig",
+      "page_rank": 2
     }
   ],
   "sitemap_urls": [


### PR DESCRIPTION
Hi folks, I'm trying to get the [TSConfig reference](https://www.typescriptlang.org/tsconfig/) added into the search, 

I wondered if I am doing something wrong here by explicitly adding it, but it shows in the sitemap and I made the DOM structure conform to the existing queries, and figure that maybe the page needs to be allow listed this way instead!