### PR TITLE
holistics.json: Change start_urls to cover other sections

### DIFF
--- a/configs/holistics.json
+++ b/configs/holistics.json
@@ -7,7 +7,7 @@
     "https://docs.holistics.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
+  "stop_urls": ["/search/"],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",

--- a/configs/holistics.json
+++ b/configs/holistics.json
@@ -1,7 +1,7 @@
 {
   "index_name": "holistics",
   "start_urls": [
-    "https://docs.holistics.io/docs/"
+    "https://docs.holistics.io/"
   ],
   "sitemap_urls": [
     "https://docs.holistics.io/sitemap.xml"


### PR DESCRIPTION
One issue I face is that the index only crawled in the `/docs/` folder, whereas in our docs, we have 3 other sections that are also part of the document.

* https://docs.holistics.io/guides/
* https://docs.holistics.io/faqs/
* https://docs.holistics.io/api/

This PR changes the start_urls so that it will crawl through all the relevant sub-sections.