### PR TITLE
Updated magic labs config to reflect a new URL and selector.

### DIFF
--- a/configs/magiclabs_magic.json
+++ b/configs/magiclabs_magic.json
@@ -1,7 +1,8 @@
 {
   "index_name": "magiclabs_magic",
   "start_urls": [
-    "https://magic.link/docs"
+    "https://magic.link/docs/",
+    "https://magic.link/docs/introduction/get-started"
   ],
   "sitemap_urls": [
     "https://magic.link/sitemap.xml"
@@ -21,11 +22,8 @@
     "lvl5": "[class^='docsContents___'] h5",
     "text": "[class^='docsContents___'] p, [class^='docsContents___'] li"
   },
-  "selectors_exclude": [
-    ""
-  ],
   "conversation_id": [
     "1225907152"
   ],
-  "nb_hits": 1224
+  "nb_hits": 2521
 }

--- a/configs/magiclabs_magic.json
+++ b/configs/magiclabs_magic.json
@@ -1,28 +1,28 @@
 {
   "index_name": "magiclabs_magic",
   "start_urls": [
-    "https://docs.magic.link/"
+    "https://magic.link/docs"
   ],
   "sitemap_urls": [
-    "https://docs.magic.link/sitemap.xml"
+    "https://magic.link/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": ".menu__link--sublist.menu__link--active",
+      "selector": "accordion__dir.accordion__dir-active",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "[class^='docItemContainer_'] h1",
-    "lvl2": "[class^='docItemContainer_'] h2",
-    "lvl3": "[class^='docItemContainer_'] h3",
-    "lvl4": "[class^='docItemContainer_'] h4",
-    "lvl5": "[class^='docItemContainer_'] h5",
-    "text": "[class^='docItemContainer_'] p, [class^='docItemContainer_'] li"
+    "lvl1": "[class^='docsContents___'] h1",
+    "lvl2": "[class^='docsContents___'] h2",
+    "lvl3": "[class^='docsContents___'] h3",
+    "lvl4": "[class^='docsContents___'] h4",
+    "lvl5": "[class^='docsContents___'] h5",
+    "text": "[class^='docsContents___'] p, [class^='docsContents___'] li"
   },
   "selectors_exclude": [
-    ".hash-link"
+    ""
   ],
   "conversation_id": [
     "1225907152"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
in order to widen the range of our docs and create a granular experience for our users when they want to learn more about our products and also learn more about the vast technology behind them. we decided to move out docs to our private site. here at `https://magic.link/docs`

### What is the current behaviour?
- Doc search crawls data from `docs.magic.link` with was hosted on docusaurus. 
- Doc search has `docs.magic.link` as its `start-url`

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
- Doc search crawls data from `magic.link/docs` with is now hosted by us. 
- Doc search has `magic.link/docs` as its `start-url` and other relative config updates.

##### NB: Do you want to request a **feature** or report a **bug**?
N/A

##### NB2: Any other feedback / questions ?
N/A
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
