### PR TITLE
Define page ranks for cakebuild.net

### DIFF
--- a/configs/cakebuild.json
+++ b/configs/cakebuild.json
@@ -6,35 +6,40 @@
       "selectors_key": "blog",
       "tags": [
         "blog"
-      ]
+      ],
+      "page_rank": -2
     },
     {
       "url": "https://cakebuild.net/docs/",
       "selectors_key": "docs",
       "tags": [
         "docs"
-      ]
+      ],
+      "page_rank": 5
     },
     {
       "url": "https://cakebuild.net/dsl/",
       "selectors_key": "dsl",
       "tags": [
         "dsl"
-      ]
+      ],
+      "page_rank": 2
     },
     {
       "url": "https://cakebuild.net/addins/",
       "selectors_key": "addins",
       "tags": [
         "addins"
-      ]
+      ],
+      "page_rank": -5
     },
     {
       "url": "https://cakebuild.net/faq/",
       "selectors_key": "faq",
       "tags": [
         "faq"
-      ]
+      ],
+      "page_rank": 0
     }
   ],
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Currently all parts of the page have the same priority. Ranking them improves search results.

### What is the current behaviour?
Ordering of search results ignores from which tag the result comes.

### What is the expected behaviour?
Search results from documentation should be priorized as it is the most up to date content. DSL is helpful to search for functionality. Blog should be fallback if results are not found somewhere else, since it might be outdated. Most results form addins probably are already returned by DSL, which is more helpful.

##### NB: Do you want to request a **feature** or report a **bug**?
Feature

##### NB2: Any other feedback / questions ?
Fixes https://github.com/cake-build/website/issues/1110