### PR TITLE
Add a new start url

### DIFF
--- a/configs/data-driven-forms.json
+++ b/configs/data-driven-forms.json
@@ -5,7 +5,8 @@
     "https://data-driven-forms.org/components/renderer",
     "https://data-driven-forms.org/schema/introduction",
     "https://data-driven-forms.org/hooks/use-field-api",
-    "https://data-driven-forms.org/mappers/custom-mapper"
+    "https://data-driven-forms.org/mappers/custom-mapper",
+    "https://data-driven-forms.org/examples/mui-one-row-layout"
   ],
   "stop_urls": [
     "https://data-driven-forms.org/mappers/checkbox(?!\\?)",


### PR DESCRIPTION
# Pull request motivation(s)

There is a new subsection in the menu. The menu is collapsed by default, so to expose all the new links, the crawler has to hit some page in that section.

cc @hyperkid123