### PR TITLE
Add /kata, /stats, and /podcasts in coderdojo.json

### DIFF
--- a/configs/coderdojo.json
+++ b/configs/coderdojo.json
@@ -1,5 +1,6 @@
 {
   "index_name": "coderdojo",
+  "start_urls": [],
   "sitemap_urls": [
     "https://coderdojo.jp/sitemap.xml"
   ],

--- a/configs/coderdojo.json
+++ b/configs/coderdojo.json
@@ -1,6 +1,11 @@
 {
   "index_name": "coderdojo",
-  "start_urls": [],
+  "start_urls": [
+    "https://coderdojo.jp/docs/",
+    "https://coderdojo.jp/kata",
+    "https://coderdojo.jp/stats",
+    "https://coderdojo.jp/podcasts"
+  ],
   "sitemap_urls": [
     "https://coderdojo.jp/sitemap.xml"
   ],
@@ -14,7 +19,6 @@
     "lvl5": "section h6",
     "text": "section p, section li"
   },
-  "scrape_start_urls": false,
   "conversation_id": [
     "796519865"
   ],

--- a/configs/coderdojo.json
+++ b/configs/coderdojo.json
@@ -1,11 +1,5 @@
 {
   "index_name": "coderdojo",
-  "start_urls": [
-    "https://coderdojo.jp/docs/",
-    "https://coderdojo.jp/kata",
-    "https://coderdojo.jp/stats",
-    "https://coderdojo.jp/podcasts"
-  ],
   "sitemap_urls": [
     "https://coderdojo.jp/sitemap.xml"
   ],

--- a/configs/coderdojo.json
+++ b/configs/coderdojo.json
@@ -1,7 +1,10 @@
 {
   "index_name": "coderdojo",
   "start_urls": [
-    "https://coderdojo.jp/docs/"
+    "https://coderdojo.jp/docs/",
+    "https://coderdojo.jp/kata",
+    "https://coderdojo.jp/stats",
+    "https://coderdojo.jp/podcasts"
   ],
   "sitemap_urls": [
     "https://coderdojo.jp/sitemap.xml"


### PR DESCRIPTION
# Pull request motivation(s)

Hi! Thanks for supporting [:octocat: coderdojo-japan/coderdojo.jp](https://github.com/coderdojo-japan/coderdojo.jp) website via [DocSearch program](https://www.algolia.com/for-open-source/). 😆

I am [owner of the website](https://github.com/coderdojo-japan/coderdojo.jp/graphs/contributors). Based on requests from our visitors we would like to add a wiki page ([/kata](https://coderdojo.jp/kata)), stats page ([/stats](https://coderdojo.jp/stats)), and podcasting page ([/podcasts](https://coderdojo.jp/podcasts)) to `start_urls` in `coderdojo.json` to be indexed. 🔍 

In order to provide better Algolia search UX with our visitors, hope you consider merging this PR. 

### What is the current behaviour?

* Only pages under [/docs](https://coderdojo.jp/docs) are searchable but our visitors often expect search results to include a wiki page ([/kata](https://coderdojo.jp/kata)), stats page ([/stats](https://coderdojo.jp/stats)), and podcasting page ([/podcasts](https://coderdojo.jp/podcasts)).

### What is the expected behaviour?

* I would like to index the pages above in addition to existing URL ([/docs](https://coderdojo.jp/docs)) so that our visitors can find out information they want before contacting us by emails.