### PR TITLE
Update Bulma config to match new website markup

### DIFF
--- a/configs/bulma.json
+++ b/configs/bulma.json
@@ -6,16 +6,16 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": ".breadcrumb li:nth-child(3) a",
+      "selector": ".algolia-lvl0",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "header h1",
-    "lvl2": ".bd-content h3",
-    "lvl3": ".bd-content h4",
-    "lvl4": ".bd-content h5",
-    "lvl5": ".bd-content h6",
-    "text": ".bd-content p, .bd-content li, .bd-header-titles p"
+    "lvl1": ".algolia-lvl1",
+    "lvl2": ".algolia-content h3",
+    "lvl3": ".algolia-content h4",
+    "lvl4": ".algolia-content h5",
+    "lvl5": ".algolia-content h6",
+    "text": ".algolia-content p, .algolia-content li"
   },
   "strip_chars": " .,;:#",
   "conversation_id": [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

I've recently updated the Bulma website with new markup: https://bulma.io/
This PR updates the config to match this new markup.

### What is the current behaviour?

The config doesn't match the production website markup.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

For the config to match the production website markup.