### PR TITLE
contao.json: index words with curly braces and underscores

### DIFF
--- a/configs/contao.json
+++ b/configs/contao.json
@@ -47,7 +47,8 @@
     "attributesForFaceting": [
       "language",
       "type"
-    ]
+    ],
+    "separatorsToIndex": "_{}"
   },
   "conversation_id": [
     "1321026817"


### PR DESCRIPTION
See https://discourse.algolia.com/t/special-characters-like-curly-braces-are-ignored-during-search/12095