### PR TITLE
Inconsistent results for Lowdefy docs indexing

### DIFF
--- a/configs/lowdefy.json
+++ b/configs/lowdefy.json
@@ -22,6 +22,6 @@
   },
   "conversation_id": ["964484389"],
   "js_render": true,
-  "js_wait": 4,
+  "js_wait": 6,
   "nb_hits": 105
 }


### PR DESCRIPTION
Hi, First off, thanks for an awesome product! Docsearch is great 💫

On the Lowdefy docs: https://docs.lowdefy.com, we are getting very inconsistent search results. For example, some days "SQL" searches will show up, others not, it's like the index only catch some data, some of the time, and almost always misses a lot. 

See examples, some days the search work on some pages, other days not:
<img width="723" alt="Screenshot 2021-06-25 at 11 16 26" src="https://user-images.githubusercontent.com/7165064/123401387-05e3c500-d5a7-11eb-9cf3-947fce822a7a.png">
<img width="884" alt="Screenshot 2021-06-25 at 11 17 09" src="https://user-images.githubusercontent.com/7165064/123401401-08461f00-d5a7-11eb-9007-b45c0a54cb35.png">


Not sure how to tweak to config to achieve a better index. Please help?

