### PR TITLE
Added the 3.2.0 sitemap URL

### DIFF
--- a/configs/wso2.json
+++ b/configs/wso2.json
@@ -17,7 +17,8 @@
     "https://apim.docs.wso2.com/en/latest/sitemap.xml",
     "https://apim.docs.wso2.com/en/next/sitemap.xml",
     "https://apim.docs.wso2.com/en/3.0.0/sitemap.xml",
-    "https://apim.docs.wso2.com/en/3.1.0/sitemap.xml"
+    "https://apim.docs.wso2.com/en/3.1.0/sitemap.xml",
+    "https://apim.docs.wso2.com/en/3.2.0/sitemap.xml"
 
   ],
   "conversation_id": [


### PR DESCRIPTION
Now WSO2 API Manager 4.0.0 documentation points to the latest URL because it is the latest release. Therefore, we need to have a sitemap URL for APIM 3.2.0.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
To index the WSO2 API Manager 3.2.0 documentation.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
