### PR TITLE
Change requester start_urls

### DIFF
--- a/configs/requester.json
+++ b/configs/requester.json
@@ -1,7 +1,7 @@
 {
   "index_name": "requester",
   "start_urls": [
-    "http://requester.org/"
+    "https://kylebebak.github.io/Requester/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

This following is basically copied from some emails I exchanged with Clement Vannicatte.

>I am the maintainer of https://kylebebak.github.io/Requester/. I actually already registered this docs site for Algolia DocSearch, at http://requester.org, but I forgot to pay the annual fee last year and Namecheap auctioned the domain off to a third party. Buying it now would cost me $670.00... So I just moved the docs site to GitHub Pages =)

>Here's the config that DocSearch was using for the requester.org: https://github.com/algolia/docsearch-configs/blob/master/configs/requester.json. The content is the same as it was before, so I think using the same config would be ideal!

Basically, I'm just updating first URL in the `start_urls` field from http://requester.org to https://kylebebak.github.io/Requester/. http://requester.org is dead and won't be coming back =/

### What is the current behaviour?

If a user goes to https://kylebebak.github.io/Requester/, searches for something using Algolia, and clicks on a result, they're sent to http://requester.org, which is dead.

### What is the expected behaviour?

The user shouldn't be sent to http://requester.org; they should remain at https://kylebebak.github.io/Requester/