### PR TITLE
Add new menu subsections as entrypoints

### DIFF
--- a/configs/data-driven-forms.json
+++ b/configs/data-driven-forms.json
@@ -6,7 +6,9 @@
     "https://data-driven-forms.org/schema/introduction",
     "https://data-driven-forms.org/hooks/use-field-api",
     "https://data-driven-forms.org/mappers/custom-mapper",
-    "https://data-driven-forms.org/examples/mui-one-row-layout"
+    "https://data-driven-forms.org/examples/mui-one-row-layout",
+    "https://data-driven-forms.org/utilities/standalone-validation",
+    "https://data-driven-forms.org/provided-mappers/component-api"
   ],
   "stop_urls": [
     "https://data-driven-forms.org/mappers/checkbox(?!\\?)",


### PR DESCRIPTION
# Pull request motivation(s)

New subsections have been added to our documentation page. Because the subsections are hidden by React, the crawler does not see them until it opens some of the new pages inside the subsections.