### PR TITLE
pluralsight_design-system config to use new site build and sitemap

### DIFF
--- a/configs/pluralsight_design-system.json
+++ b/configs/pluralsight_design-system.json
@@ -1,23 +1,16 @@
 {
   "index_name": "pluralsight_design-system",
+  "sitemap_urls": ["https://design-system.pluralsight.com/sitemap.xml"],
   "start_urls": ["https://design-system.pluralsight.com/"],
   "stop_urls": [],
+  "selectors_exclude": ["nav"],
   "selectors": {
-    "lvl0": {
-      "selector": "//nav//*[contains(@class,'linkActive')]/preceding::*[contains(@class,'groupTitle')][1]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
-    },
-    "lvl1": {
-      "selector": "//nav//*[contains(@class,'linkActive')][1]",
-      "type": "xpath",
-      "global": true
-    },
-    "lvl2": "div.content h2",
-    "lvl3": "div.content h3, .content [role='cell']:first-child",
-    "lvl4": "div.content h4",
-    "text": "div.content p, .content li, .content [role='cell']:not(first-child)"
+    "lvl0": "main h1",
+    "lvl1": "main h2",
+    "lvl2": "main h3",
+    "lvl3": "main h4",
+    "lvl4": "main h5",
+    "text": "main p, main li, main [role='cell']:not(first-child)"
   },
   "conversation_id": ["1206797091"],
   "nb_hits": 1754


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
We rebuilt our site using Gatsby last month after its initial indexing. We've added a sitemap and hope this new config will kill dead links. 

### What is the current behaviour?

When searching dead links are persistent in our results and h1 are not receiving priority.

For example when searching dropdown the first result is Dropdown proptypes which no longer exist.
<img width="570" alt="Screen Shot 2020-11-25 at 11 21 17 AM" src="https://user-images.githubusercontent.com/1058725/100272734-7e4eae80-2f10-11eb-9b39-d36bc1a1dc7a.png">

### What is the expected behaviour?
Should return back just Dropdown: Dropdown a link to the page H1

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
