### PR TITLE
Prebid: adding page_rank for most useful references

### DIFF
--- a/configs/prebid.json
+++ b/configs/prebid.json
@@ -99,6 +99,102 @@
       "tags": [
         "cookies"
       ]
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/publisher-api-reference.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/modules/userId.html",
+      "page_rank": 1
+    },
+    {
+      "url": "https://docs.prebid.org/prebid/prebidjs.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/overview/prebid-server-overview.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/getting-started.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/overview/intro.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/bidder-adaptor.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/prebid-server/developers/add-new-bidder-go.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/prebid-server/developers/add-new-bidder-java.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/prebid-server/developers/pbs-build-an-analytics-adapter.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/integrate-with-the-prebid-analytics-api.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/add-rtd-submodule.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/adops/step-by-step.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/modules/consentManagement.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/troubleshooting-tips.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/show-outstream-video-ads.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/adops/send-all-bids-adops.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/prebid-video/video-overview.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/faq.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/prebid/native-implementation.html",
+      "page_rank": 3
+    },
+    {
+      "url": "https://docs.prebid.org/prebid-server/use-cases/pbs-amp.html",
+      "page_rank": 2
+    },
+    {
+      "url": "https://docs.prebid.org/prebid-server/use-cases/pbs-sdk.html",
+      "page_rank": 2
+    },
+    {
+      "url": "https://docs.prebid.org/prebid-mobile/prebid-mobile.html",
+      "page_rank": 3
     }
   ],
   "sitemap_urls": [


### PR DESCRIPTION
# Pull request motivation(s)
Adding page_rank for most useful references.

We're finding that some detail pages (more focused scope, less relevant) pages are showing up before the overview-type pages in some of the searches we've tried, so would like to elevate these pages to be higher in the search results.

### What is the current behaviour?

Typing a search term results in a sorted(ranked?) list of results that have some of the more relevant answers lower down the list than we'd like them.

### What is the expected behaviour?

The top most useful pages are at the top

##### NB: Do you want to request a **feature** or report a **bug**?

Neither 

##### NB2: Any other feedback / questions ?

By way of proving I'm authorized to request this change, I'm one of the top contributors to the docs.prebid.org website as evidenced by https://github.com/prebid/prebid.github.io/graphs/contributors
