### PR TITLE
update hummingbot.json config

### DIFF
--- a/configs/hummingbot.json
+++ b/configs/hummingbot.json
@@ -7,13 +7,13 @@
       "tags": ["docs"]
     },
     {
-      "url": "https://miner-docs.hummingbot.io/",
+      "url": "https://docs.hummingbot.io/miner",
       "selectors_key": "miner",
       "tags": ["miner"]
     }
   ],
   "sitemap_urls": ["https://docs.hummingbot.io/sitemap.xml"],
-  "stop_urls": ["/release-notes"],
+  "stop_urls": [""],
   "selectors": {
     "docs": {
       "lvl0": {

--- a/configs/hummingbot.json
+++ b/configs/hummingbot.json
@@ -13,7 +13,7 @@
     }
   ],
   "sitemap_urls": ["https://docs.hummingbot.io/sitemap.xml"],
-  "stop_urls": [""],
+  "stop_urls": [],
   "selectors": {
     "docs": {
       "lvl0": {


### PR DESCRIPTION
# Pull request motivation(s)

We have changed the routing of our documentation and need to update the search accordingly.

### What is the current behaviour?

1. We just configured doc search and it currently points to (1) https://docs.hummingbot.io and (2) **_https://miner-docs.hummingbot.io_**
2. By default, the search excluded release notes

### What is the expected behaviour?

1. We would like to change the **_https://miner-docs.hummingbot.io_** => **https://docs.hummingbot.io/miner**.  The second docs site is now in a folder of the main docs site
2. We would like to include the release notes in the search