### PR TITLE
Update WPGraphQL config

### DIFF
--- a/configs/wpgraphql.json
+++ b/configs/wpgraphql.json
@@ -7,6 +7,11 @@
       "selectors_key": "docs"
     },
     {
+      "url": "https://www.wpgraphql.com/extension-plugins/",
+      "tags": ["extensions"],
+      "selectors_key": "extensions"
+    },
+    {
       "url": "https://www.wpgraphql.com/developer-reference/",
       "tags": ["dev"],
       "selectors_key": "dev"
@@ -25,6 +30,11 @@
       "url": "https://www.wpgraphql.com/functions/",
       "tags": ["dev"],
       "selectors_key": "dev"
+    },
+    {
+      "url": "https://www.wpgraphql.com/recipes/",
+      "tags": ["dev"],
+      "selectors_key": "dev"
     }
   ],
   "stop_urls": [],
@@ -35,6 +45,16 @@
         "selector": "",
         "global": true,
         "default_value": "Documentation"
+      },
+      "lvl1": ".content h1",
+      "lvl2": ".content h2",
+      "text": ".content h3, .content p, .content li"
+    },
+    "extensions": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Extensions"
       },
       "lvl1": ".content h1",
       "lvl2": ".content h2",

--- a/configs/wpgraphql.json
+++ b/configs/wpgraphql.json
@@ -36,12 +36,9 @@
         "global": true,
         "default_value": "Documentation"
       },
-      "lvl2": ".content h1",
-      "lvl3": ".content h2",
-      "lvl4": ".content h3",
-      "lvl5": ".content h4",
-      "lvl6": ".content h5",
-      "text": ".content p, .content li"
+      "lvl1": ".content h1",
+      "lvl2": ".content h2",
+      "text": ".content h3, .content p, .content li"
     },
     "dev": {
       "lvl0": {
@@ -49,12 +46,9 @@
         "global": true,
         "default_value": "Developer Reference"
       },
-      "lvl2": ".content h1",
-      "lvl3": ".content h2",
-      "lvl4": ".content h3",
-      "lvl5": ".content h4",
-      "lvl6": ".content h5",
-      "text": ".content p, .content li"
+      "lvl1": ".content h1",
+      "lvl2": ".content h2",
+      "text": ".content h3, .content p, .content li"
     }
   },
   "custom_settings": {


### PR DESCRIPTION
**#1906 Pull request motivation(s):**

Update the selectors for wpgraphql.com and add additional start_urls

### What is the current behaviour?

Current behavior is showing "Documentation" as level 0, 1, and 2.

![Screen Shot 2020-11-19 at 2 54 16 PM](https://user-images.githubusercontent.com/1260765/99728738-1a8f3600-2a77-11eb-818b-3f4ef9bccd2e.png)

### What is the expected behaviour?

I expect to see different text for level 0, 1, 2. 

For example: 

**Documentation**
----
- {Article Title}
  - {section title (h2)}
    - {search text}
