### PR TITLE
update vee-validate v3 docs link

### DIFF
--- a/configs/vee-validate.json
+++ b/configs/vee-validate.json
@@ -1,7 +1,7 @@
 {
   "index_name": "vee-validate",
   "start_urls": [
-    "https://logaretm.github.io/vee-validate/"
+    "https://vee-validate.logaretm.com/v3/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
After tagging v4.0 the links of vee-validate docs have been moved to another domain.

This PR updates the link to the new documentation page