### PR TITLE
Added new start_url to Twenty57_linx config

### DIFF
--- a/configs/twenty57_linx.json
+++ b/configs/twenty57_linx.json
@@ -1,6 +1,7 @@
 {
   "index_name": "twenty57_linx",
   "start_urls": [
+    "https://linx.software/docs/full_index/",
     "https://linx.software/docs/"
   ],
   "stop_urls": [],


### PR DESCRIPTION
The new start_url contains a full menu.
We have optimised the menu on our site and now use JS to load only what needs to be shown in the menu (see second start_url). The indexer was therefor missing pages as they were not in the menu. 
The new start_url contains all pages in one menu for the crawler to follow. 

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
