### PR TITLE
Changed eth2-docker.net to eth-docker.net

### DIFF
--- a/configs/eth2-docker.json
+++ b/configs/eth2-docker.json
@@ -1,10 +1,10 @@
 {
-  "index_name": "eth2-docker",
+  "index_name": "eth-docker",
   "start_urls": [
-    "https://eth2-docker.net"
+    "https://eth-docker.net"
   ],
   "sitemap_urls": [
-    "https://eth2-docker.net/sitemap.xml"
+    "https://eth-docker.net/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
We're changing the name of the tool

# Pull request motivation(s)

Ethereum Foundation is deprecating the use of "eth2/eth1" in all docs; we are following suit.
