### PR TITLE
Fix incorrect selector for level 0 on Commerce.js

### DIFF
--- a/configs/commercejs.json
+++ b/configs/commercejs.json
@@ -25,7 +25,7 @@
   "selectors": {
     "default": {
       "lvl0": {
-        "selector": ".docs-layout .docs-side-nav__section-header .docs-side-nav__section-header--active",
+        "selector": ".docs-layout .docs-side-nav__section-header.docs-side-nav__section-header--active",
         "default_value": "Documentation"
       },
       "lvl1": "main h1",


### PR DESCRIPTION
# Pull request motivation(s)

Commerce.js docs still is showing the incorrect level 0 value

### What is the current behaviour?

The selector for level zero is never matching as it's incorrectly looking for a child

### What is the expected behaviour?

It shouldn't look for a child, but instead look for the active tag

Sorry for another PR. 3rd time's the charm? 🙈 
