### PR TITLE
Add "Visual Studio Code" as a synonym for "VsCode"

### DIFF
--- a/configs/cakebuild.json
+++ b/configs/cakebuild.json
@@ -100,6 +100,15 @@
       "text": "div.content-wrapper .content p, div.content-wrapper .content li"
     }
   },
+  "custom_settings": {
+    "synonyms": [
+      [
+        "vscode",
+        "vs code",
+        "visual studio code"
+      ]
+    ]
+  },
   "conversation_id": [
     "1299917176"
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
`Visual Studio Code` and `VsCode` are two terms which are used interchangeable.

### What is the current behaviour?

When searching for `vscode` the [Visual Studio Code documentation](https://cakebuild.net/docs/integrations/editors/vscode/) is not shown as search result.

### What is the expected behaviour?

[Visual Studio Code documentation](https://cakebuild.net/docs/integrations/editors/vscode/) is a likely match for people searching for `vscode` and therefore should be returned.

##### NB: Do you want to request a **feature** or report a **bug**?

Feature

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
