### PR TITLE
update config to make it work on vuepress2

### DIFF
--- a/configs/waline.json
+++ b/configs/waline.json
@@ -22,6 +22,9 @@
       "global": true
     }
   },
+   "custom_settings": {
+    "attributesForFaceting": ["lang"]
+  },
   "js_render": true,
   "conversation_id": [
     "1530163255"


### PR DESCRIPTION
See https://vuepress2.netlify.app/reference/plugin/docsearch.html#get-search-index

![image](https://user-images.githubusercontent.com/33315834/121891664-53159a80-cd4e-11eb-8adb-0a8fefff7391.png)

I think you should also take care of this if other vuepress2 sites are requesting docsearch. I think it wound be nice if it can be corrected on the default config for our sites intead of opening a pr themselevs for everyone using vuepress2 