### PR TITLE
Preact: add language and version facets

### DIFF
--- a/configs/buf.json
+++ b/configs/buf.json
@@ -10,7 +10,7 @@
   "stop_urls": [],
   "selectors": {
      "lvl0": {
-      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "selector": "(//a[contains(@class, 'menu__link menu__link--active')]//ancestor::li/a/text())[last() - 1]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"

--- a/configs/preact.json
+++ b/configs/preact.json
@@ -4,14 +4,8 @@
     {
       "url": "https://preactjs.com/guide/(?P<version>.*?)/",
       "variables": {
-        "version": [
-          "v8",
-          "v10"
-        ],
-        "language": [
-          "en",
-          "ja"
-        ]
+        "version": ["v8", "v10"],
+        "language": ["en", "ja"]
       }
     }
   ],
@@ -33,17 +27,11 @@
       "default_value": "en-US"
     }
   },
-  "min_indexed_level": true,
   "js_render": true,
   "js_wait": 2,
   "custom_settings": {
-    "attributesForFaceting": [
-      "lang",
-      "version"
-    ]
+    "attributesForFaceting": ["lang", "version"]
   },
-  "conversation_id": [
-    "195298870"
-  ],
+  "conversation_id": ["195298870"],
   "nb_hits": 2679
 }

--- a/configs/preact.json
+++ b/configs/preact.json
@@ -2,25 +2,15 @@
   "index_name": "preact",
   "start_urls": [
     {
-      "url": "https://preactjs.com/guide/v(?P<version>.*?)/getting-started",
+      "url": "https://preactjs.com/guide/(?P<version>.*?)/",
       "variables": {
-        "language": "en",
         "version": [
-          "10",
-          "8"
-        ]
-      }
-    },
-    {
-      "url": "https://preactjs.com/guide/v(?P<version>.*?)/getting-started?lang=(?P<language>.*?)",
-      "variables": {
-        "language": {
-          "url": "https://aframe.io/docs/",
-          "js": "return JSON.stringify([].slice.call(document.querySelectorAll('footer select > option')).map(o => o.value))"
-        },
-        "version": [
-          "10",
-          "8"
+          "v8",
+          "v10"
+        ],
+        "language": [
+          "en",
+          "ja"
         ]
       }
     }
@@ -35,18 +25,25 @@
     "lvl3": "main h3",
     "lvl4": "main h4",
     "lvl5": "main h5",
-    "text": "main p, main li, main td"
+    "text": "main p, main li, main td",
+    "lang": {
+      "selector": "/html/@lang",
+      "type": "xpath",
+      "global": true,
+      "default_value": "en-US"
+    }
   },
   "min_indexed_level": true,
   "js_render": true,
+  "js_wait": 2,
   "custom_settings": {
     "attributesForFaceting": [
-      "language",
+      "lang",
       "version"
     ]
   },
   "conversation_id": [
     "195298870"
   ],
-  "nb_hits": 2327
+  "nb_hits": 2679
 }

--- a/configs/preact.json
+++ b/configs/preact.json
@@ -1,8 +1,29 @@
 {
   "index_name": "preact",
   "start_urls": [
-    "https://preactjs.com/guide",
-    "https://preactjs.com/guide/getting-started"
+    {
+      "url": "https://preactjs.com/guide/v(?P<version>.*?)/getting-started",
+      "variables": {
+        "language": "en",
+        "version": [
+          "10",
+          "8"
+        ]
+      }
+    },
+    {
+      "url": "https://preactjs.com/guide/v(?P<version>.*?)/getting-started?lang=(?P<language>.*?)",
+      "variables": {
+        "language": {
+          "url": "https://aframe.io/docs/",
+          "js": "return JSON.stringify([].slice.call(document.querySelectorAll('footer select > option')).map(o => o.value))"
+        },
+        "version": [
+          "10",
+          "8"
+        ]
+      }
+    }
   ],
   "selectors": {
     "lvl0": {
@@ -18,6 +39,12 @@
   },
   "min_indexed_level": true,
   "js_render": true,
+  "custom_settings": {
+    "attributesForFaceting": [
+      "language",
+      "version"
+    ]
+  },
   "conversation_id": [
     "195298870"
   ],


### PR DESCRIPTION
Currently, documentation results for Preact 8 and 10 are intermixed in results - I'm hoping this configuration addresses that, and brings search to the other languages.

I tried to based this off some of the other definitions from this repo, but I don't actually know if it is correct.

Fixes preactjs/preact-www#713.