### PR TITLE
allow Gatsby to filter by hierarchy

### DIFF
--- a/configs/gatsbyjs.json
+++ b/configs/gatsbyjs.json
@@ -96,6 +96,12 @@
       "text": ".docSearch-content p, .docSearch-content li"
     }
   },
+  "custom_settings": {
+    "attributesForFaceting": [
+      "tags",
+      "hierarchy.lvl0"
+    ]
+  },
   "selectors_exclude": [
     "hr ~ div",
     "#next-steps",


### PR DESCRIPTION
# Pull request motivation(s)

Similar to what is described in this discourse thread (https://discourse.algolia.com/t/how-to-configure-a-new-facet/10776/3), we want to filter by hierarchy, eg, only show results from the docs when searching in the docs. It sounds like to do this we need to add this custom_settings key.

Thanks so much --