### PR TITLE
/addins has been moved to /extensions

### DIFF
--- a/configs/cakebuild.json
+++ b/configs/cakebuild.json
@@ -26,10 +26,10 @@
       "page_rank": 2
     },
     {
-      "url": "https://cakebuild.net/addins/",
-      "selectors_key": "addins",
+      "url": "https://cakebuild.net/extensions/",
+      "selectors_key": "extensions",
       "tags": [
-        "addins"
+        "extensions"
       ],
       "page_rank": -5
     }
@@ -69,10 +69,10 @@
       "lvl4": "div.content-wrapper .content h3",
       "text": "div.content-wrapper .content p, div.content-wrapper .content li"
     },
-    "addins": {
+    "extensions": {
       "lvl0": {
         "selector": "",
-        "default_value": "Addins"
+        "default_value": "Extensions"
       },
       "lvl1": "div.content-wrapper .content-header h1",
       "lvl2": "div.content-wrapper .content h1",


### PR DESCRIPTION
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
`/addin` has been moved to `/extensions` with https://github.com/cake-build/website/pull/1147

### What is the current behaviour?
`/addin` is index, but only contains a redirect to `/extensions` for the main site, while subsites aren't redirected.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
Instead of `/addin`, `/extensions` should be indexed.
