### PR TITLE
Update apiato.json to remove the subdomain

### DIFF
--- a/configs/apiato.json
+++ b/configs/apiato.json
@@ -1,10 +1,10 @@
 {
   "index_name": "apiato",
   "start_urls": [
-    "http://docs.apiato.io/docs/"
+    "http://apiato.io/docs/"
   ],
   "sitemap_urls": [
-    "http://docs.apiato.io/sitemap.xml"
+    "http://apiato.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
Update the documentation URL from http://docs.apiato.io/docs to http://apiato.io/docs.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

The documentation was accessible at this subdomain http://docs.apiato.io

### What is the expected behaviour?

The documentation should be accessible without the subdomain http://apiato.io/docs


<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
