### PR TITLE
katex: remove version faceting

### DIFF
--- a/configs/katex.json
+++ b/configs/katex.json
@@ -28,8 +28,7 @@
   ],
   "custom_settings": {
     "attributesForFaceting": [
-      "language",
-      "version"
+      "language"
     ]
   },
   "conversation_id": [


### PR DESCRIPTION
# Pull request motivation(s)
I'm a maintainer of KaTeX and we no longer use documentation versioning.

### What is the current behaviour?
Search with versioning, resulting in search results pointing to non-existent versioned docs.

### What is the expected behaviour?
Search without versioning.

##### NB: Do you want to request a **feature** or report a **bug**?
N/A

##### NB2: Any other feedback / questions ?
It seems the search index is old, possibly due to versions were not available. Would it be possible to update the index?