### PR TITLE
brew_all: re-add analytics pages

### DIFF
--- a/configs/brew_all.json
+++ b/configs/brew_all.json
@@ -53,6 +53,14 @@
       "extra_attributes": {
         "site": ["formulae"]
       }
+    },
+    {
+      "url": "https://formulae.brew.sh/analytics/",
+      "selectors_key": "install_events",
+      "tags": ["analytics", "formula", "install_events"],
+      "extra_attributes": {
+        "site": ["formulae"]
+      }
     }
   ],
   "sitemap_urls": [
@@ -184,6 +192,22 @@
         "global": true,
         "default_value": "en"
       }
+    },
+    "install_events": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Analytics"
+      },
+      "lvl1": "#wrap h2",
+      "lvl2": "#wrap h2",
+      "text": "#wrap h3",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en"
+      }
     }
   },
   "custom_settings": {
@@ -191,5 +215,5 @@
     "separatorsToIndex": "_+@/"
   },
   "conversation_id": ["771112570"],
-  "nb_hits": 52725
+  "nb_hits": 36765
 }

--- a/configs/brew_all.json
+++ b/configs/brew_all.json
@@ -4,62 +4,94 @@
     {
       "url": "https://brew.sh/\\d{4}/\\d{2}/\\d{2}/",
       "selectors_key": "blog",
-      "tags": ["blog"],
+      "tags": [
+        "blog"
+      ],
       "extra_attributes": {
-        "site": ["brew"]
+        "site": [
+          "brew"
+        ]
       }
     },
     {
       "url": "https://brew.sh/",
       "extra_attributes": {
-        "site": ["brew"]
+        "site": [
+          "brew"
+        ]
       }
     },
     {
       "url": "https://docs.brew.sh/",
       "selectors_key": "docs",
       "extra_attributes": {
-        "site": ["docs"]
+        "site": [
+          "docs"
+        ]
       }
     },
     {
       "url": "https://formulae.brew.sh/docs/",
       "selectors_key": "formulae_docs",
-      "tags": ["formulae_docs"],
+      "tags": [
+        "formulae_docs"
+      ],
       "extra_attributes": {
-        "site": ["formulae"]
+        "site": [
+          "formulae"
+        ]
       }
     },
     {
       "url": "https://formulae.brew.sh/formula/",
       "selectors_key": "formula",
-      "tags": ["formula"],
+      "tags": [
+        "formula"
+      ],
       "extra_attributes": {
-        "site": ["formulae"]
+        "site": [
+          "formulae"
+        ]
       }
     },
     {
       "url": "https://formulae.brew.sh/cask/",
       "selectors_key": "cask",
-      "tags": ["cask", "formula"],
+      "tags": [
+        "cask",
+        "formula"
+      ],
       "extra_attributes": {
-        "site": ["formulae"]
+        "site": [
+          "formulae"
+        ]
       }
     },
     {
       "url": "https://formulae.brew.sh/analytics/$",
       "selectors_key": "analytics",
-      "tags": ["analytics", "formula"],
+      "tags": [
+        "analytics",
+        "formula"
+      ],
       "extra_attributes": {
-        "site": ["formulae"]
+        "site": [
+          "formulae"
+        ]
       }
     },
     {
       "url": "https://formulae.brew.sh/analytics/",
       "selectors_key": "install_events",
-      "tags": ["analytics", "formula", "install_events"],
+      "tags": [
+        "analytics",
+        "formula",
+        "install_events"
+      ],
       "extra_attributes": {
-        "site": ["formulae"]
+        "site": [
+          "formulae"
+        ]
       }
     }
   ],
@@ -68,7 +100,10 @@
     "https://docs.brew.sh/sitemap.xml",
     "https://formulae.brew.sh/sitemap.xml"
   ],
