### PR TITLE
Attempt to fix scanpy docs

### DIFF
--- a/configs/scanpy.json
+++ b/configs/scanpy.json
@@ -9,6 +9,9 @@
           "js": "let versions=[]; for (let b of document.querySelectorAll('.rst-other-versions dl:first-child dd')){versions.push(b.innerText.trim())};return JSON.stringify(versions)"
         }
       }
+    },
+    {
+      "url": "https://scanpy.readthedocs.io/"
     }
   ],
   "sitemap_urls": [

--- a/configs/scanpy.json
+++ b/configs/scanpy.json
@@ -6,7 +6,7 @@
       "variables": {
         "version": {
           "url": "https://scanpy.readthedocs.io/",
-          "js": "let versions=[]; for (let b of document.querySelectorAll('.rst-other-versions dl:first-child dd')){versions.push(b.innerText)};return JSON.stringify(versions)"
+          "js": "let versions=[]; for (let b of document.querySelectorAll('.rst-other-versions dl:first-child dd')){versions.push(b.innerText.trim())};return JSON.stringify(versions)"
         }
       }
     }

--- a/configs/scanpy.json
+++ b/configs/scanpy.json
@@ -27,9 +27,8 @@
     "lvl5": ".section h6",
     "text": ".section p, .section li"
   },
-  "js_render": true,
   "conversation_id": [
     "1432038966"
   ],
-  "nb_hits": 9501
+  "nb_hits": 14773
 }


### PR DESCRIPTION
# Pull request motivation(s)

Attempt to fix #4306

I noticed the javascript for getting the versions in the config was receiving version strings like:

```
["↵          latest↵        ", "↵          stable↵        ", "↵          docsearch↵        "] 
```

Which could be causing a problem. So I've `.trim()`-ed those.

I've also implemented the suggestion from @shortcuts (https://github.com/algolia/docsearch-configs/issues/4306#issuecomment-873855656) to modify our `start_urls`

### What is the current behaviour?

scanpy is getting a 404 when we make API requests

### What is the expected behaviour?

Working search.