### PR TITLE
we have migrated to new docs site - docs.wavemaker.com/learn. hence t…

### DIFF
--- a/configs/wavemaker.json
+++ b/configs/wavemaker.json
@@ -3,9 +3,6 @@
   "start_urls": [
     "https://docs.wavemaker.com/learn/"
   ],
-  "stop_urls": [
-    "https://www.wavemaker.com/learn/"
-  ],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {

--- a/configs/wavemaker.json
+++ b/configs/wavemaker.json
@@ -1,10 +1,10 @@
 {
   "index_name": "wavemaker",
   "start_urls": [
-    "https://www.wavemaker.com/learn/"
+    "https://docs.wavemaker.com/learn/"
   ],
-  "sitemap_urls": [
-    "https://www.wavemaker.com/learn/sitemap.xml"
+  "stop_urls": [
+    "https://www.wavemaker.com/learn/"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
…he change in the configuration

# Pull request motivation(s)

I'm a member of the wavemaker team where we are using docsearch for our documentation repo - https://github.com/wavemaker/docs. 

Updated the config file to use the new start_url which is - https://docs.wavemaker.com/learn/

We have already a PR in place where we are planning to announce the migration to the new site - https://docs.wavemaker.com/learn.

PR - https://github.com/wavemaker/docs/pull/474
Preview of the above PR - https://pr-474.d2ulx3keu6fdjg.amplifyapp.com/learn/blog/2021/06/15/announcement-documentation-hostname-update

