### PR TITLE
(chore): added sidebar links as a 'lvl1' link also

### DIFF
--- a/configs/magiclabs_magic.json
+++ b/configs/magiclabs_magic.json
@@ -15,7 +15,7 @@
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "[class^='docsContents___'] h1",
+    "lvl1": "[class^='docsContents___'] h1, [class^='accordionChild___'] a",
     "lvl2": "[class^='docsContents___'] h2",
     "lvl3": "[class^='docsContents___'] h3",
     "lvl4": "[class^='docsContents___'] h4",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://community.algolia.com/docsearch/documentation/)
    - try [to implement the recommendations](https://community.algolia.com/docsearch/documentation/docsearch/recommendations/)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
We have been able to successfully get the crawler to get contents from the new page, but some behaviors seem estranged, we have some pages not named directly in the `doc-search` so we have to add them as an alternate `lvl1` property.

### What is the current behaviour?
- Search for `Quickstart Cli Tool` and you get a zero top-level match but its also a page on its own

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
- Search for `Quickstart Cli Tool` and you get a `lvl1` match 

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
