### PR TITLE
update config file for calindra

### DIFF
--- a/configs/calindra.json
+++ b/configs/calindra.json
@@ -1,10 +1,16 @@
 {
   "index_name": "calindra",
   "start_urls": [
-    "https://developer.ame.calindra.com.br/docs/"
+    "https://developer.ame.calindra.com.br/docs/",
+    "https://ame-miniapp-components.calindra.com.br/docs/estrutura",
+    "https://super-app-client.calindra.com.br/docs/ame-super-app-client",
+    "https://ame-app-tools.calindra.com.br/docs/cli"
   ],
   "sitemap_urls": [
-    "https://developer.ame.calindra.com.br/sitemap.xml"
+    "https://developer.ame.calindra.com.br/sitemap.xml",
+    "https://super-app-client.calindra.com.br/sitemap.xml",
+    "https://ame-app-tools.calindra.com.br/sitemap.xml",
+    "https://ame-miniapp-components.calindra.com.br/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
Adds more start_urls and sitemap_urls to support subdomains of the same product documentation site