### PR TITLE
Adds Sitemap.xml to help with the search index for Chromatic

### DIFF
--- a/configs/chromatic.json
+++ b/configs/chromatic.json
@@ -1,7 +1,6 @@
 {
   "index_name": "chromatic",
   "start_urls": ["https://www.chromatic.com/docs/"],
-  "stop_urls": ["chromatic(\\?!\\.com\\/docs)"],
   "sitemap_urls": [
     "https://www.chromatic.com/docs/sitemap.xml"
   ],

--- a/configs/chromatic.json
+++ b/configs/chromatic.json
@@ -2,6 +2,9 @@
   "index_name": "chromatic",
   "start_urls": ["https://www.chromatic.com/docs/"],
   "stop_urls": ["chromatic(\\?!\\.com\\/docs)"],
+  "sitemap_urls": [
+    "https://www.chromatic.com/docs/sitemap.xml"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "//*[contains(@class,'sidebar-nav')]//*[contains(@class,'active')]/preceding::*[contains(@class,'title')][1]",


### PR DESCRIPTION
With this pull request, the configurations for Chromatic are updated to include a sitemap in an effort to optimize the search engine to lookup for new documents/pages that are being added and not being properly indexed.

This change was proposed as part of an ongoing conversation with the documentation team and follows up on #4229.

Feel free to provide feedback.

