### PR TITLE
change url to sleepy-discord

### DIFF
--- a/configs/sleepy-discord-docs.json
+++ b/configs/sleepy-discord-docs.json
@@ -1,10 +1,10 @@
 {
   "index_name": "sleepy-discord-docs",
   "start_urls": [
-    "https://yourwaifu.dev/sleepy-discord-docs/"
+    "https://yourwaifu.dev/sleepy-discord/"
   ],
   "sitemap_urls": [
-    "https://yourwaifu.dev/sleepy-discord-docs/sitemap.xml"
+    "https://yourwaifu.dev/sleepy-discord/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)
I changed the docs's URL as the original was for the test site that I plan on putting offline soon.

### What is the current behaviour?

searches go to a 404 page