### PR TITLE
Update motionroutes config file

### DIFF
--- a/configs/motionroutes.json
+++ b/configs/motionroutes.json
@@ -1,19 +1,27 @@
 {
   "index_name": "motionroutes",
-  "start_urls": ["https://docs.motionroutes.com/"],
+  "start_urls": [
+    {
+      "url": "https://docs.motionroutes.com/",
+      "extra_attributes": {
+        "language": [
+          "fr"
+        ]
+      }
+    }
+  ],
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "",
-      "global": true,
+      "selector": "aside > div > ul > li.active > p",
       "default_value": "Documentation"
     },
-    "lvl1": "article h1",
-    "lvl2": "article h2",
-    "lvl3": "article h3",
-    "lvl4": "article h4",
-    "lvl5": "article h5",
-    "text": "article p, article li",
+    "lvl1": "div.flex div article.prose h1",
+    "lvl2": "div.flex div article.prose h2",
+    "lvl3": "div.flex div article.prose h3",
+    "lvl4": "div.flex div article.prose h4",
+    "lvl5": "div.flex div article.prose h5",
+    "text": "div.flex div article.prose p, div.flex div article.prose li",
     "language": {
       "selector": "/html/@lang",
       "type": "xpath",
@@ -21,6 +29,8 @@
       "default_value": "en-US"
     }
   },
-  "conversation_id": ["1489169376"],
+  "conversation_id": [
+    "1489169376"
+  ],
   "nb_hits": 84
 }


### PR DESCRIPTION
# Pull request motivation(s)
We are updating our config file to let the crawler detect certain selectors

### What is the current behaviour?
Docsearch is not able to detect any kind of text
*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*
![Bug screenshott](https://ibb.co/sP8RxfF)
### What is the expected behaviour?
Docsearch should be able to detect almost all elements in any given page

##### NB: Do you want to request a **feature** or report a **bug**?
update config

##### NB2: Any other feedback / questions ?

