### PR TITLE
Index content of table cells in Cloudflare Developer Docs

### DIFF
--- a/configs/developers-cloudflare.json
+++ b/configs/developers-cloudflare.json
@@ -85,7 +85,7 @@
     "lvl3": ".DocsContent h4",
     "lvl4": ".DocsContent h5",
     "lvl5": ".DocsContent h6",
-    "text": ".DocsContent p, .DocsContent li"
+    "text": ".DocsContent p, .DocsContent li, .DocsContent tbody tr > td"
   },
   "selectors_exclude": [
     "h1 + ul"


### PR DESCRIPTION
# Pull request motivation(s)

Some important content inside table cells is not currently being indexed. This PR changes the configuration so that table cells are also indexed, while excluding table headings.

### What is the current behaviour?

Some important content inside table cells is not currently being indexed. 

### What is the expected behaviour?

Relevant content inside tables is indexed and searchable.

--- 

I'm part of the Cloudflare org on GitHub and I have merge permissions on the `cloudflare-docs` repository ([example PR](https://github.com/cloudflare/cloudflare-docs/pull/1631)).