### PR TITLE
fix: exclude the old /docs/ content

### DIFF
--- a/configs/jenkins_x.json
+++ b/configs/jenkins_x.json
@@ -22,7 +22,7 @@
   "sitemap_urls": [
     "https://jenkins-x.io/sitemap.xml"
   ],
-  "stop_urls": [],
+  "stop_urls": ["/docs/$"],
   "selectors": {
     "lvl0": ".td-content h1, .documentation-copy h1",
     "lvl1": ".td-content h2, .documentation-copy h2",

--- a/configs/jenkins_x.json
+++ b/configs/jenkins_x.json
@@ -22,7 +22,7 @@
   "sitemap_urls": [
     "https://jenkins-x.io/sitemap.xml"
   ],
-  "stop_urls": ["/docs/$"],
+  "stop_urls": ["/docs/.*$"],
   "selectors": {
     "lvl0": ".td-content h1, .documentation-copy h1",
     "lvl1": ".td-content h2, .documentation-copy h2",


### PR DESCRIPTION
this fix removes the old content from the search index

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
