### PR TITLE
preemptively exclude legacy docs

### DIFF
--- a/configs/fluxcd.json
+++ b/configs/fluxcd.json
@@ -6,7 +6,9 @@
   "sitemap_urls": [
     "https://fluxcd.io/sitemap.xml"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "https://fluxcd.io/legacy"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "",


### PR DESCRIPTION
### What is the current behaviour?

Not sure if you want this level of details, but in fluxcd/website#310 we are looking to integrating our v1 docs into fluxcd.io (instead of being on a separate service on docs.fluxcd.io). We'd like to exclude them from search results though.

Ideally we'd have a second, separate search for this. For now excluding them from search results would do it.


@stefanprodan @kingdonb As discussed in our last meeting, I used https://docsearch.algolia.com/docs/config-file#stop_urls-optional for excluding legacy docs.