### PR TITLE
Vue Router: rank guide in front of api

### DIFF
--- a/configs/next_router_vuejs.json
+++ b/configs/next_router_vuejs.json
@@ -4,6 +4,7 @@
     {
       "url": "https://next.router.vuejs.org/guide/",
       "selectors_key": "guide",
+      "page_rank": 10,
       "tags": [
         "guide"
       ]
@@ -11,6 +12,7 @@
     {
       "url": "https://next.router.vuejs.org/api/",
       "selectors_key": "api",
+      "page_rank": 8,
       "tags": [
         "api"
       ]

--- a/configs/next_router_vuejs.json
+++ b/configs/next_router_vuejs.json
@@ -18,7 +18,9 @@
       ]
     }
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    ".html"
+  ],
   "selectors": {
     "guide": {
       "lvl0": {
@@ -49,5 +51,5 @@
   "conversation_id": [
     "1305035158"
   ],
-  "nb_hits": 897
+  "nb_hits": 924
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Right now API results appear before the guide and I would like it to be the other way around

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
