### PR TITLE
[Issue 2978] Fix search for Apache Pulsar website

### DIFF
--- a/configs/apache_pulsar.json
+++ b/configs/apache_pulsar.json
@@ -5,8 +5,10 @@
       "url": "https://pulsar.apache.org/docs/(?P<language>.*?)/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "2.6.1",
+          "2.7.0",
           "next",
+          "2.6.2",
+          "2.6.1",
           "2.6.0",
           "2.5.2",
           "2.5.1",


### PR DESCRIPTION
Fixes #2978 
# Pull request motivation(s)
1. The search does not work for Apache Pulsar doc 2.6.2 and 2.7.0 versions on https://pulsar.apache.org/docs/en/standalone/ 

### What is the current behaviour?
Nothing comes out on the research results.
![image](https://user-images.githubusercontent.com/47805623/101001734-7939d100-359a-11eb-9b91-3048e5a50cfc.png)

### What is the expected behaviour?
It should be sth like this.
![image](https://user-images.githubusercontent.com/47805623/101001802-8d7dce00-359a-11eb-886b-3ed796ecbf65.png)


##### NB: Do you want to request a **feature** or report a **bug**?
1. Do we need to add the version number here for each release?
2. Do we need additional configuration, so it would work better?
3. The search function does not work properly for some key words, how to solve it?

