### PR TITLE
Pype project rename to OpenPype

### DIFF
--- a/configs/openpype.json
+++ b/configs/openpype.json
@@ -1,7 +1,7 @@
 {
-  "index_name": "pype",
-  "start_urls": ["https://pype.club/"],
-  "sitemap_urls": ["https://pype.club/sitemap.xml"],
+  "index_name": "openpype",
+  "start_urls": ["https://openpype.io/"],
+  "sitemap_urls": ["https://openpype.io/sitemap.xml"],
   "sitemap_alternate_links": true,
   "stop_urls": ["/blog/"],
   "selectors": {


### PR DESCRIPTION
Hi.

We've recently renamed the project to OpenPype and updated a lot of the documentation, so we need to tweak the config here, to point to correct URL 

Thanks