### PR TITLE
fix(chemotion): update startUrl

### DIFF
--- a/configs/chemotion.json
+++ b/configs/chemotion.json
@@ -1,7 +1,7 @@
 {
   "index_name": "chemotion",
   "start_urls": [
-    "https://eln.chemotion.net/chemotionsaurus/docs/"
+    "https://www.chemotion.net/chemotionsaurus/"
   ],
   "sitemap_urls": [
     "https://eln.chemotion.net/chemotionsaurus/sitemap.xml"
@@ -43,5 +43,5 @@
   "conversation_id": [
     "1419639046"
   ],
-  "nb_hits": 361
+  "nb_hits": 1236
 }


### PR DESCRIPTION
# Pull request motivation(s)
 This pull request is related to a broken search for chemotion.

### What is the current behaviour?

The current start url was targeting a 404 page, this failed to scrap records.

### What is the expected behaviour?

To be able to scrap records. 


