### PR TITLE
Update keystonejs.json

### DIFF
--- a/configs/keystonejs.json
+++ b/configs/keystonejs.json
@@ -1,21 +1,22 @@
 {
   "index_name": "keystonejs",
   "start_urls": [
-    "https://www.keystonejs.com/"
+    "https://keystonejs.com/"
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": "main h1",
-    "lvl1": "main h2",
-    "lvl2": "main h3",
-    "lvl3": "main h4",
-    "lvl4": "main h5",
-    "lvl5": "main h6",
+    "lvl0": {
+      "selector": "",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": "main h1",
+    "lvl2": "main h2",
+    "lvl3": "main h3",
+    "lvl4": "main h4",
+    "lvl5": "main h5",
     "text": "main p, main li"
   },
-  "selectors_exclude": [
-    "main style"
-  ],
   "conversation_id": [
     "1113924890"
   ],


### PR DESCRIPTION
`next.keystonejs.com` has been switched over to `keystonejs.com`, updating the config to match the `next.keystonejs.com` config file that was recently setup here - https://github.com/algolia/docsearch-configs/blob/master/configs/next-keystone.json