### PR TITLE
Update cardano.json with subdomain to crawl

### DIFF
--- a/configs/cardano.json
+++ b/configs/cardano.json
@@ -48,6 +48,9 @@
       "text": "[class*='MainContent'] p, [class*='MainContent'] li"
     }
   },
+  "custom_settings": {
+    "attributesForFaceting": ["tags"]
+  },
   "conversation_id": [
     "1223539650"
   ],

--- a/configs/cardano.json
+++ b/configs/cardano.json
@@ -2,30 +2,54 @@
   "index_name": "cardano",
   "start_urls": [
     {
-      "url": "https://docs.cardano.org/"
+      "url": "https://docs.cardano.org/",
+      "tags": [
+        "docs"
+      ],
+      "selectors_key": "docs"
     },
     {
-      "url": "https://developers.cardano.org/"
+      "url": "https://developers.cardano.org/",
+      "tags": [
+        "developers"
+      ],
+      "selectors_key": "developers"
     }
   ],
   "sitemap_urls": [
-    "https://docs.cardano.org/sitemap.xml"
+    "https://docs.cardano.org/sitemap.xml",
+    "https://developers.cardano.org/sitemap.xml"
   ],
   "selectors": {
-    "lvl0": {
-      "selector": "",
-      "global": true,
-      "default_value": "Documentation"
+    "docs": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": "main h1",
+      "lvl2": "main h2",
+      "lvl3": "main h3",
+      "lvl4": "main h4",
+      "lvl5": "main h5",
+      "text": "main p, main li"
     },
-    "lvl1": "main h1",
-    "lvl2": "main h2",
-    "lvl3": "main h3",
-    "lvl4": "main h4",
-    "lvl5": "main h5",
-    "text": "main p, main li"
+    "developers": {
+      "lvl0": {
+        "selector": "",
+        "global": true,
+        "default_value": "Developers"
+      },
+      "lvl1": "[class*='MainContent'] h1",
+      "lvl2": "[class*='MainContent'] h2",
+      "lvl3": "[class*='MainContent'] h3",
+      "lvl4": "[class*='MainContent'] h4",
+      "lvl5": "[class*='MainContent'] h5",
+      "text": "[class*='MainContent'] p, [class*='MainContent'] li"
+    }
   },
   "conversation_id": [
     "1223539650"
   ],
-  "nb_hits": 2447
+  "nb_hits": 11373
 }

--- a/configs/cardano.json
+++ b/configs/cardano.json
@@ -1,7 +1,12 @@
 {
   "index_name": "cardano",
   "start_urls": [
-    "https://docs.cardano.org/"
+    {
+      "url": "https://docs.cardano.org/"
+    },
+    {
+      "url": "https://developers.cardano.org/"
+    }
   ],
   "sitemap_urls": [
     "https://docs.cardano.org/sitemap.xml"


### PR DESCRIPTION
We would like to crawl the subdomain: https://developers.cardano.org/ so we can have docsearch active on it too.
I was emailed by support who suggested this change.
Many thanks

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
