### PR TITLE
Folder "docs" no longer being used

### DIFF
--- a/configs/testspace_help.json
+++ b/configs/testspace_help.json
@@ -1,7 +1,7 @@
 {
   "index_name": "testspace_help",
   "start_urls": [
-    "https://help.testspace.com/docs/"
+    "https://help.testspace.com/"
   ],
   "sitemap_urls": [
     "https://help.testspace.com/sitemap.xml"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Changed the Documentation (Docusaurus) URL to **no longer** use `docs`.  The provided pages are incorrect, including `docs` as part of the URL. 

For example - https://help.testspace.com/docs/manual/implementation-spec#spec-preview.  

The URL should be: https://help.testspace.com/manual/implementation-spec#spec-preview

### What is the current behaviour?
Includes `docs` in the URL.

- https://help.testspace.com/docs/manual/implementation-spec#spec-preview

### What is the expected behaviour?
Do not include `docs` in the URL.

- https://help.testspace.com/manual/implementation-spec#spec-preview
