### PR TITLE
Adding examples to searchable content

### DIFF
--- a/configs/serverless-stack.json
+++ b/configs/serverless-stack.json
@@ -1,7 +1,8 @@
 {
   "index_name": "serverless-stack",
   "start_urls": [
-    "https://serverless-stack.com/chapters/"
+    "https://serverless-stack.com/chapters/",
+    "https://serverless-stack.com/examples/"
   ],
   "stop_urls": [],
   "sitemap_urls": [


### PR DESCRIPTION
Hi there, we recently added a new section to the site that needs to be indexed as well. Hopefully adding to the `start_urls` does that.

Let me know if it doesn't!