### PR TITLE
Update confetti-framework.json

### DIFF
--- a/configs/confetti-framework.json
+++ b/configs/confetti-framework.json
@@ -1,7 +1,7 @@
 {
   "index_name": "confetti-framework",
   "start_urls": [
-    "https://confetti-framework.github.io/docs/"
+    "https://confetti-framework.com/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
Confetti framework is now live with its own domain. Because of this you can no longer search. This causes the results to be incorrectly redirected to, for example, https://www.confetti-framework.com/docs/docs/the-basics/routing.html#route-model-binding


https://www.confetti-framework.com/docs/get-started/meet.html

