### PR TITLE
Update "plaiceholder" to use docs-specific sitemap

### DIFF
--- a/configs/plaiceholder.json
+++ b/configs/plaiceholder.json
@@ -4,7 +4,7 @@
     "https://plaiceholder.co/docs"
   ],
   "sitemap_urls": [
-    "https://plaiceholder.co/sitemap.xml"
+    "https://plaiceholder.co/docs/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?


The current configuration references the domain's sitemap, but I only want DocSearch to crawl over the `/docs` (which has a specific sitemap)



### What is the expected behaviour?

Sets the correct sitemap URL


##### NB: Do you want to request a **feature** or report a **bug**?

N/A


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
