### PR TITLE
updated start_urls variables for expressionengine config

### DIFF
--- a/configs/expressionengine.json
+++ b/configs/expressionengine.json
@@ -5,7 +5,7 @@
       "url": "https://docs.expressionengine.com/(?P<version>.*?)/",
       "variables": {
         "version": [
-          "latest"
+          "latest","v5","v4","v3","v2","v1"
         ]
       }
     }


### PR DESCRIPTION
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Previous versions of our documentation (https://docs.expressionengine.com/latest/index.html) were not being indexed and thus not searchable. Since people continue to use previous versions we need those docs to be available.

### What is the current behaviour?

Only https://docs.expressionengine.com/latest/ is indexed

### What is the expected behaviour?
The following would all be searchable:
 https://docs.expressionengine.com/latest/
 https://docs.expressionengine.com/v5/
 https://docs.expressionengine.com/v4/
 https://docs.expressionengine.com/v3/
 https://docs.expressionengine.com/v2/
 https://docs.expressionengine.com/v1/
