### PR TITLE
temporal config: updating start_urls

### DIFF
--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -2,34 +2,33 @@
   "index_name": "temporal",
   "start_urls": [
     {
-      "url": "https://docs.temporal.io/docs/concept-overview",
+      "url": "https://docs.temporal.io/docs/concepts/introduction",
       "page_rank": 999
     },
     {
-      "url": "https://docs.temporal.io/docs/concept-workflows",
+      "url": "https://docs.temporal.io/docs/concepts/workflows",
       "page_rank": 998
     },
     {
-      "url": "https://docs.temporal.io/docs/concept-activities",
+      "url": "https://docs.temporal.io/docs/concepts/activities",
       "page_rank": 997
     },
     {
-      "url": "https://docs.temporal.io/docs/concept-events",
+      "url": "https://docs.temporal.io/docs/concepts/events",
       "page_rank": 996
     },
     {
-      "url": "https://docs.temporal.io/docs/concept-queries",
+      "url": "https://docs.temporal.io/docs/concepts/queries",
       "page_rank": 995
     },
     {
-      "url": "https://docs.temporal.io/docs/concept-task-queues",
+      "url": "https://docs.temporal.io/docs/concepts/task-queues",
       "page_rank": 994
     },
     {
-      "url": "https://docs.temporal.io/docs/get-started",
+      "url": "https://docs.temporal.io/",
       "page_rank": 1
-    },
-    "https://docs.temporal.io/docs/"
+    }
   ],
   "sitemap_urls": [
     "https://docs.temporal.io/sitemap.xml"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

The urls of our pages have changed recently. This an attempt to propagate those changes to our search config.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

The page urls in the config do not match our actual page urls.
But, this has not caused any known negative behavior. But its possible the page ranking is not having any effect.

### What is the expected behaviour?

If the page URLs match then the start_urls page rank will probably work as expected if it has not been.

##### NB: Do you want to request a **feature** or report a **bug**?

N/A

##### NB2: Any other feedback / questions ?

N/A

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
