### PR TITLE
Use the `/latest` branch for Godot documentation

### DIFF
--- a/configs/godotengine.json
+++ b/configs/godotengine.json
@@ -5,7 +5,7 @@
       "url": "https://docs.godotengine.org/en/(?P<version>.*?)/",
       "variables": {
         "version": {
-          "url": "https://docs.godotengine.org/en/stable/",
+          "url": "https://docs.godotengine.org/en/latest/",
           "js": "let versions=[]; for (let b of document.querySelectorAll('.rst-other-versions dl:nth-child(2) dd')){versions.push(b.innerText)};return JSON.stringify(versions)"
         }
       }


### PR DESCRIPTION
Algolia will be first experimented with on `/latest` rather than `/stable`.

See https://github.com/godotengine/godot-docs/issues/4461#issuecomment-821846303.