### PR TITLE
Pull request motivation(s)

### DIFF
--- a/configs/tigera.json
+++ b/configs/tigera.json
@@ -4,7 +4,8 @@
     "https://docs.tigera.io/"
   ],
   "sitemap_urls": [
-    "https://docs.tigera.io/sitemap.xml"
+    "https://docs.tigera.io/sitemap.xml",
+    "https://docs.tigera.io/release-legacy-sitemap.xml"
   ],
   "stop_urls": [
     "/releases"


### PR DESCRIPTION
Since legacy site mapping is not included, Algolia search does not work on older versions of the site.
I guess it will fix the problem.

