### PR TITLE
Fixing the luckyframework URL for the sitemaps

### DIFF
--- a/configs/luckyframework.json
+++ b/configs/luckyframework.json
@@ -4,7 +4,7 @@
     "https://luckyframework.org/guides/"
   ],
   "sitemap_urls": [
-    "https://luckyframework.com/sitemap.xml"
+    "https://luckyframework.org/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
I noticed the `sitemap_urls` showed `.com` for the TLD, but it should be `.org`

https://luckyframework.org/sitemap.xml

