### PR TITLE
fix(mapillary): add config sitemap url and lvl6

### DIFF
--- a/configs/mapillary.json
+++ b/configs/mapillary.json
@@ -3,6 +3,9 @@
   "start_urls": [
     "https://mapillary.github.io/mapillary-js/"
   ],
+  "sitemap_urls": [
+    "https://mapillary.github.io/mapillary-js/sitemap.xml"
+  ],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
@@ -17,6 +20,7 @@
     "lvl3": "article h3",
     "lvl4": "article h4",
     "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
     "text": "article p, article li, article td:last-child"
   },
   "strip_chars": " .,;:#",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Make the mapillary config equivalent to the [Docusaurus 2 config](https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json). Add sitemap URL to comply with the [required configuration specification](https://docsearch.algolia.com/docs/required-configuration).

### What is the current behaviour?

Search works in the MapillaryJS [navbar search box](https://mapillary.github.io/mapillary-js/), but not on the [`/search`](https://mapillary.github.io/mapillary-js/search) page. Maybe the sitemap URL will help resolve the problem.

### What is the expected behaviour?

Search works on the [`/search`](https://mapillary.github.io/mapillary-js/search) page.


<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
