### PR TITLE
Fix selectors for CastHub Docs

### DIFF
--- a/configs/casthub.json
+++ b/configs/casthub.json
@@ -15,6 +15,9 @@
     "lvl4": "div.flex div article.prose h4",
     "text": "div.flex div article.prose p, div.flex div article.prose li",
   },
+  "custom_settings": {
+    "attributesForFaceting": ["language"]
+  },
   "conversation_id": [
     "1382995547"
   ],

--- a/configs/casthub.json
+++ b/configs/casthub.json
@@ -6,16 +6,14 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "",
-      "global": true,
+      "selector": "aside > div > ul > li.active > p",
       "default_value": "Documentation"
     },
-    "lvl1": "article h1",
-    "lvl2": "article h2",
-    "lvl3": "article h3",
-    "lvl4": "article h4",
-    "lvl5": "article h5",
-    "text": "article p, article li"
+    "lvl1": "div.flex div article.prose h1",
+    "lvl2": "div.flex div article.prose h2",
+    "lvl3": "div.flex div article.prose h3",
+    "lvl4": "div.flex div article.prose h4",
+    "text": "div.flex div article.prose p, div.flex div article.prose li",
   },
   "conversation_id": [
     "1382995547"

--- a/configs/casthub.json
+++ b/configs/casthub.json
@@ -14,6 +14,12 @@
     "lvl3": "div.flex div article.prose h3",
     "lvl4": "div.flex div article.prose h4",
     "text": "div.flex div article.prose p, div.flex div article.prose li",
+    "language": {
+      "selector": "/html/@lang",
+      "type": "xpath",
+      "global": true,
+      "default_value": "en-US"
+    }
   },
   "custom_settings": {
     "attributesForFaceting": ["language"]


### PR DESCRIPTION
# Pull request motivation(s)
Updating the CastHub crawler config. It is based on the Nuxt Content config, since CastHub uses the same library.

### What is the current behaviour?
DocSearch Crawler isn't picking up a lot of content due to the default set-up config.

### What is the expected behaviour?
The Crawler should pick up all of the relevant content effectively.