### PR TITLE
materialize: update start URL

### DIFF
--- a/configs/materialize.json
+++ b/configs/materialize.json
@@ -1,7 +1,7 @@
 {
   "index_name": "materialize",
   "start_urls": [
-    "https://materialize.io/docs"
+    "https://materialize.com/docs"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
We've moved the docs from materialize.io to materialize.com. Seems like this config needs to be updated like so. Thanks in advance!