### PR TITLE
add sitemap for https://socket.io

### DIFF
--- a/configs/socket_io.json
+++ b/configs/socket_io.json
@@ -3,6 +3,9 @@
   "start_urls": [
     "https://socket.io/docs/"
   ],
+  "sitemap_urls": [
+    "https://socket.io/sitemap.xml"
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": {
@@ -19,7 +22,7 @@
   "min_indexed_level": 1,
   "js_render": true,
   "strip_chars": " .,;:#",
-  "nb_hits": 674,
+  "nb_hits": 3000,
   "custom_settings": {
     "attributesForFaceting": ["language", "version"]
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Add a sitemap for the Socket.IO website: https://socket.io/sitemap.xml

### What is the current behaviour?

N/A

### What is the expected behaviour?

N/A

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

I also increased the `nb_hits` value, as it seems our latest updates were not reflected in the search.

From what I read here: https://docsearch.algolia.com/docs/config-file/#nb_hits-special

> nb_hits is updated automatically each time you run DocSearch on your config.

Is this the expected process?
