### PR TITLE
Update craftcms_commerce.json

### DIFF
--- a/configs/craftcms_commerce.json
+++ b/configs/craftcms_commerce.json
@@ -37,7 +37,7 @@
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".theme-default-content h1",
+    "lvl1": ".theme-default-content .router-link-exact-active",
     "lvl2": ".theme-default-content h2",
     "lvl3": ".theme-default-content h3",
     "lvl4": ".theme-default-content h4",


### PR DESCRIPTION
Our search results can include seemingly-identical results because pages—each representing a class—reference the class name only. This PR should grab the class name *with its path* and make suggested results distinguishable from one another.