### PR TITLE
Crawl Spatie laravel-mailcoach docs

### DIFF
--- a/configs/spatie_be.json
+++ b/configs/spatie_be.json
@@ -19,6 +19,7 @@
         ],
         "project": [
           "laravel-backup",
+          "laravel-mailcoach",
           "laravel-medialibrary",
           "laravel-blade-x",
           "laravel-tags",


### PR DESCRIPTION
This PR adds support for crawling the docs at https://spatie.be/docs/laravel-mailcoach/v4/introduction