### PR TITLE
Use sitemap for docs.aspect.dev

### DIFF
--- a/configs/aspect.json
+++ b/configs/aspect.json
@@ -1,9 +1,6 @@
 {
   "index_name": "aspect",
-  "start_urls": [
-    "https://docs.aspect.dev"
-  ],
-  "stop_urls": [],
+  "sitemap_urls": ["https://docs.aspect.dev/sitemap.xml"],
   "selectors": {
     "lvl0": ".container h1",
     "lvl1": ".container h2",

--- a/configs/aspect.json
+++ b/configs/aspect.json
@@ -1,6 +1,11 @@
 {
   "index_name": "aspect",
-  "sitemap_urls": ["https://docs.aspect.dev/sitemap.xml"],
+  "start_urls": [
+    "https://docs.aspect.dev"
+  ],
+  "sitemap_urls": [
+    "https://docs.aspect.dev/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": ".container h1",
     "lvl1": ".container h2",

--- a/configs/aspect.json
+++ b/configs/aspect.json
@@ -1,8 +1,6 @@
 {
   "index_name": "aspect",
-  "start_urls": [
-    "https://docs.aspect.dev"
-  ],
+  "start_urls": [],
   "sitemap_urls": [
     "https://docs.aspect.dev/sitemap.xml"
   ],


### PR DESCRIPTION
Prevents the crawler from seeing historical versions of docs (currently there are five copies of rules_nodejs docs for example)

Per https://docsearch.algolia.com/docs/config-file#sitemap_urls-optional this can replace start_urls