### PR TITLE
Add apache-spark versions 3.1.0 and 3.1.1

### DIFF
--- a/configs/apache_spark.json
+++ b/configs/apache_spark.json
@@ -4,7 +4,7 @@
     {
       "url": "https://spark.apache.org/docs/(?P<version>.*?)/",
       "variables": {
-        "version": ["latest"]
+        "version": ["latest", "3.1.0", "3.1.1"]
       }
     }
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
As the apache spark community are going to release 3.1.1, we should add versions for Spark documentation of different releases. 

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

Supporting version key filtering in https://spark.apache.org/docs

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
