### PR TITLE
Update mikro-orm.json

### DIFF
--- a/configs/mikro-orm.json
+++ b/configs/mikro-orm.json
@@ -7,7 +7,9 @@
     "https://mikro-orm.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
+  "stop_urls": [
+    "https://mikro-orm.io/docs/api"
+  ],
   "selectors": {
     "lvl0": {
       "selector": ".menu__link--sublist.menu__link--active",


### PR DESCRIPTION
# Pull request motivation(s)

Do not index API docs.

##### NB2: Any other feedback / questions ?

I wanted to use regexp there to also handle versioned docs correctly, but i failed to find any example in the algolia docs. The only one about regexps is using fixed set of variables and their values - that totally beats the purpose of regexps, I don't want to adjust the configuration every time I realease new version... 

https://docsearch.algolia.com/docs/config-file/#using-regular-expressions

Would be great if anyone could suggest how this can be done without variables (allowing any version, not just one from the list).