### PR TITLE
Add alias list to search index

### DIFF
--- a/configs/cakebuild.json
+++ b/configs/cakebuild.json
@@ -75,7 +75,7 @@
       "lvl2": "div.content-wrapper .content h1",
       "lvl3": "div.content-wrapper .content h2",
       "lvl4": "div.content-wrapper .content h3",
-      "text": "div.content-wrapper .content p, div.content-wrapper .content li"
+      "text": "div.content-wrapper .content p, div.content-wrapper .content li, div.content-wrapper .content table.alias-list td"
     },
     "extensions": {
       "lvl0": {
@@ -86,7 +86,7 @@
       "lvl2": "div.content-wrapper .content h1",
       "lvl3": "div.content-wrapper .content h2",
       "lvl4": "div.content-wrapper .content h3",
-      "text": "div.content-wrapper .content p, div.content-wrapper .content li"
+      "text": "div.content-wrapper .content p, div.content-wrapper .content li, div.content-wrapper .content table.alias-list td"
     },
     "community": {
       "lvl0": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Aliases documented on the Cake website should be part of the search index.

### What is the current behaviour?

Aliases are listed on the extension detail page (see e.g. `NewIssue` at https://cakebuild.net/extensions/cake-issues/) or the DSL reference page (see e.g. `NewIssue` at https://cakebuild.net/dsl/issues/). If searching for `NewIssue` currently neither is found, since they are in a table.

### What is the expected behaviour?

It should be possible to search for aliases.

##### NB: Do you want to request a **feature** or report a **bug**?

Bug

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

Fixes https://github.com/cake-build/website/issues/1111