### PR TITLE
[Camunda] Add docusaurus_tag to attributesForFaceting

### DIFF
--- a/configs/camunda.json
+++ b/configs/camunda.json
@@ -8,9 +8,10 @@
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],
-  "selectors": {
+ "selectors": {
     "lvl0": {
-      "selector": ".menu__link--sublist.menu__link--active",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
@@ -19,6 +20,7 @@
     "lvl3": "article h3",
     "lvl4": "article h4",
     "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
     "text": "article p, article li, article td:last-child"
   },
   "strip_chars": " .,;:#",

--- a/configs/camunda.json
+++ b/configs/camunda.json
@@ -27,7 +27,8 @@
     "attributesForFaceting": [
       "language",
       "version",
-      "type"
+      "type",
+      "docusaurus_tag"
     ],
     "attributesToRetrieve": [
       "hierarchy",


### PR DESCRIPTION
# Pull request motivation(s)
Contextual search config yields no results. We would like to modify our search experience to include searching that's limited to the version you are searching in, and without contextual search, we do not get this experience.

https://github.com/camunda-cloud/camunda-cloud-documentation/issues/309

### What is the current behaviour?

After implementing contextual search config, no search results are returned in the UI

### What is the expected behaviour?

Search results should be returned with contextual search config enabled. 

##### NB: Do you want to request a **feature** or report a **bug**?

IMO this is a bug for us because we have a poor search experience at this time with contextual search config enabled. 

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
