### PR TITLE
Update: improve indexing on API docs

### DIFF
--- a/configs/talon.json
+++ b/configs/talon.json
@@ -1,7 +1,18 @@
 {
   "index_name": "talon",
   "start_urls": [
-    "https://docs.talon.one/"
+    {
+      "url": "https://docs.talon.one/",
+      "selectors_key": "default"
+    },
+    {
+      "url": "https://docs.talon.one/management-api",
+      "selectors_key": "api"
+    },
+    {
+      "url": "https://docs.talon.one/integration-api",
+      "selectors_key": "api"
+    }
   ],
   "sitemap_urls": [
     "https://docs.talon.one/sitemap.xml"
@@ -9,18 +20,27 @@
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
+    "default":{
+      "lvl0": {
+        "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+        "type": "xpath",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": "header h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5, article td:first-child",
+      "text": "article p, article li, article td:last-child"
     },
-    "lvl1": "header h1",
-    "lvl2": "article h2",
-    "lvl3": "article h3",
-    "lvl4": "article h4",
-    "lvl5": "article h5, article td:first-child",
-    "text": "article p, article li, article td:last-child"
+    "api":{
+      "lvl1": ".api-content h1",
+      "lvl2": ".api-content h2",
+      "lvl3": ".api-content h3",
+      "lvl4": ".api-content h4",
+      "text": ".api-content p"
+    }
   },
   "strip_chars": " .,;:#",
   "custom_settings": {


### PR DESCRIPTION

# Pull request motivation(s)

We have a couple of pages that are API docs and the current config doesn't cover them.

### What is the current behaviour?

The index doesn't contain the API docs (such as [this page](https://docs.talon.one/integration-api)).

### What is the expected behaviour?

The API docs should be indexed, at least the text and endpoint names.