### PR TITLE
Update gmetri.json

### DIFF
--- a/configs/gmetri.json
+++ b/configs/gmetri.json
@@ -1,10 +1,10 @@
 {
   "index_name": "gmetri",
   "start_urls": [
-    "https://gmetri.com/docs/"
+    "https://docs.gmetri.com/"
   ],
   "sitemap_urls": [
-    "https://gmetri.com/sitemap.xml"
+    "https://docs.gmetri.com/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

At @gmetrixr and we recently shifted our docs from https://gmetri.com/docs to https://docs.gmetri.com
Changing this config to re-configure Algolia to work for our new domain.

#### What is the current behaviour?

The Algolia search points to the older domain of our docs.

#### What is the expected behaviour?

The Algolia search should start crawling docs.gmetri.com instead of gmetri.com/docs.
