### PR TITLE
Add "common-tasks" and "installation" under "start_urls"

### DIFF
--- a/configs/home-assistant.json
+++ b/configs/home-assistant.json
@@ -14,7 +14,7 @@
       "page_rank": 2
     },
     "https://www.home-assistant.io/docs/",
-    "https://www.home-assistant.io/hassio/",
+    "https://www.home-assistant.io/installation/",
     "https://www.home-assistant.io/common-tasks/"
   ],
   "sitemap_urls": [

--- a/configs/home-assistant.json
+++ b/configs/home-assistant.json
@@ -14,7 +14,8 @@
       "page_rank": 2
     },
     "https://www.home-assistant.io/docs/",
-    "https://www.home-assistant.io/hassio/"
+    "https://www.home-assistant.io/hassio/",
+    "https://www.home-assistant.io/common-tasks/"
   ],
   "sitemap_urls": [
     "https://www.home-assistant.io/sitemap.xml"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Articles under /common-tasks and /installation are not searchable, while they should be.
We recently redid parts of the documentation and while doing that /common-tasks and /installation was added and /hassio was removed

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*
It's not a bug, it's just missing

### What is the expected behaviour?

That articles are searchable

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
