### PR TITLE
Configure strip_chars for reflexjs

### DIFF
--- a/configs/reflexjs.json
+++ b/configs/reflexjs.json
@@ -19,6 +19,7 @@
   "selectors_exclude": [
     "main style"
   ],
+  "strip_chars": " .,;:#",
   "only_content_level": true,
   "conversation_id": [
     "1262412313"


### PR DESCRIPTION
### What is the current behaviour?

The site structure changed a bit and we're seeing # characters in the search results.

### What is the expected behaviour?

No # characters in search results.