### PR TITLE
[SAP Cloud SDK]: Enable indexing of the <code> tag to highlight the terms in documentation (not related to code blocks)

### DIFF
--- a/configs/sap_cloud-sdk.json
+++ b/configs/sap_cloud-sdk.json
@@ -20,7 +20,7 @@
     "lvl3": "[class^='docItemContainer_'] h3",
     "lvl4": "[class^='docItemContainer_'] h4",
     "lvl5": "[class^='docItemContainer_'] h5",
-    "text": "[class^='docItemContainer_'] p, [class^='docItemContainer_'] li"
+    "text": "[class^='docItemContainer_'] p, [class^='docItemContainer_'] li, code"
   },
   "selectors_exclude": [
     ".hash-link"

--- a/configs/sap_cloud-sdk.json
+++ b/configs/sap_cloud-sdk.json
@@ -20,7 +20,7 @@
     "lvl3": "[class^='docItemContainer_'] h3",
     "lvl4": "[class^='docItemContainer_'] h4",
     "lvl5": "[class^='docItemContainer_'] h5",
-    "text": "[class^='docItemContainer_'] p, [class^='docItemContainer_'] li, code"
+    "text": "[class^='docItemContainer_'] p, [class^='docItemContainer_'] li, [class^='docItemContainer_'] code"
   },
   "selectors_exclude": [
     ".hash-link"


### PR DESCRIPTION
- The `<code>` tag in Docusaurus is used for inline code snippets and we use it to highlight the terms in our docs.
- We want to see it in the index as those are often searched for
- Larger example code snippets are excluded from the search index


# Pull request motivation(s)

### What is the current behaviour?

`<code>` tags are not indexed on https://sap.github.io/cloud-sdk/docs/overview/overview-cloud-sdk

### What is the expected behaviour?

The` <code>` tag is used for the inline code highlight which is mostly leveraged for tech terms frequently searched by the customers. This doesn't break the best practice to not index example code snippets as they are not marked with the `<code>` tag but are represented by `<div>` with a dedicated CSS class.

##### NB: Do you want to request a **feature** or report a **bug**?

This is a config update

##### NB2: Any other feedback / questions ?

Thanks for the great tool and wonderful support for OS projects.
