### PR TITLE
Fix plumierjs start url

### DIFF
--- a/configs/plumierjs.json
+++ b/configs/plumierjs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "plumierjs",
   "start_urls": [
-    "https://plumierjs.com/docs/"
+    "https://plumierjs.com"
   ],
   "sitemap_urls": [
     "https://plumierjs.com/sitemap.xml"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Plumier configuration start urls refer to [https://plumierjs.com/docs](https://plumierjs.com/docs) which is 404 now

### What is the expected behaviour?

The correct start url is [https://plumierjs.com](https://plumierjs.com)


<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
