### PR TITLE
[Temporal config] add stop url to prevent indexing shared content

### DIFF
--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -113,7 +113,8 @@
   "stop_urls": [
     "https://docs.temporal.io/blog/tags/announcement/",
     "https://docs.temporal.io/blog/tags/case-study/",
-    "https://docs.temporal.io/blog/tags/"
+    "https://docs.temporal.io/blog/tags/",
+    "https:\/\/docs.temporal.io\/docs\/shared\/*"
   ],
   "selectors": {
     "lvl0": {

--- a/configs/temporal.json
+++ b/configs/temporal.json
@@ -111,10 +111,8 @@
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [
-    "https://docs.temporal.io/blog/tags/announcement/",
-    "https://docs.temporal.io/blog/tags/case-study/",
     "https://docs.temporal.io/blog/tags/",
-    "https:\/\/docs.temporal.io\/docs\/shared\/*"
+    "https://docs.temporal.io/docs/shared/"
   ],
   "selectors": {
     "lvl0": {
@@ -152,5 +150,5 @@
   "conversation_id": [
     "1206028908"
   ],
-  "nb_hits": 3992
+  "nb_hits": 4683
 }


### PR DESCRIPTION
# Pull request motivation(s)

algolia was starting to index a private page that wasn't linked... not sure how

![CleanShot 2021-06-15 at 07 42 47](https://user-images.githubusercontent.com/6764957/121972307-50965d80-cdad-11eb-8d33-67bbc17532d7.png)


### What is the expected behaviour?

nothing  that is in the /shared folder should show up in algolia.

![CleanShot 2021-06-15 at 07 43 07](https://user-images.githubusercontent.com/6764957/121972334-62780080-cdad-11eb-8e38-aebc9243d552.png)

intended solution is to use a regex in `stop_urls` to prevent the crawl
