### PR TITLE
Update mikro-orm.json

### DIFF
--- a/configs/mikro-orm.json
+++ b/configs/mikro-orm.json
@@ -30,7 +30,8 @@
     "attributesForFaceting": [
       "language",
       "version",
-      "type"
+      "type",
+      "docusaurus_tag"
     ],
     "attributesToRetrieve": [
       "hierarchy",


### PR DESCRIPTION
# Pull request motivation(s)

Search on SERP is broken due to recent changes in docusaurus 2 (e.g. https://mikro-orm.io/search/?q=populate), looks like it is because of missing `docusaurus_tag ` attribute in the config