### PR TITLE
API Platform: index docs of the new version

### DIFF
--- a/configs/api-platform.json
+++ b/configs/api-platform.json
@@ -5,7 +5,8 @@
       "url": "https://api-platform.com/docs/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "master",
+          "main",
+          "2.6",
           "2.5",
           "2.4",
           "2.3",


### PR DESCRIPTION
We released a new version of API Platform and renamed the `master` branch in `main`.