### PR TITLE
Exclude versions and next

### DIFF
--- a/configs/arrow.json
+++ b/configs/arrow.json
@@ -4,11 +4,8 @@
     "https://arrow-kt.io"
   ],
   "stop_urls": [
-    "https://arrow-kt.io/docs/0.9",
-    "https://arrow-kt.io/docs/next/core/",
-    "https://arrow-kt.io/docs/next/fx/",
-    "https://arrow-kt.io/docs/next/optics/dsl/",
-    "https://arrow-kt.io/docs/next/aql/intro/",
+    "https://arrow-kt.io/docs/[0-9]",
+    "https://arrow-kt.io/docs/next",
     "!index.html"
   ],
   "sitemap_urls": [


### PR DESCRIPTION
# Pull request motivation(s)

Excluding the crawler's visit for all the pages which URL starts with:

```
https://arrow-kt.io/docs/next

https://arrow-kt.io/docs/0.9
https://arrow-kt.io/docs/0.10
https://arrow-kt.io/docs/0.11
...
https://arrow-kt.io/docs/<other-version>
```

According to the documentation:

> stop_urls: This is an array of strings or regular expressions.

So I'm using `[0-9]` to exclude all the versions (any string that starts with a number).

You can find me as a member here: https://github.com/orgs/arrow-kt/people

### What is the current behaviour?

The crawler visits all the pages for new versions like: https://arrow-kt.io/docs/0.12/apidocs/arrow-core/arrow.core.extensions.sequencek.foldable/index.html#package-arrowcoreextensionssequencekfoldable

The idea is having a robust configuration here for releasing new versions without updating this configuration.

### What is the expected behaviour?

Excluding the visit for all the URLs that start with:

```
https://arrow-kt.io/docs/next

https://arrow-kt.io/docs/0.9
https://arrow-kt.io/docs/0.10
https://arrow-kt.io/docs/0.11
...
https://arrow-kt.io/docs/<other-version>
```

##### NB: Do you want to request a **feature** or report a **bug**?

It's a feature.

##### NB2: Any other feedback / questions ?

Thanks for your help!
