### PR TITLE
Update: add wait time

### DIFF
--- a/configs/talon.json
+++ b/configs/talon.json
@@ -39,7 +39,7 @@
       "lvl2": ".api-content h2",
       "lvl3": ".api-content h3",
       "lvl4": ".api-content h4",
-      "text": ".api-content p"
+      "text": ".api-content p, .api-content ul, .api-content ol"
     }
   },
   "strip_chars": " .,;:#",
@@ -61,6 +61,7 @@
     ]
   },
   "js_render": true,
+  "js_wait": 3,
   "conversation_id": [
     "1442884792"
   ],

--- a/configs/talon.json
+++ b/configs/talon.json
@@ -61,7 +61,7 @@
     ]
   },
   "js_render": true,
-  "js_wait": 3,
+  "js_wait": 1,
   "conversation_id": [
     "1442884792"
   ],


### PR DESCRIPTION
Certain pages are not indexed even though the selectors seem OK. 

Adding `wait_time` to see if this helps.