### PR TITLE
use custom tags for fluxcd

### DIFF
--- a/configs/fluxcd.json
+++ b/configs/fluxcd.json
@@ -2,12 +2,12 @@
   "index_name": "fluxcd",
   "start_urls": [
     {
-      "url": "https://fluxcd.io/",
-      "tags": ["current"]
-    },
-    {
       "url": "https://fluxcd.io/legacy",
       "tags": ["legacy"]
+    },
+    {
+      "url": "https://fluxcd.io/",
+      "tags": ["current"]
     }
   ],
   "sitemap_urls": [

--- a/configs/fluxcd.json
+++ b/configs/fluxcd.json
@@ -1,13 +1,17 @@
 {
   "index_name": "fluxcd",
   "start_urls": [
-    "https://fluxcd.io/"
+    {
+      "url": "https://fluxcd.io/",
+      "tags": ["current"]
+    },
+    {
+      "url": "https://fluxcd.io/legacy",
+      "tags": ["legacy"]
+    }
   ],
   "sitemap_urls": [
     "https://fluxcd.io/sitemap.xml"
-  ],
-  "stop_urls": [
-    "https://fluxcd.io/legacy"
   ],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
Signed-off-by: Daniel Holbach <daniel@weave.works>

### What is the current behaviour?

As of #4190 Algolia excludes `fluxcd.io/legacy/*` urls. 

### What is the expected behaviour?

As @shortcuts noted in https://github.com/algolia/docsearch-configs/pull/4190#pullrequestreview-683025654 custom tags, we'd like to make use of this feature starting by using this PR.
