### PR TITLE
add kapp-controller docs to search

### DIFF
--- a/configs/carvel.json
+++ b/configs/carvel.json
@@ -5,7 +5,8 @@
     { "url": "https://carvel.dev/kbld/docs/latest/", "tags": ["kbld"] },
     { "url": "https://carvel.dev/kapp/docs/latest/", "tags": ["kapp"] },
     { "url": "https://carvel.dev/imgpkg/docs/latest/", "tags": ["imgpkg"] },
-    { "url": "https://carvel.dev/vendir/docs/latest/", "tags": ["vendir"] }
+    { "url": "https://carvel.dev/vendir/docs/latest/", "tags": ["vendir"] },
+    { "url": "https://carvel.dev/kapp-controller/docs/latest/", "tags": ["kapp-controller"] }
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

The search functionality for https://carvel.dev/kapp-controller is currently not enabled. This pull request add's the kapp-controller page for carvel.dev to search through kapp-controller documentation.

### What is the current behaviour?

No results are returned via the enabled search bar for the docs portion of the site: https://carvel.dev/kapp-controller/docs/latest/

### What is the expected behaviour?

Display search results in search bar.
