### PR TITLE
Add Astro

### DIFF
--- a/configs/astro.json
+++ b/configs/astro.json
@@ -1,0 +1,26 @@
+{
+  "index_name": "astro",
+  "start_urls": [
+    "https://docs.astro.build"
+  ],
+  "sitemap_urls": [
+    "https://docs.astro.build/sitemap.xml"
+  ],
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": {
+      "selector": "",
+      "default_value": "Documentation"
+    },
+    "lvl1": ".content h1",
+    "lvl2": ".content h2",
+    "lvl3": ".content h3",
+    "lvl4": ".content h4",
+    "lvl5": ".content h5",
+    "text": ".content p, .content li"
+  },
+  "conversation_id": [
+    "1341434945"
+  ],
+  "nb_hits": 885
+}


### PR DESCRIPTION
Hey yall! This PR adds support for Astro (https://docs.astro.build) so that we can add Algolia to the docs site. 

Background: I'm the creator of Snowpack (https://snowpack.dev), and when I got set up with Algolia on that docs site my contact person at Algolia had said that I could add a future project here directly next time. Hope this is okay!