### PR TITLE
Index tables and update sitemap URL in Amplience docs

### DIFF
--- a/configs/amplience.json
+++ b/configs/amplience.json
@@ -16,7 +16,7 @@
     "lvl3": "section h4",
     "lvl4": "section h5",
     "lvl5": "section h6",
-    "text": "section p, section li"
+    "text": "section p, section li, section td"
   },
   "conversation_id": [
     "1354307626"

--- a/configs/amplience.json
+++ b/configs/amplience.json
@@ -7,7 +7,7 @@
     "/releasenotes/"
   ],
   "sitemap_urls": [
-    "https://amplience.com/sitemap.xml"
+    "https://amplience.com/sitemap-docs.xml"
   ],
   "selectors": {
     "lvl0": "section h1",


### PR DESCRIPTION
Added section td to the text selectors to enable indexing of tables.

Updated the "start_url field with the correct sitemap for Amplience docs

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

* Some nested information in tables, such as API parameters etc. is not searchable
* Sitemap url points at top level sitemap for amplience.com rather than the docs-specific sitemap so contains a lot of noise 

### What is the expected behaviour?

Data in tables should be searchable

Sitemap should contain https://amplience.com/docs URLs only


##### NB: Do you want to request a **feature** or report a **bug**?
n/a

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
