### PR TITLE
fix language facet

### DIFF
--- a/configs/next_router_vuejs.json
+++ b/configs/next_router_vuejs.json
@@ -5,13 +5,19 @@
       "url": "https://next.router.vuejs.org/guide/",
       "selectors_key": "guide",
       "page_rank": 10,
-      "tags": ["guide"]
+      "tags": ["guide"],
+      "extra_attributes": {
+        "language": ["zh"]
+      }
     },
     {
       "url": "https://next.router.vuejs.org/api/",
       "selectors_key": "api",
       "page_rank": 8,
-      "tags": ["api"]
+      "tags": ["api"],
+      "extra_attributes": {
+        "language": ["zh"]
+      }
     }
   ],
   "stop_urls": ["(?:(?<!\\.html)(?<!/))$"],
@@ -26,7 +32,13 @@
       "lvl3": ".content h3",
       "lvl4": ".content h4",
       "lvl5": ".content h5",
-      "text": ".content p, .content li"
+      "text": ".content p, .content li",
+      "language": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en-US"
+      }
     },
     "api": {
       "lvl0": {
@@ -38,18 +50,18 @@
       "lvl3": ".content h3",
       "lvl4": ".content h4",
       "lvl5": ".content h5",
-      "text": ".content p, .content li"
-    },
-    "lang": {
-      "selector": "/html/@lang",
-      "type": "xpath",
-      "global": true,
-      "default_value": "en-US"
+      "text": ".content p, .content li",
+      "language": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en-US"
+      }
     }
   },
   "strip_chars": " .,;:#",
   "custom_settings": {
-    "attributesForFaceting": ["lang"]
+    "attributesForFaceting": ["language"]
   },
   "conversation_id": ["1305035158"],
   "nb_hits": 1518

--- a/configs/next_router_vuejs.json
+++ b/configs/next_router_vuejs.json
@@ -5,28 +5,39 @@
       "url": "https://next.router.vuejs.org/zh/guide/",
       "selectors_key": "guide",
       "page_rank": 10,
-      "tags": ["guide"]
+      "tags": [
+        "guide"
+      ]
     },
     {
       "url": "https://next.router.vuejs.org/zh/api/",
       "selectors_key": "api",
       "page_rank": 8,
-      "tags": ["api"]
+      "tags": [
+        "api"
+      ]
     },
     {
       "url": "https://next.router.vuejs.org/guide/",
       "selectors_key": "guide",
       "page_rank": 10,
-      "tags": ["guide"]
+      "tags": [
+        "guide"
+      ]
     },
     {
       "url": "https://next.router.vuejs.org/api/",
       "selectors_key": "api",
       "page_rank": 8,
-      "tags": ["api"]
+      "tags": [
+        "api"
+      ]
     }
   ],
-  "stop_urls": ["(?:(?<!\\.html)(?<!/))$"],
+  "stop_urls": [
+    "(?:(?<!\\.html)(?<!/))$",
+    "/zh/"
+  ],
   "selectors": {
     "guide": {
       "lvl0": {
@@ -67,8 +78,13 @@
   },
   "strip_chars": " .,;:#",
   "custom_settings": {
-    "attributesForFaceting": ["language", "tags"]
+    "attributesForFaceting": [
+      "language",
+      "tags"
+    ]
   },
-  "conversation_id": ["1305035158"],
-  "nb_hits": 3034
+  "conversation_id": [
+    "1305035158"
+  ],
+  "nb_hits": 1518
 }

--- a/configs/next_router_vuejs.json
+++ b/configs/next_router_vuejs.json
@@ -2,22 +2,28 @@
   "index_name": "next_router_vuejs",
   "start_urls": [
     {
+      "url": "https://next.router.vuejs.org/zh/guide/",
+      "selectors_key": "guide",
+      "page_rank": 10,
+      "tags": ["guide"]
+    },
+    {
+      "url": "https://next.router.vuejs.org/zh/api/",
+      "selectors_key": "api",
+      "page_rank": 8,
+      "tags": ["api"]
+    },
+    {
       "url": "https://next.router.vuejs.org/guide/",
       "selectors_key": "guide",
       "page_rank": 10,
-      "tags": ["guide"],
-      "extra_attributes": {
-        "language": ["zh"]
-      }
+      "tags": ["guide"]
     },
     {
       "url": "https://next.router.vuejs.org/api/",
       "selectors_key": "api",
       "page_rank": 8,
-      "tags": ["api"],
-      "extra_attributes": {
-        "language": ["zh"]
-      }
+      "tags": ["api"]
     }
   ],
   "stop_urls": ["(?:(?<!\\.html)(?<!/))$"],
@@ -61,8 +67,8 @@
   },
   "strip_chars": " .,;:#",
   "custom_settings": {
-    "attributesForFaceting": ["language"]
+    "attributesForFaceting": ["language", "tags"]
   },
   "conversation_id": ["1305035158"],
-  "nb_hits": 1518
+  "nb_hits": 3034
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

I think the config I did wasn't right because it wasn't doing anything, empty results when adding:

```js
      searchParameters: {
		// lang can be 'en-US' or 'zh-CN'
        facetFilters: ['language:' + lang, 'tags:guide,api']
      }),
```

Is config correct with the current setup?

- English docs: https://next.router.vuejs.org/
- Chinese docs: https://next.router.vuejs.org/zh/index.html

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
