### PR TITLE
Update wpgraphql.json

### DIFF
--- a/configs/wpgraphql.json
+++ b/configs/wpgraphql.json
@@ -10,6 +10,21 @@
       "url": "https://www.wpgraphql.com/developer-reference/",
       "tags": ["dev"],
       "selectors_key": "dev"
+    },
+    {
+      "url": "https://www.wpgraphql.com/actions/",
+      "tags": ["dev"],
+      "selectors_key": "dev"
+    },
+    {
+      "url": "https://www.wpgraphql.com/filters/",
+      "tags": ["dev"],
+      "selectors_key": "dev"
+    },
+    {
+      "url": "https://www.wpgraphql.com/functions/",
+      "tags": ["dev"],
+      "selectors_key": "dev"
     }
   ],
   "stop_urls": [],


### PR DESCRIPTION
Update config to include actions, filters and functions in the developer reference urls

# Pull request motivation(s)
Many pages of documentation for wpgraphq.com appear to not be included in the docsearch results. 

This update adds start pages for content under `/actions`, `/filters`, and `/functions`

### What is the current behaviour?

Current behavior is that Algolia searches for WPGraphQL.com don't include content from most of the developer reference documentation.

### What is the expected behaviour?

Actions, Filters and Functions should be returned in the results.


##### NB2: Any other feedback / questions ?

Am I allowed to also include the blog or does that break TOS for docsearch? The blog is used to update the community about releases and use cases for using the open source project. And could be helpful for users searching for things, such as breaking changes to a release, etc