### PR TITLE
Update bonitasoft.json

### DIFF
--- a/configs/bonitasoft.json
+++ b/configs/bonitasoft.json
@@ -5,7 +5,7 @@
       "url": "https://preview.documentation.bonitasoft.com/bonita/(?P<version>.*?)/",
       "tags": ["bonita"],
       "variables": {
-        "version": ["7.5", "7.6", "7.7", "7.8", "7.9", "7.10", "7.11", "7.12"]
+        "version": ["7.5", "7.6", "7.7", "7.8", "7.9", "7.10", "7.11", "2021.1"]
       }
     },
     {


### PR DESCRIPTION
- Replace 7.12 version by 2021.1 version, the 'branding version' now used by Bonita. 

I am one of the maintainers of the site, here are the sources -> https://github.com/bonitasoft/bonitasoft.github.io