### PR TITLE
Add new url path to config

### DIFF
--- a/configs/gooddata.json
+++ b/configs/gooddata.json
@@ -1,47 +1,53 @@
 {
-    "index_name": "gooddata",
-    "start_urls": [
-        "https://sdk.gooddata.com/gooddata-ui/docs/",
-        "https://sdk.gooddata.com/gooddata-ui/docs/about_gooddataui.html",
-        {
-            "url": "https://sdk.gooddata.com/gooddata-ui-apidocs/v(?P<version>.*?)/",
-            "variables": {
-                "version": ["8.4.0", "Next"]
-            },
-            "tags": ["gooddata-ui-apidocs"]
-        },
-        {
-            "url": "https://sdk.gooddata.com/gooddata-ui-apidocs/v(?P<version>.*?)/docs/index.html",
-            "variables": {
-                "version": ["8.4.0", "Next"]
-            },
-            "tags": ["gooddata-ui-apidocs"]
-        }
-    ],
-    "stop_urls": [],
-    "sitemap_urls": [
-        "https://sdk.gooddata.com/gooddata-ui/sitemap.xml",
-        "https://sdk.gooddata.com/gooddata-ui-apidocs/v8.4.0/sitemap.xml",
-        "https://sdk.gooddata.com/gooddata-ui-apidocs/vNext/sitemap.xml"
-    ],
-    "sitemap_alternate_links": true,
-    "selectors": {
-        "lvl0": {
-            "selector": "//*[contains(@class,'navGroupActive')]//a[contains(@class,'navItemActive')]/preceding::h3[1]",
-            "type": "xpath",
-            "global": true,
-            "default_value": "Documentation"
-        },
-        "lvl1": ".post h1",
-        "lvl2": ".post h2",
-        "lvl3": ".post h3",
-        "lvl4": ".post h4",
-        "text": ".post article p, .post article li"
+  "index_name": "gooddata",
+  "start_urls": [
+    {
+      "url": "https://sdk.gooddata.com/gooddata-ui/docs/",
+      "tags": ["gooddata-ui-docs"]
     },
-    "selectors_exclude": [".hash-link"],
-    "custom_settings": {
-        "attributesForFaceting": ["version"]
+    {
+      "url": "https://sdk.gooddata.com/gooddata-ui/docs/about_gooddataui.html",
+      "tags": ["gooddata-ui-docs"]
     },
-    "conversation_id": ["591776394"],
-    "nb_hits": 25185
+    {
+      "url": "https://sdk.gooddata.com/gooddata-ui-apidocs/v(?P<version>.*?)/",
+      "variables": {
+        "version": ["8.4.0", "Next"]
+      },
+      "tags": ["gooddata-ui-apidocs"]
+    },
+    {
+      "url": "https://sdk.gooddata.com/gooddata-ui-apidocs/v(?P<version>.*?)/docs/index.html",
+      "variables": {
+        "version": ["8.4.0", "Next"]
+      },
+      "tags": ["gooddata-ui-apidocs"]
+    }
+  ],
+  "stop_urls": [],
+  "sitemap_urls": [
+    "https://sdk.gooddata.com/gooddata-ui/sitemap.xml",
+    "https://sdk.gooddata.com/gooddata-ui-apidocs/v8.4.0/sitemap.xml",
+    "https://sdk.gooddata.com/gooddata-ui-apidocs/vNext/sitemap.xml"
+  ],
+  "sitemap_alternate_links": true,
+  "selectors": {
+    "lvl0": {
+      "selector": "//*[contains(@class,'navGroupActive')]//a[contains(@class,'navItemActive')]/preceding::h3[1]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": ".post h1",
+    "lvl2": ".post h2",
+    "lvl3": ".post h3",
+    "lvl4": ".post h4",
+    "text": ".post article p, .post article li"
+  },
+  "selectors_exclude": [".hash-link"],
+  "custom_settings": {
+    "attributesForFaceting": ["version", "tags"]
+  },
+  "conversation_id": ["591776394"],
+  "nb_hits": 25185
 }

--- a/configs/gooddata.json
+++ b/configs/gooddata.json
@@ -4,10 +4,18 @@
         "https://sdk.gooddata.com/gooddata-ui/docs/",
         "https://sdk.gooddata.com/gooddata-ui/docs/about_gooddataui.html",
         {
+            "url": "https://sdk.gooddata.com/gooddata-ui-apidocs/v(?P<version>.*?)/",
+            "variables": {
+                "version": ["8.4.0", "Next"]
+            },
+            "tags": ["gooddata-ui-apidocs"]
+        },
+        {
             "url": "https://sdk.gooddata.com/gooddata-ui-apidocs/v(?P<version>.*?)/docs/index.html",
             "variables": {
                 "version": ["8.4.0", "Next"]
-            }
+            },
+            "tags": ["gooddata-ui-apidocs"]
         }
     ],
     "stop_urls": [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Hello, yesterday I have created a new config with additional urls (https://github.com/algolia/docsearch-configs/pull/4087); however, the search is not working as I expected. This is my fault that I have not included more open path for the crawler so I am adding it right now. 

The bigger issue that we are encountering right now is that we have two URLs and we need to separate the crawler so search is not looking into both paths at the same time.

### What is the expected behaviour?
When I am in the `gooddata-ui` path I will be able to search only the content of `gooddata-ui`. Same with `gooddata-ui-apidocs` I will be able to seach only content of `gooddata-ui-apidocs`. I hope we can resolve this somehow in the config, so far I have gone through the documentation and `stop_urls` seems like it won't do the job. Thank you for any suggestions


<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
