### PR TITLE
Changing main domain for grocerycrud.com

### DIFF
--- a/configs/grocerycrud.json
+++ b/configs/grocerycrud.json
@@ -1,7 +1,7 @@
 {
   "index_name": "grocerycrud",
   "start_urls": [
-    "https://new.grocerycrud.com/"
+    "https://www.grocerycrud.com/"
   ],
   "stop_urls": ["/v1.x/.*"],
   "selectors": {


### PR DESCRIPTION
Changing main domain from new.grocerycrud.com to www.grocerycrud.com for the website grocerycrud