### PR TITLE
Add faceting attribute for Prismic

### DIFF
--- a/configs/prismic.json
+++ b/configs/prismic.json
@@ -16,6 +16,11 @@
     "lvl5": ".main-content h5",
     "text": ".main-content p, .main-content li"
   },
+  "custom_settings": {
+    "attributesForFaceting": [
+      "hierarchy.lvl0"
+    ]
+  },
   "conversation_id": [
     "1087344940"
   ],


### PR DESCRIPTION
Adds a faceting attribute for Prismic using the custom settings to allow filtering on the level 0 hierarchy attribute.