### PR TITLE
Excluding any subfolder for v1.x from docsearch for grocerycrud

### DIFF
--- a/configs/grocerycrud.json
+++ b/configs/grocerycrud.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "https://new.grocerycrud.com/"
   ],
-  "stop_urls": [],
+  "stop_urls": ["/v1.x/.*"],
   "selectors": {
     "lvl0": "main h1",
     "lvl1": "main h2",


### PR DESCRIPTION
The docsearch is all about the newer versions so we would like to exclude any version 1.x subfolder URLS even if we have a reference on the website

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Currently we are indexing by default any subfolder that we have as link. For example: https://new.grocerycrud.com/v1.x/examples

### What is the expected behaviour?

We would like to exclude any subfolder from search for the folder /v1.x/ . For example we do NOT want to have docsearch for the URLS:
- https://new.grocerycrud.com/v1.x/examples
- https://new.grocerycrud.com/v1.x/

##### NB: Do you want to request a **feature** or report a **bug**?

feature

##### NB2: Any other feedback / questions ?

Nope! All good! Thank youf for docsearch it is just awesome 🤗

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
