### PR TITLE
Update transposit.json with stop_urls

### DIFF
--- a/configs/transposit.json
+++ b/configs/transposit.json
@@ -7,7 +7,9 @@
     "https://www.transposit.com/docs-sitemap.xml"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
+  "stop_urls": [
+    "^https:\/\/transposit\.com\/docs\/references\/connectors\/(?:[a-z0-9_]*)"
+  ],
   "selectors": {
     "lvl0": ".center [class*='w-75'] h1",
     "lvl1": ".center [class*='w-75'] h2",

--- a/configs/transposit.json
+++ b/configs/transposit.json
@@ -8,7 +8,7 @@
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [
-    "^https:\/\/transposit\.com\/docs\/references\/connectors\/(?:[a-z0-9_]*)"
+    "/docs/references/connectors/"
   ],
   "selectors": {
     "lvl0": ".center [class*='w-75'] h1",


### PR DESCRIPTION
# Pull request motivation(s)
Adding `stop_urls` regex for pages that are not relevant for Transposit user searches, creating a better search experience

### What is the expected behaviour?
No search results for pages that start with `https://transposit.com/docs/references/connectors/`
