### PR TITLE
Update avo.json

### DIFF
--- a/configs/avo.json
+++ b/configs/avo.json
@@ -1,5 +1,6 @@
 {
   "index_name": "avo",
+  "start_urls": [],
   "sitemap_urls": [
     "https://www.avo.app/docs/sitemap.xml"
   ],

--- a/configs/avo.json
+++ b/configs/avo.json
@@ -1,9 +1,5 @@
 {
   "index_name": "avo",
-  "start_urls": [
-    "https://www.avo.app/docs/"
-  ],
-  "stop_urls": [],
   "sitemap_urls": [
     "https://www.avo.app/docs/sitemap.xml"
   ],
@@ -19,5 +15,5 @@
   "conversation_id": [
     "1221281426"
   ],
-  "nb_hits": 650
+  "nb_hits": 1811
 }

--- a/configs/avo.json
+++ b/configs/avo.json
@@ -1,6 +1,6 @@
 {
   "index_name": "avo",
-  "start_urls": [],
+  "start_urls": ["https://www.avo.app"],
   "sitemap_urls": [
     "https://www.avo.app/docs/sitemap.xml"
   ],


### PR DESCRIPTION
Related to #3121 

I've tried removing `start_urls` and it picks up the sitemap when I run the crawler locally.