### PR TITLE
Move buf index from buf.build/docs to docs.buf.build

### DIFF
--- a/configs/buf.json
+++ b/configs/buf.json
@@ -1,10 +1,10 @@
 {
   "index_name": "buf",
   "start_urls": [
-    "https://buf.build/docs/"
+    "https://docs.buf.build/"
   ],
   "sitemap_urls": [
-    "https://buf.build/sitemap.xml"
+    "https://docs.buf.build/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
We have moved the documentation for buf from https://buf.build/docs to https://docs.buf.build - this updates the configuration as such. Thanks for your continued service here!