### PR TITLE
Add versions for banuba.json

### DIFF
--- a/configs/banuba.json
+++ b/configs/banuba.json
@@ -1,10 +1,16 @@
 {
   "index_name": "banuba",
   "start_urls": [
-    "https://docs.banuba.com/face-ar-sdk/"
+    {
+      "url": "https://docs.banuba.com/(?P<version>.*?)/",
+      "variables": {
+        "version": ["face-ar-sdk", "face-ar-sdk-v1"]
+      }
+    }
   ],
   "sitemap_urls": [
-    "https://docs.banuba.com/face-ar-sdk/sitemap.xml"
+    "https://docs.banuba.com/face-ar-sdk/sitemap.xml",
+    "https://docs.banuba.com/face-ar-sdk-v1/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

Our software has two major versions, both of them will be maintained in the near feature. Because of this we also have two docs versions:
-    https://docs.banuba.com/face-ar-sdk
-    https://docs.banuba.com/face-ar-sdk-v1

These versions are diverged that's why we need to separate their index and search results.

## NB2: Any other feedback / questions ?

Not sure if [this](https://github.com/algolia/docsearch-configs/compare/master...akrivbanuba:patch-1#diff-ea49c333e36bab6ba9c3255384dce49d4bf89e17f1cb88438d6a4fc2f2fa6e31R12) would work for two sitemaps, is this correct construction for versioned docs?

```
"sitemap_urls": [
    "https://docs.banuba.com/face-ar-sdk/sitemap.xml",
    "https://docs.banuba.com/face-ar-sdk-v1/sitemap.xml"
  ],
```
