### PR TITLE
Update overwolf.json

### DIFF
--- a/configs/overwolf.json
+++ b/configs/overwolf.json
@@ -7,7 +7,7 @@
     "https://overwolf.github.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
+  "stop_urls": ["https://overwolf.github.io/docs/api/overwolf-log"],
   "selectors": {
     "lvl0": {
       "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",


### PR DESCRIPTION
trying to "hide" one of the pages from the search:

I temporarily removed the page from the menu, but I don't want to delete it. 
But the issue now is that I can still see it in the search.

I'm hoping that the stop URL is the right place for that.