### PR TITLE
commercetools: remove old config, exclude a special page

### DIFF
--- a/configs/commercetools.json
+++ b/configs/commercetools.json
@@ -3,11 +3,10 @@
   "start_urls": ["https://docs.commercetools.com"],
   "sitemap_urls": [],
   "stop_urls": [
-    "/release-notes",
     ".*/releases$",
     ".*/releases/.*",
-    "/merchant-center-releases",
-    ".html$"
+    ".html$",
+    "docs/removed-functionality"
   ],
   "selectors": {
     "lvl0": {
@@ -21,7 +20,7 @@
     "lvl4": "article h4",
     "text": "article p, article li, article figure, article .lead"
   },
-  "selectors_exclude": ["#toc"],
+  "selectors_exclude": [],
   "conversation_id": ["707863318"],
   "nb_hits": 12036
 }


### PR DESCRIPTION
# Pull request motivation(s)
 - old site code is finally offline, we can remove the config for that
 - we have a new special page that is linked but still needs to be excluded

Thank you for the great product!