### PR TITLE
Update ligolang.json

### DIFF
--- a/configs/ligolang.json
+++ b/configs/ligolang.json
@@ -23,7 +23,17 @@
     "separatorsToIndex": "_",
     "attributesForFaceting": [
       "language",
-      "version"
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
     ]
   },
   "conversation_id": [


### PR DESCRIPTION
This is to get the Ligolang contextual search (which uses a recent Docusaurus 2) working properly, and aligns the custom_settings of ligolang with the one of docusaurus-2.
