### PR TITLE
Update pachyderm.json

### DIFF
--- a/configs/pachyderm.json
+++ b/configs/pachyderm.json
@@ -33,7 +33,7 @@
     "lvl5": "article h5",
     "text": "article p, article li"
   },
-  "strip_chars": " .,;:#",
+  "strip_chars": " .,;:#¶",
   "custom_settings": {
     "separatorsToIndex": "_",
     "attributesForFaceting": [


### PR DESCRIPTION
# Pull request motivation(s)
we use that character in anchors ¶

### What is the current behaviour?

That character shows in autosuggest

### What is the expected behaviour?

No more ¶ in search results


