### PR TITLE
Update datachat.json

### DIFF
--- a/configs/datachat.json
+++ b/configs/datachat.json
@@ -8,13 +8,13 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".main h1",
-    "lvl1": ".main h2",
-    "lvl2": ".main h3",
-    "lvl3": ".main h4",
-    "lvl4": ".main h5",
-    "lvl5": ".main h6",
-    "text": ".main p, .main li"
+    "lvl0": "article header h1",
+    "lvl1": ".markdown h2",
+    "lvl2": ".markdown h3",
+    "lvl3": ".markdown h4",
+    "lvl4": ".markdown h5",
+    "lvl5": ".markdown h6",
+    "text": ".markdown p, .markdown li, .markdown ul, .markdown code"
   },
   "conversation_id": [
     "1482282279"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?
On my site, docs.datachat.ai, the search index contains content from the old version of my site (with a different file structure) and the new site, leading to some things being double indexed in the search results. For example, searching for "Slice" provides the following results:
<img width="573" alt="Screen Shot 2021-05-18 at 11 05 54 AM" src="https://user-images.githubusercontent.com/44580393/118685813-07acb280-b7c9-11eb-84d0-430f87839692.png">

The purple result goes to a dead link (because the site's structure has changed), while the link above it succeeds. You can also see that these are duplicate results.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
Only the content live on the site is returned by the search.

##### NB: Do you want to request a **feature** or report a **bug**?
Bug.

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
