### PR TITLE
update standardnotes to match docusaurus-2

### DIFF
--- a/configs/standardnotes.json
+++ b/configs/standardnotes.json
@@ -1,31 +1,37 @@
 {
   "index_name": "standardnotes",
-  "start_urls": [
-    "https://docs.standardnotes.org/"
-  ],
-  "sitemap_urls": [
-    "https://docs.standardnotes.org/sitemap.xml"
-  ],
+  "start_urls": ["https://docs.standardnotes.org/"],
+  "sitemap_urls": ["https://docs.standardnotes.org/sitemap.xml"],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": ".menu__link--sublist.menu__link--active",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "[class^='docItemContainer_'] h1",
-    "lvl2": "[class^='docItemContainer_'] h2",
-    "lvl3": "[class^='docItemContainer_'] h3",
-    "lvl4": "[class^='docItemContainer_'] h4",
-    "lvl5": "[class^='docItemContainer_'] h5",
-    "text": "[class^='docItemContainer_'] p, [class^='docItemContainer_'] li"
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
-  "selectors_exclude": [
-    ".hash-link"
-  ],
-  "conversation_id": [
-    "1211718080"
-  ],
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": ["language", "version", "type", "docusaurus_tag"],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  },
+  "conversation_id": ["1211718080"],
   "nb_hits": 864
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

I would like to update [`standardnotes.json`](https://github.com/algolia/docsearch-configs/blob/master/configs/standardnotes.json) to match [`docusaurus-2.json`](https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json) to keep up with the latest developments of Docusaurus 2 as discussed in https://github.com/facebook/docusaurus/issues/3996.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

The current behavior does not produce results on [standardnotes.org/search](https://docs.standardnotes.org/search/?q=self) even though results appear in the popup that results from searching in the navbar:

![image](https://user-images.githubusercontent.com/22967798/103693887-dd133900-4f4e-11eb-943d-4bf735dcf1bf.png)

![image](https://user-images.githubusercontent.com/22967798/103693948-f916da80-4f4e-11eb-9de0-a0fe69e69b44.png)

### What is the expected behaviour?

The expected behavior is to have results appear on the /search page as on [Docusaurus 2's website](https://v2.docusaurus.io/search/?q=self).

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
