### PR TITLE
Exclude old documentation (fiskaltrust)

### DIFF
--- a/configs/fiskaltrust.json
+++ b/configs/fiskaltrust.json
@@ -4,7 +4,9 @@
     "https://docs.fiskaltrust.cloud/"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
+  "stop_urls": [
+    "https:\\/\\/docs\\.fiskaltrust\\.cloud\\/doc\\/.*"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
We're publishing a pinned, old version of our documentation in the `doc/` folder to not break old links. This old information shouldn't show up in the search, so we'd like to exclude the folder.

### What is the current behaviour?
Content from the `doc/` folder shows up in the search.

### What is the expected behaviour?
The content should not show up.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

Thank you!
