### PR TITLE
Update rucio-cern.json (now docusaurus v2)

### DIFF
--- a/configs/rucio-cern.json
+++ b/configs/rucio-cern.json
@@ -44,5 +44,5 @@
   "conversation_id": [
     "1339779250"
   ],
-  "nb_hits": 3259
+  "nb_hits": 8071
 }

--- a/configs/rucio-cern.json
+++ b/configs/rucio-cern.json
@@ -1,37 +1,46 @@
 {
   "index_name": "rucio-cern",
   "start_urls": [
-    "http://rucio.cern.ch/documentation/"
+    "https://rucio.cern.ch/documentation/"
   ],
+  "sitemap_urls": [
+    "https://rucio.cern.ch/documentation/sitemap.xml"
+  ],
+  "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
-    "text": ".post article p, .post article li",
     "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".post h2",
-    "lvl2": ".post h3",
-    "lvl3": ".post h4",
-    "lvl4": ".post h5",
-    "lvl5": ".post h6"
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
-  "selectors_exclude": [
-    ".hash-link"
-  ],
-  "sitemap_urls": [
-    "http://rucio.cern.ch/documentation/sitemap.xml"
-  ],
-  "sitemap_alternate_links": true,
+  "strip_chars": " .,;:#",
   "custom_settings": {
+    "separatorsToIndex": "_",
     "attributesForFaceting": [
       "language",
-      "version"
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
     ]
   },
-  "min_indexed_level": 0,
   "conversation_id": [
     "1339779250"
   ],


### PR DESCRIPTION
https://rucio.cern.ch/documentation/ was updated to docusaurus v2 lately and the search wasn't working anymore after that. I have taken https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json as a base for my changes. Please have a closer look at the `custom_settings` since I do not know if they apply to all docusaurus v2 websites. The selectors check out afaict.