### PR TITLE
index not just docs, but also blog, etc

### DIFF
--- a/configs/fluxcd.json
+++ b/configs/fluxcd.json
@@ -1,7 +1,7 @@
 {
   "index_name": "fluxcd",
   "start_urls": [
-    "https://fluxcd.io/docs/"
+    "https://fluxcd.io/"
   ],
   "sitemap_urls": [
     "https://fluxcd.io/sitemap.xml"


### PR DESCRIPTION
For <https://fluxcd.io>, we would like to index not just `/docs` but also our blog and the main site. Thanks a lot!