### PR TITLE
fix: update config for next-drupal

### DIFF
--- a/configs/next-drupal.json
+++ b/configs/next-drupal.json
@@ -5,18 +5,19 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "",
-      "global": true,
-      "default_value": "Documentation"
-    },
-    "lvl1": "main h1",
-    "lvl2": "main h2",
-    "lvl3": "main h3",
-    "lvl4": "main h4",
-    "lvl5": "main h5",
-    "text": "main p, main li"
+    "lvl0": ".DocSearch-content h1",
+    "lvl1": ".DocSearch-content h2",
+    "lvl2": ".DocSearch-content h3",
+    "lvl3": ".DocSearch-content h4",
+    "lvl4": ".DocSearch-content h5",
+    "lvl5": ".DocSearch-content h6",
+    "text": ".DocSearch-content p, .DocSearch-content li"
   },
+  "selectors_exclude": [
+    "main style"
+  ],
+  "strip_chars": " .,;:#",
+  "only_content_level": true,
   "conversation_id": [
     "1473895095"
   ],


### PR DESCRIPTION
### What is the current behaviour?

The current selectors is crawling the whole site including sidebar content.

![next-drupal-algolia](https://user-images.githubusercontent.com/124599/113913350-45dbad00-97ed-11eb-809c-d1ccdb60c135.jpg)

### What is the expected behaviour?

We need to only include the main content and exclude sidebars.

##### NB: Do you want to request a **feature** or report a **bug**?

bug