### PR TITLE
Update getkong.json with new url and selector

### DIFF
--- a/configs/getkong.json
+++ b/configs/getkong.json
@@ -2,10 +2,10 @@
   "index_name": "getkong",
   "start_urls": [
     {
-      "url": "https://docs.konghq.com/(?P<version>.*?)/",
+      "url": "https://docs.konghq.com/gateway-oss/(?P<version>.*?)/",
       "variables": {
         "version": {
-          "url": "https://docs.konghq.com/",
+          "url": "https://docs.konghq.com/gateway-oss/",
           "js": "var versions = $('ul[aria-labelledby=version-dropdown] a, button#version-dropdown').map(function(i, e) { return $(e).text().replace(/\\s+/g, '').replace(/Version/g, '').replace(/\\(latest\\)/g, ''); }).toArray(); return JSON.stringify(versions);"
         }
       }
@@ -17,7 +17,7 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": ".docs-navigation > a.active",
+      "selector": ".search-selector",
       "global": true,
       "default_value": "Kong"
     },


### PR DESCRIPTION
The Kong docs ([source repo here](https://github.com/Kong/docs.konghq.com)) have just been moved from the root of the site, `docs.konghq.com`, to the `docs.konghq.com/gateway-oss/` URL. 

### Changes
* Updating the URL in the search config so that it crawls the same set of pages as before. 
* Changing the top level selector to `.search-selector`, as the old `docs-navigation` element is being removed in the near future.
