### PR TITLE
update hummingbot.json

### DIFF
--- a/configs/hummingbot.json
+++ b/configs/hummingbot.json
@@ -7,12 +7,11 @@
       "tags": ["docs"]
     },
     {
-      "url": "https://docs.hummingbot.io/miner",
+      "url": "https://docs.hummingbot.io/miner/",
       "selectors_key": "miner",
       "tags": ["miner"]
     }
   ],
-  "sitemap_urls": ["https://docs.hummingbot.io/sitemap.xml"],
   "stop_urls": [],
   "selectors": {
     "docs": {


### PR DESCRIPTION
Some clean-up edits

# Pull request motivation(s)

Cleaning up the file

##### NB2: Any other feedback / questions ?

I don't think the edits will fix the problem we're having, but maybe the indexing/site cache needs to be reset?
We migrated the site 3 days ago, but seems like the search records are either not updated or there's something wrong with the indexing:

**Example 1)**

https://docs.hummingbot.io
Example search: `liquidity mining
One retrieved record: “What is liquidity mining”
URL fetched: https://docs.hummingbot.io/#what-is-liquidity-mining

It only shows the hash # reference, but does not return the full page address, which should be:
https://docs.hummingbot.io/ `intro/liquidity-mining/` #what-is-liquidity-mining

**Example 2)**

Example search: `paper_trade`
URL fetched: https://docs.hummingbot.io/operation/commands/paper-trade/ (old address)
URL it should fetch: https://docs.hummingbot.io/operation/command-ref/#paper_trade


Thank you