### PR TITLE
Add community section to search index

### DIFF
--- a/configs/cakebuild.json
+++ b/configs/cakebuild.json
@@ -32,6 +32,14 @@
         "extensions"
       ],
       "page_rank": -5
+    },
+    {
+      "url": "https://cakebuild.net/community/",
+      "selectors_key": "community",
+      "tags": [
+        "community"
+      ],
+      "page_rank": 0
     }
   ],
   "stop_urls": [],
@@ -73,6 +81,17 @@
       "lvl0": {
         "selector": "",
         "default_value": "Extensions"
+      },
+      "lvl1": "div.content-wrapper .content-header h1",
+      "lvl2": "div.content-wrapper .content h1",
+      "lvl3": "div.content-wrapper .content h2",
+      "lvl4": "div.content-wrapper .content h3",
+      "text": "div.content-wrapper .content p, div.content-wrapper .content li"
+    },
+    "extensions": {
+      "lvl0": {
+        "selector": "",
+        "default_value": "Community"
       },
       "lvl1": "div.content-wrapper .content-header h1",
       "lvl2": "div.content-wrapper .content h1",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Add community section which was added with https://github.com/cake-build/website/pull/1197 to search index.

### What is the current behaviour?

Community section is currently not part of the search index

### What is the expected behaviour?

Community section should be part of the search index.
