### PR TITLE
Updates apostrophe config for v2 and v3 tags (#1)

### DIFF
--- a/configs/apostrophecms.json
+++ b/configs/apostrophecms.json
@@ -1,7 +1,18 @@
 {
   "index_name": "apostrophecms",
   "start_urls": [
-    "https://docs.apostrophecms.org"
+    {
+      "url": "https://v2.docs.apostrophecms.org/",
+      "tags": [
+        "v2"
+      ]
+    },
+    {
+      "url": "https://v3.docs.apostrophecms.org/",
+      "tags": [
+        "v3"
+      ]
+    }
   ],
   "stop_urls": [],
   "selectors": {
@@ -29,12 +40,13 @@
   "strip_chars": " .,;:#",
   "custom_settings": {
     "attributesForFaceting": [
-      "lang"
+      "lang",
+      "tags"
     ]
   },
   "conversation_id": [
     "1157891501"
   ],
   "scrape_start_urls": false,
-  "nb_hits": 7671
+  "nb_hits": 9276
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

The Apostrophe documentation is now in two different websites for versions two and three. We need each indexed separately. @shortcuts helped identify this as the correct strategy to do that.

### What is the current behaviour?

The config currently indexes a deprecated URL.

### What is the expected behaviour?

We'd like it to index the two live URLs.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
