### PR TITLE
fix(svgjs): update domain name to svgjs.dev

### DIFF
--- a/configs/svgjs.json
+++ b/configs/svgjs.json
@@ -1,14 +1,14 @@
 {
   "index_name": "svgjs",
   "start_urls": [
-    "http://svgjs.com/docs/2.7",
-    "http://svgjs.com/docs/3.0",
-    "http://svgjs.com/docs/3.1"
+    "https://svgjs.dev/docs/2.7",
+    "https://svgjs.dev/docs/3.0",
+    "https://svgjs.dev/docs/3.1"
   ],
   "sitemap_urls": [
-    "https://svgjs.com/docs/2.7/sitemap/",
-    "https://svgjs.com/docs/3.0/sitemap/",
-    "https://svgjs.com/docs/3.1/sitemap/"
+    "https://svgjs.dev/docs/2.7/sitemap/",
+    "https://svgjs.dev/docs/3.0/sitemap/",
+    "https://svgjs.dev/docs/3.1/sitemap/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

We don't control the DNS records of our previous domain name (svgjs.com) and it's now pointing to a gambling site. So we bought a new one (https://svgjs.dev).

This PR updates the config for our docs to use the new domain name.