### PR TITLE
Changing from http to https

### DIFF
--- a/configs/grocerycrud.json
+++ b/configs/grocerycrud.json
@@ -1,7 +1,7 @@
 {
   "index_name": "grocerycrud",
   "start_urls": [
-    "http://new.grocerycrud.com/"
+    "https://new.grocerycrud.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Changing the URL from http to https. The website has an installed SSL certificate so it is better to use the HTTPS URLs.

More specifically from:

https://new.grocerycrud.com/ 

to:

http://new.grocerycrud.com/