### PR TITLE
Only index one of the nav elements

### DIFF
--- a/configs/laravel.json
+++ b/configs/laravel.json
@@ -26,13 +26,13 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//nav//*[contains(@class,'active')]/preceding::h2[1]",
+      "selector": "//*[@id='indexed-nav']//*[contains(@class,'active')]/preceding::h2[1]",
       "default_value": "Documentation",
       "type": "xpath",
       "global": true
     },
     "lvl1": {
-      "selector": "//nav//*[contains(@class,'active')]",
+      "selector": "//*[@id='indexed-nav']//*[contains(@class,'active')]",
       "default_value": "Chapter",
       "type": "xpath",
       "global": true


### PR DESCRIPTION
We rebuilt the laravel.com site and we now have two nav elements (one for mobile, one for desktop). This PR should make it so Algolia only indexes one of the nav elements instead of both.