### PR TITLE
update URL for git-gosling project

### DIFF
--- a/configs/git-gosling.json
+++ b/configs/git-gosling.json
@@ -1,10 +1,10 @@
 {
   "index_name": "git-gosling",
   "start_urls": [
-    "https://git-gosling.netlify.app/docs/"
+    "https://git-gosling.vercel.app/docs/"
   ],
   "sitemap_urls": [
-    "https://git-gosling.netlify.app/sitemap.xml"
+    "https://git-gosling.vercel.app/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

I've migrated from Netlify hosting to Vercel hosting.
The URL where you can find my project has changed.
This means that the Algolia crawler should stop indexing the Netlify site, and instead index the Vercel site.

I've also transferred the repository under my own namespace (from `RoostingGeese/git-gosling` to `HonkingGoose/git-gosling`).
I don't know if this affect my eligibility for the Algolia DocSearch for Open Source projects, I'm not changing any license/content stuff.

I'm still using Docusaurus v2 on the Vercel hosted URL, so the build system is not changing.

### What is the current behaviour?

The crawler indexes the Netlify site once every 24 hours.

### What is the expected behaviour?

The Algolia crawler should index the Vercel site instead.

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

I hope I'm doing this right.
Is there anything else I should know/do to complete the migration?
Can I  keep using the Algolia `APIKey` and `indexName` that were provided when I was using Netlify, or do I need to request new ones?