### PR TITLE
romefrontend: update url

### DIFF
--- a/configs/romefrontend.json
+++ b/configs/romefrontend.json
@@ -1,7 +1,7 @@
 {
   "index_name": "romefrontend",
   "start_urls": [
-    "https://romefrontend.dev/"
+    "https://rome.tools/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
https://romefrontend.dev isn't live anymore, it's now https://rome.tools. The results still seem fairly relevant, so I assume the nbHits is correct? 

The domain was changed back in December: https://twitter.com/rometools/status/1336022273313153036

cc @sebmck