### PR TITLE
Update thephpleague.json

### DIFF
--- a/configs/thephpleague.json
+++ b/configs/thephpleague.json
@@ -6,9 +6,9 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "",
-      "global": true,
-      "default_value": "Documentation"
+      "selector": "//menu//*[contains(@class,'menu-section')]//*[contains(@class,'selected')]/preceding::h2[1]",
+      "type": "xpath",
+      "global": true
     },
     "lvl1": "main h1",
     "lvl2": "main h2",
@@ -20,5 +20,10 @@
   "conversation_id": [
     "1528868066"
   ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "version"
+    ]
+  },
   "nb_hits": 297
 }


### PR DESCRIPTION
# Pull request motivation(s)

This docs site is based on the same code as the commonmark-thephpleague site, so we can leverage the same lvl0 selector and version facet configs.

I am the maintainer of both sites as you can see on the bottom of these pages (see the "Questions?" section):

 - https://config.thephpleague.com/
 - https://commonmark.thephpleague.com/

### What is the current behaviour?

Site is not configured with the desired `lvl0` config or the `version` facet.

### What is the expected behaviour?

Site should be configured with those things.

##### NB: Do you want to request a **feature** or report a **bug**?

Neither - just a config change.

##### NB2: Any other feedback / questions ?

Thanks for supporting the open-source community!

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
