### PR TITLE
Update assemblyscript.json

### DIFF
--- a/configs/assemblyscript.json
+++ b/configs/assemblyscript.json
@@ -1,7 +1,10 @@
 {
   "index_name": "assemblyscript",
   "start_urls": [
-    "https://assemblyscript.org/"
+    "https://www.assemblyscript.org/"
+  ],
+  "sitemap_urls": [
+    "https://www.assemblyscript.org/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

### What is the current behaviour?

Some pages are not being indexed as it seems. For example, searching for "Mandelbrot" does not find the respective [example](https://www.assemblyscript.org/examples.html#mandelbrot).

### What is the expected behaviour?

All pages should be indexed, and all content should be found.

### Proposed changes

* Updates the `start_urls` configuration entry to point to the `www.` subdomain instead of to the TLD, so it isn't a redirect anymore.
* Adds the `sitemap_urls` configuration entry so the crawler can more easily find all relevant content.
