### PR TITLE
Take French part of website into account

### DIFF
--- a/configs/centreon.json
+++ b/configs/centreon.json
@@ -1,12 +1,22 @@
 {
   "index_name": "centreon",
   "start_urls": [
-    "https://docs.centreon.com/",
-    "https://docs.centreon.com/current/en/"
+    {
+      "url": "https://docs.centreon.com/(?P<version>.*?)/(?P<language>.*?)/",
+      "variables": {
+        "version": [
+          "21.04",
+          "20.10",
+          "20.04"
+        ],
+        "language": [
+          "en",
+          "fr"
+        ]
+      }
+    }
   ],
-  "sitemap_urls": [
-    "https://docs.centreon.com/sitemap.xml"
-  ],
+  "sitemap_urls": [],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
@@ -35,5 +45,5 @@
   "conversation_id": [
     "1142111397"
   ],
-  "nb_hits": 18160
+  "nb_hits": 153247
 }


### PR DESCRIPTION
The search was only returning results from the English part of our website. Algolia provided a new configuration file so that the search also works on the French part of the site.

# Pull request motivation(s)

### What is the current behaviour?
The search is only returning results from the English part of our website.

### What is the expected behaviour?

A search on the French website 'https://docs.centreon.com/21.04/fr/getting-started/installation-first-steps.html) should return results in French.
