### PR TITLE
Update site URL

### DIFF
--- a/configs/g-despot.json
+++ b/configs/g-despot.json
@@ -1,10 +1,10 @@
 {
   "index_name": "g-despot",
   "start_urls": [
-    "https://g-despot.github.io/docs/"
+    "https://docs.memgraph.com"
   ],
   "sitemap_urls": [
-    "https://g-despot.github.io/docs/sitemap.xml"
+    "https://docs.memgraph.com/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation

### What is the current behavior?

The current config file contains an outdated URL for the site. 

### What is the expected behavior?

The new URL is: [docs.memgraph.com](docs.memgraph.com).

### Edit permission evidence

This GitHub account is the owner of the current site (https://github.com/g-despot/docs) and I am a contributor for the new one (https://github.com/memgraph/docs).