### PR TITLE
add pagerank to temporal's docs

### DIFF
--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -28,8 +28,8 @@
     {
       "url": "https://docs.temporal.io/docs/get-started",
       "page_rank": 1
-    }
-  "https://docs.temporal.io/docs/"
+    },
+    "https://docs.temporal.io/docs/"
   ],
   "sitemap_urls": [
     "https://docs.temporal.io/sitemap.xml"

--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -1,8 +1,34 @@
 {
   "index_name": "temporal",
   "start_urls": [
-    "https://docs.temporal.io/docs/",
-    "https://docs.temporal.io/docs/overview"
+    {
+      "url": "https://docs.temporal.io/docs/concept-overview",
+      "page_rank": 999
+    },
+    {
+      "url": "https://docs.temporal.io/docs/concept-workflows",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/concept-activities",
+      "page_rank": 997
+    },
+    {
+      "url": "https://docs.temporal.io/docs/concept-events",
+      "page_rank": 996
+    },
+    {
+      "url": "https://docs.temporal.io/docs/concept-queries",
+      "page_rank": 995
+    },
+    {
+      "url": "https://docs.temporal.io/docs/concept-task-queues",
+      "page_rank": 994
+    },
+    {
+      "url": "https://docs.temporal.io/docs/get-started",
+      "page_rank": 1
+    }
   ],
   "sitemap_urls": [
     "https://docs.temporal.io/sitemap.xml"

--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -29,6 +29,7 @@
       "url": "https://docs.temporal.io/docs/get-started",
       "page_rank": 1
     }
+  "https://docs.temporal.io/docs/"
   ],
   "sitemap_urls": [
     "https://docs.temporal.io/sitemap.xml"


### PR DESCRIPTION
# Pull request motivation(s)

our search results weren't being prioritized properly

### What is the current behaviour?

![image](https://user-images.githubusercontent.com/6764957/113197629-783e5500-9297-11eb-82b1-48b7f233a0d3.png)


### What is the expected behaviour?

"concepts" section should be up top

##### NB: Do you want to request a **feature** or report a **bug**?

no

##### NB2: Any other feedback / questions ?

no, thank you