### PR TITLE
config: fix Apache Camel documentation levels

### DIFF
--- a/configs/apache_camel.json
+++ b/configs/apache_camel.json
@@ -55,10 +55,10 @@
       "text": "article p, article li"
     },
     "antora-pages": {
-      "lvl0": "div.toolbar ul li:nth-child(1) a",
-      "lvl1": "div.toolbar ul li:nth-child(2) a",
-      "lvl2": "div.toolbar ul li:nth-child(3) a",
-      "lvl3": "div.toolbar ul li:nth-child(4) a",
+      "lvl0": ".breadcrumbs ul li:nth-child(1) a",
+      "lvl1": ".breadcrumbs ul li:nth-child(2) a",
+      "lvl2": ".breadcrumbs ul li:nth-child(3) a",
+      "lvl3": ".breadcrumbs ul li:nth-child(4) a",
       "lvl4": "article h2",
       "lvl5": "article h3",
       "lvl6": {


### PR DESCRIPTION
We changed the markup of the documentation, breadcrumbs element is no longer a `div` but rather a `nav`. To make the solution more portable with respect to these kinds of changes selector is changed to target by class name rather than by element.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

We're receiving `null` values for `lvl0`...`lvl3`.

### What is the expected behaviour?

We should be getting `lvl0`...`lvl3` values corresponding to the breadcrumbs element.

##### NB: Do you want to request a **feature** or report a **bug**?

This is a bug, search results are displayed as having _NULL_ headings.

##### NB2: Any other feedback / questions ?

I've contacted support, as I wasn't sure this was an issue we introduced by changing the markup, this should fix it.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
