### PR TITLE
Update banuba.json

### DIFF
--- a/configs/banuba.json
+++ b/configs/banuba.json
@@ -1,7 +1,7 @@
 {
   "index_name": "banuba",
   "start_urls": [
-    "http://docs.banuba.com/docs/"
+    "http://docs.banuba.com/face-ar-sdk/"
   ],
   "sitemap_urls": [
     "http://docs.banuba.com/sitemap.xml"


### PR DESCRIPTION
# Pull request motivation(s)

http://docs.banuba.com/docs/ is renamed to http://docs.banuba.com/face-ar-sdk/ 

### What is the current behaviour?

Search results point to old urls (see screenshot above)

<img width="745" alt="Screen Shot 2020-10-23 at 2 36 51 PM" src="https://user-images.githubusercontent.com/3768221/96999267-94e29e00-153d-11eb-8e7e-3d106688728c.png">

### What is the expected behaviour?

Search results should point to new urls