### PR TITLE
[yarn next] add tables to docsearch config

### DIFF
--- a/configs/yarnpkg_next.json
+++ b/configs/yarnpkg_next.json
@@ -16,7 +16,7 @@
     "lvl4": "article h4",
     "lvl5": "article h5",
     "lvl6": "article h6",
-    "text": "article p, article li"
+    "text": "article p, article li, article td"
   },
   "custom_settings": {
     "separatorsToIndex": "_",

--- a/configs/yarnpkg_next.json
+++ b/configs/yarnpkg_next.json
@@ -3,7 +3,10 @@
   "start_urls": [
     "https://yarnpkg.com/"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "/api/",
+    "/package/"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "header .active",
@@ -38,5 +41,5 @@
   "conversation_id": [
     "1113982325"
   ],
-  "nb_hits": 1939
+  "nb_hits": 2616
 }


### PR DESCRIPTION

# Pull request motivation(s)

fixes https://github.com/yarnpkg/berry/issues/2201


### What is the current behaviour?

the config doesn't allow content in tables to be searched

### What is the expected behaviour?

you can search in tables (like this comparison one)


##### NB: Do you want to request a **feature** or report a **bug**?

bug


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

when do I update the nbHits, in this PR or after it's been merged?