### PR TITLE
fix: blockstack

### DIFF
--- a/configs/blockstack.json
+++ b/configs/blockstack.json
@@ -1,7 +1,7 @@
 {
   "index_name": "blockstack",
   "start_urls": [
-    "https://docs.blockstack.org/"
+    "https://docs.stacks.co/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
This updates our domain from `docs.blockstack.org` to `doc.stacks.co`, it's the same site/content, and the old domain redirects to the new one. Let me know if there's anything else we need to do!