### PR TITLE
Upgrade Jest configurations

### DIFF
--- a/configs/jest-v2.json
+++ b/configs/jest-v2.json
@@ -1,6 +1,6 @@
 {
   "index_name": "jest-v2",
-  "start_urls": ["https://jest-v2.netlify.app/"],
+  "start_urls": ["https://jestjs.io"],
   "stop_urls": [],
   "selectors": {
     "lvl0": {
@@ -17,7 +17,7 @@
     "lvl6": "article h6",
     "text": "article p, article li"
   },
-  "sitemap_urls": ["https://jest-v2.netlify.app/sitemap.xml"],
+  "sitemap_urls": ["https://jestjs.io/sitemap.xml"],
   "sitemap_alternate_links": true,
   "strip_chars": " .,;:#",
   "custom_settings": {

--- a/configs/jest-v2.json
+++ b/configs/jest-v2.json
@@ -1,6 +1,8 @@
 {
   "index_name": "jest-v2",
-  "start_urls": ["https://jestjs.io"],
+  "start_urls": [
+    "https://jestjs.io"
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": {
@@ -17,12 +19,19 @@
     "lvl6": "article h6",
     "text": "article p, article li"
   },
-  "sitemap_urls": ["https://jestjs.io/sitemap.xml"],
+  "sitemap_urls": [
+    "https://jestjs.io/sitemap.xml"
+  ],
   "sitemap_alternate_links": true,
   "strip_chars": " .,;:#",
   "custom_settings": {
     "separatorsToIndex": "_",
-    "attributesForFaceting": ["language", "version", "type", "docusaurus_tag"],
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
     "attributesToRetrieve": [
       "hierarchy",
       "content",
@@ -33,6 +42,8 @@
     ]
   },
   "min_indexed_level": 0,
-  "conversation_id": ["1355494505"],
-  "nb_hits": 2293
+  "conversation_id": [
+    "1355494505"
+  ],
+  "nb_hits": 56061
 }

--- a/configs/jest.json
+++ b/configs/jest.json
@@ -1,11 +1,12 @@
 {
   "index_name": "jest",
   "start_urls": [
-    "https://archive.jestjs.io/docs/"
+    "https://archive.jestjs.io/"
   ],
   "stop_urls": [
     "/help",
-    "/videos"
+    "/videos",
+    "/blog"
   ],
   "sitemap_urls": [
     "https://archive.jestjs.io/sitemap.xml"
@@ -39,5 +40,5 @@
       "version"
     ]
   },
-  "nb_hits": 102626
+  "nb_hits": 101899
 }

--- a/configs/jest.json
+++ b/configs/jest.json
@@ -1,14 +1,14 @@
 {
   "index_name": "jest",
   "start_urls": [
-    "https://jestjs.io/docs/"
+    "https://archive.jestjs.io/docs/"
   ],
   "stop_urls": [
     "/help",
     "/videos"
   ],
   "sitemap_urls": [
-    "https://jestjs.io/sitemap.xml"
+    "https://archive.jestjs.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "selectors": {


### PR DESCRIPTION
We just deployed the Jest website using Docusaurus 2.

The old v1 website and older Jest versions are now at https://archive.jestjs.io/

Docsearch config jest => Docsaurus 1 (https://archive.jestjs.io/)
Docsearch config jest-v2 => Docusaurus 2 site (https://jestjs.io/)