### PR TITLE
Updated the config for Teamforge 21.1

### DIFF
--- a/configs/collab.json
+++ b/configs/collab.json
@@ -5,6 +5,7 @@
       "url": "https://docs.collab.net/(?P<tags>.*?)/",
       "variables": {
         "tags": [
+          "teamforge211",
           "teamforge210",
           "teamforge203",
           "teamforge202",


### PR DESCRIPTION
There was an issue last time and the site was not indexed post PR merge. Can you please check or trigger the index job once you merge the PR? Thanks.

