### PR TITLE
Add Spark version 3.1.2 to apache_spark.json

### DIFF
--- a/configs/apache_spark.json
+++ b/configs/apache_spark.json
@@ -4,7 +4,7 @@
     {
       "url": "https://spark.apache.org/docs/(?P<version>.*?)/",
       "variables": {
-        "version": ["latest", "3.1.1"]
+        "version": ["latest", "3.1.1", "3.1.2"]
       }
     }
   ],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
As the Apache Spark community is going to release 3.1.2, we should index the Spark documentation of the new version.

### What is the current behaviour?

The Spark documentation for 3.1.2 is not indexed.
### What is the expected behaviour?
The Spark documentation for 3.1.2 is indexed.
