### PR TITLE
Bug: dunglas_mercure.json

### DIFF
--- a/configs/dunglas_mercure.json
+++ b/configs/dunglas_mercure.json
@@ -1,7 +1,7 @@
 {
   "index_name": "dunglas_mercure",
   "start_urls": [
-    "https://mercure.rocks/docs"
+    "https://mercure.rocks"
   ],
   "stop_urls": [],
   "selectors": {

--- a/configs/dunglas_mercure.json
+++ b/configs/dunglas_mercure.json
@@ -1,7 +1,12 @@
 {
   "index_name": "dunglas_mercure",
   "start_urls": [
-    "https://mercure.rocks"
+    {
+      "url": "https://mercure.rocks/docs"
+    },
+    {
+      "url": "https://mercure.rocks/spec"
+    }
   ],
   "stop_urls": [],
   "selectors": {
@@ -19,5 +24,5 @@
   "conversation_id": [
     "1229847392"
   ],
-  "nb_hits": 351
+  "nb_hits": 746
 }


### PR DESCRIPTION
"start_urls" not including the specification section of mercure's project . This part is accessible with the url: https://mercure.rocks/spec. At the moment, this section is not accessible for the crawler.
