### PR TITLE
[GitLab] Support indexing text inside codeblocks

### DIFF
--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -57,7 +57,7 @@
     "lvl2": ".article-content h3",
     "lvl3": ".article-content h4",
     "lvl4": ".article-content h5, .article-content td:first-child",
-    "text": ".article-content p, .article-content li, .article-content td:last-child"
+    "text": ".article-content p, .article-content li, .article-content td:last-child, .article-content pre.highlight code"
   },
   "stop_content": [
     "This document was moved to",

--- a/configs/gitlab.json
+++ b/configs/gitlab.json
@@ -50,7 +50,7 @@
   "sitemap_urls": [
     "https://docs.gitlab.com/sitemap.xml"
   ],
-  "force_sitemap_urls_crawling": "true",
+  "force_sitemap_urls_crawling": true,
   "selectors": {
     "lvl0": ".article-content h1",
     "lvl1": ".article-content h2",


### PR DESCRIPTION
# Pull request motivation(s)

This adds support for indexing text inside codeblocks fro the GitLab documentation.

Closes https://github.com/algolia/docsearch-configs/issues/2529.
