### PR TITLE
update config file for calindra. Removes /preceding::h3[1] from lvl0

### DIFF
--- a/configs/calindra.json
+++ b/configs/calindra.json
@@ -2,9 +2,9 @@
   "index_name": "calindra",
   "start_urls": [
     "https://developer.ame.calindra.com.br/docs/",
-    "https://ame-miniapp-components.calindra.com.br/docs/estrutura",
     "https://super-app-client.calindra.com.br/docs/ame-super-app-client",
-    "https://ame-app-tools.calindra.com.br/docs/cli"
+    "https://ame-app-tools.calindra.com.br/docs/cli",
+    "https://ame-miniapp-components.calindra.com.br/docs/"
   ],
   "sitemap_urls": [
     "https://developer.ame.calindra.com.br/sitemap.xml",
@@ -40,5 +40,5 @@
   "conversation_id": [
     "1436984933"
   ],
-  "nb_hits": 92
+  "nb_hits": 36567
 }

--- a/configs/calindra.json
+++ b/configs/calindra.json
@@ -16,7 +16,7 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
+      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"


### PR DESCRIPTION
update config file for calindra. Removes /preceding::h3[1] from lvl0 xpath.

# Pull request motivation(s)

Some results are not appearing in the search, like: 

window - https://ame-miniapp-components.calindra.com.br/docs/window/

The sitemap has "window" page listed.

### What is the expected behaviour?

All items from left menu on (https://ame-miniapp-components.calindra.com.br/) showing in search results.

