### PR TITLE
Update ory search config and problems with search index and empty results

### DIFF
--- a/configs/ory.json
+++ b/configs/ory.json
@@ -4,13 +4,7 @@
     {
       "url": "https://www.ory.sh/docs",
       "tags": [
-        "cloud"
-      ]
-    },
-    {
-      "url": "https://www.ory.sh/docs/ecosystem",
-      "tags": [
-        "ecosystem"
+        "docs"
       ]
     },
     {
@@ -53,26 +47,32 @@
     "https://www.ory.sh/.*?/docs/next"
   ],
   "selectors": {
-    "lvl0": "header h1",
-    "lvl1": "article h2",
-    "lvl2": "article h3",
-    "lvl3": "article h4",
-    "lvl4": "article h5",
-    "lvl5": "article h6",
+
+    "lvl0": {
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5",
     "text": "article p, article li, article code"
   },
   "conversation_id": [
     "704914956"
   ],
-  "strip_chars": " .,;:#",
-  "js_render": true,
+  "strip_chars": " .,;:#>",
   "custom_settings": {
     "separatorsToIndex": "_",
     "attributesForFaceting": [
-      "tags",
-      "version",
+      "docusaurus_tag",
       "language",
-      "docusaurus_tag"
+      "version",
+      "tags",
+      "type"
     ],
     "attributesToRetrieve": [
       "hierarchy",

--- a/configs/ory.json
+++ b/configs/ory.json
@@ -64,7 +64,7 @@
   "conversation_id": [
     "704914956"
   ],
-  "strip_chars": " .,;:#>",
+  "strip_chars": " .,;:#>'",
   "custom_settings": {
     "separatorsToIndex": "_",
     "attributesForFaceting": [


### PR DESCRIPTION
# Pull request motivation(s)

We are currently encountering several issues related to search when using docusaurus `2.0.0-alpha.69`.

**Search result previews are empty / `null`**

<img width="2672" alt="Bildschirmfoto 2020-11-25 um 15 24 59" src="https://user-images.githubusercontent.com/3372410/100240060-6b4cd600-2f32-11eb-98a7-f2ebcdb27f17.png">

This result happens without facet filters. For example, search for `login` on https://www.ory.sh/hydra/docs/5min-tutorial/. We have facet filters disabled on those subpages currently (due to another bug.. ;) )

**FacetFilters not working**

When adding facetFilters to the queries, the search results are simply empty. I checked the meta tags and they seem to be included so I am not sure what is happening. You can check this on: https://www.ory.sh/oathkeeper/docs/ (search for e.g. "access rule").

Here are the facetFilters we are using: `["language:en",["docusaurus_tag:default","docusaurus_tag:docs-default-v0.38"],["tags:oathkeeper","tags:docs"]]`

I believe the problem is the `docusaurus_tag` facets but they seem to be rendered correctly when I check the website's source.

### What is the current behaviour?

See above

### What is the expected behaviour?

We would expect snippets to show previews, and `docusaurus_tag` filters not to cause issues.

We hope that these changes to the index fix the problems mentioned but it is a lot of trial and error figuring out what's going on.

It would also be cool if there was some way of debugging this stuff faster and more efficient :)