### PR TITLE
Ignore one subdir, remove TOC tree wrapper

### DIFF
--- a/configs/trident.json
+++ b/configs/trident.json
@@ -2,7 +2,7 @@
   "index_name": "trident",
   "start_urls": ["https://scaleoutsean.github.io/trident/"],
   "sitemap_urls": ["https://scaleoutsean.github.io/trident/sitemap.xml"],
-  "stop_urls": ['https://scaleoutsean.github.io/trident/docker/*'],
+  "stop_urls": ["https://scaleoutsean.github.io/trident/docker/*"],
   "selectors": {
     "lvl0": {
       "selector": "",

--- a/configs/trident.json
+++ b/configs/trident.json
@@ -2,7 +2,7 @@
   "index_name": "trident",
   "start_urls": ["https://scaleoutsean.github.io/trident/"],
   "sitemap_urls": ["https://scaleoutsean.github.io/trident/sitemap.xml"],
-  "stop_urls": [],
+  "stop_urls": ['https://scaleoutsean.github.io/trident/docker/*'],
   "selectors": {
     "lvl0": {
       "selector": "",
@@ -16,6 +16,7 @@
     "lvl5": "main h5",
     "text": "main p, main li"
   },
+  "selectors_exclude": [".toctree-wrapper"],
   "conversation_id": ["1441199566"],
   "nb_hits": 9795
 }


### PR DESCRIPTION
# Pull request motivation(s)

1) Need to eliminate double results resulting from ToC wrapper in left side-bar as [suggested](https://discourse.algolia.com/t/duplicate-results-in-docsearch-with-a-bootstrap-based-static-site/12206/2)

2) Need to eliminate docs from `docker/*` path because they create unnecessary search hits

### What is the current behaviour?

Getting duplicate results because of 1) above (I hope; I don't know if I can test this without making this PR first)

Change 2) is just a minor problem as Docker-related results are very rarely required.

### What is the expected behaviour?

Regarding 1), I want to see one unique URL per result.
