### PR TITLE
Update apimatic.json

### DIFF
--- a/configs/apimatic.json
+++ b/configs/apimatic.json
@@ -6,26 +6,41 @@
   "sitemap_urls": [
     "https://docs.apimatic.io/sitemap.xml"
   ],
-  "stop_urls": [
-    "https://docs.apimatic.io$",
-    "api-description",
-    "keep-in-touch"
-  ],
+  "sitemap_alternate_links": true,
+  "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//div[contains(@class, 'toc')]/ul/li/ul/li/a[contains(@class, 'selected')]/../../preceding::h5[1]",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
       "type": "xpath",
+      "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "article h1",
+    "lvl1": "header h1",
     "lvl2": "article h2",
     "lvl3": "article h3",
     "lvl4": "article h4",
-    "lvl5": "article h5",
-    "text": "article p, article li, article td"
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
-  "min_indexed_level": 1,
-  "scrape_start_urls": false,
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  },
   "conversation_id": [
     "256019787"
   ],


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

APIMatic has migrated to Docusaurus 2. I have updated the apimatic.json, adapted from https://github.com/algolia/docsearch-configs/blob/5ca11a9/configs/docusaurus-2.json.

I don't know how accurate my work is. This will need review.

Note that, unlike the Docusaurus team, we do not use versioning and do not have translated docs. We also have a [changelog](https://docs.apimatic.io/changelog) (based on Docusaurus blog) alongside the main docs.

### What is the current behaviour?

The search config for APIMatic was based on a custom Hugo docs that is no longer up.

### What is the expected behaviour?

Search works on the new Docusaurus site. I have attempted to submit a patch for the config. Once you confirm the patch, I can update my Docusaurus site to add search again.

##### NB: Do you want to request a **feature** or report a **bug**?

Update to APIMatic's config.

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->

No.