### PR TITLE
adding some language based content ranking for temporal.io search

### DIFF
--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -113,7 +113,7 @@
   "stop_urls": [
     "https://docs.temporal.io/blog/tags/announcement/",
     "https://docs.temporal.io/blog/tags/case-study/",
-    "https://docs.temporal.io/blog/page/2/",
+    "https://docs.temporal.io/blog/tags/"
   ],
   "selectors": {
     "lvl0": {

--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -7,26 +7,102 @@
     },
     {
       "url": "https://docs.temporal.io/docs/concepts/workflows",
-      "page_rank": 998
+      "page_rank": 999
     },
     {
       "url": "https://docs.temporal.io/docs/concepts/activities",
-      "page_rank": 997
+      "page_rank": 999
     },
     {
       "url": "https://docs.temporal.io/docs/concepts/events",
-      "page_rank": 996
+      "page_rank": 999
     },
     {
       "url": "https://docs.temporal.io/docs/concepts/queries",
-      "page_rank": 995
+      "page_rank": 999
     },
     {
       "url": "https://docs.temporal.io/docs/concepts/task-queues",
+      "page_rank": 999
+    },
+    {
+      "url": "https://docs.temporal.io/docs/glossary",
+      "page_rank": 999
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/introduction",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/quick-install",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/production-deployment",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/server-architecture",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/versions-and-dependencies",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/namespaces",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/workflow-search",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/elasticsearch-setup",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/options",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/security",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/configuration",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/server/archive-data",
+      "page_rank": 998
+    },
+    {
+      "url": "https://docs.temporal.io/docs/go/introduction",
+      "page_rank": 997
+    },
+    {
+      "url": "https://docs.temporal.io/docs/java/introduction",
+      "page_rank": 996
+    },
+    {
+      "url": "https://docs.temporal.io/docs/php/introduction",
+      "page_rank": 995
+    },
+    {
+      "url": "https://docs.temporal.io/docs/node/introduction",
+      "page_rank": 994
+    },
+    {
+      "url": "https://docs.temporal.io/docs/system-tools/tctl",
       "page_rank": 994
     },
     {
       "url": "https://docs.temporal.io/",
+      "page_rank": 2
+    }
+    {
+      "url": "https://docs.temporal.io/blog",
       "page_rank": 1
     }
   ],
@@ -34,7 +110,11 @@
     "https://docs.temporal.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
+  "stop_urls": [
+    "https://docs.temporal.io/blog/tags/announcement/",
+    "https://docs.temporal.io/blog/tags/case-study/",
+    "https://docs.temporal.io/blog/page/2/",
+  ],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",

--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -100,7 +100,7 @@
     {
       "url": "https://docs.temporal.io/",
       "page_rank": 2
-    }
+    },
     {
       "url": "https://docs.temporal.io/blog",
       "page_rank": 1
@@ -151,5 +151,5 @@
   "conversation_id": [
     "1206028908"
   ],
-  "nb_hits": 2523
+  "nb_hits": 3992
 }


### PR DESCRIPTION
# Pull request motivation(s)

adding some language based content ranking for temporal.io search


### What is the current behaviour?

we were getting a lot of results out of order with less relevant SDKs up top (search "workflows" and you get PHP first, when most people will want Server and Go and Java docs first). 

also had a lot of repeat blog results from the multiple indexes. (so my solution is to use `stop_urls`... i hope it works)

### What is the expected behaviour?

more relevant search results