-  "stop_urls": ["https://brew.sh/blog/", "\\.json"],
+  "stop_urls": [
+    "https://brew.sh/blog/",
+    "\\.json"
+  ],
   "selectors": {
     "default": {
       "lvl0": "#wrap h1",
@@ -181,7 +216,7 @@
       "lvl0": {
         "selector": "",
         "global": true,
-        "default_value": "Analytics"
+        "default_value": "Formulae"
       },
       "lvl1": "#page h1",
       "lvl2": "#page h2",
@@ -197,11 +232,14 @@
       "lvl0": {
         "selector": "",
         "global": true,
+        "default_value": "Formulae"
+      },
+      "lvl1": {
+        "selector": "",
+        "global": true,
         "default_value": "Analytics"
       },
-      "lvl1": "#wrap h2",
       "lvl2": "#wrap h2",
-      "text": "#wrap h3",
       "lang": {
         "selector": "/html/@lang",
         "type": "xpath",
@@ -211,9 +249,15 @@
     }
   },
   "custom_settings": {
-    "attributesForFaceting": ["lang", "tags", "site"],
+    "attributesForFaceting": [
+      "lang",
+      "tags",
+      "site"
+    ],
     "separatorsToIndex": "_+@/"
   },
-  "conversation_id": ["771112570"],
-  "nb_hits": 36765
+  "conversation_id": [
+    "771112570"
+  ],
+  "nb_hits": 36822
 }

--- a/configs/brew_all.json
+++ b/configs/brew_all.json
@@ -45,6 +45,14 @@
       "extra_attributes": {
         "site": ["formulae"]
       }
+    },
+    {
+      "url": "https://formulae.brew.sh/analytics/$",
+      "selectors_key": "analytics",
+      "tags": ["analytics", "formula"],
+      "extra_attributes": {
+        "site": ["formulae"]
+      }
     }
   ],
   "sitemap_urls": [
@@ -154,6 +162,22 @@
       "lvl4": "#page h5",
       "lvl5": "#page h6",
       "text": "#page p, #page li",
+      "lang": {
+        "selector": "/html/@lang",
+        "type": "xpath",
+        "global": true,
+        "default_value": "en"
+      }
+    },
+    "analytics": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Analytics"
+      },
+      "lvl1": "#page h1",
+      "lvl2": "#page h2",
+      "text": "#page td:first-child",
       "lang": {
         "selector": "/html/@lang",
         "type": "xpath",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Follow up to #3931 and #3922. See https://github.com/algolia/docsearch-configs/pull/3931#issuecomment-814530447

The analytics pages were intentionally excluded because they were making the crawl timeout. However, it would be helpful for these pages to still show up. The formulae linked on the pages, though, need not appear in the search.

Link showing maintainership: https://github.com/Homebrew/brew#who-we-are

Sitemaps: https://brew.sh/sitemap.xml, https://formulae.brew.sh/sitemap.xml

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

Searching for "analytics" or "formula install events" don't return the expected pages on https://brew.sh and https://formulae.brew.sh.

### What is the expected behaviour?

Searching for "analytics" would show a result for https://formulae.brew.sh/analytics/. Searching for formula install events would show results for pages like https://formulae.brew.sh/analytics/install/30d/ and https://formulae.brew.sh/analytics-linux/install/30d/.

##### NB: Do you want to request a **feature** or report a **bug**?

I'd classify this as a bug

##### NB2: Any other feedback / questions ?

I've copied this change from the [gist](https://gist.github.com/shortcuts/0d348d9f77415e85ecbfc120f1e3520d#file-brew_all-json-L70-L82) that was linked in https://github.com/algolia/docsearch-configs/pull/3931#issuecomment-815016964. I've looked over it to verify that it seems to fit what I'm looking for, but I'm not super familiar with these configuration files so it's possible that I'm misunderstanding what this will do.

One thing I'm not sure about is whether the 30d/90d/365d distinction will be handled by the search? For each analytics category, we have three different time periods (which really is three different pages) so, ideally, each one would show up in the search so the user to navigate directly to the one they want.

Also, I don't think we need to include the `/api/*` entries in the table on https://formulae.brew.sh/analytics/. I think these will be automatically excluded because they are JSON files and should be excluded by the `stop_urls` entry.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
