### PR TITLE
H2O Wave docs domain change

### DIFF
--- a/configs/wave.json
+++ b/configs/wave.json
@@ -1,10 +1,10 @@
 {
   "index_name": "wave",
   "start_urls": [
-    "https://h2oai.github.io/wave/"
+    "https://wave.h2o.ai/"
   ],
   "sitemap_urls": [
-    "https://h2oai.github.io/wave/sitemap.xml"
+    "https://wave.h2o.ai/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
We have recently changed our docs domain which resulted in incorrectly indexed page (based on old domain), giving us 404 on hitting search results. This PR should resolve the problem.