### PR TITLE
Update reimagined-resolve config

### DIFF
--- a/configs/reimagined_resolve.json
+++ b/configs/reimagined_resolve.json
@@ -10,24 +10,35 @@
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": ".postHeader h1",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".post article h1",
-    "lvl2": ".post article h2",
-    "lvl3": ".post article h3",
-    "lvl4": ".post article h4",
-    "lvl5": ".post article h5",
-    "text": ".post article p, .post article li"
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
-  "selectors_exclude": [
-    ".hash-link"
-  ],
+  "strip_chars": " .,;:#",
   "custom_settings": {
+    "separatorsToIndex": "_",
     "attributesForFaceting": [
       "language",
-      "version"
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
     ]
   },
   "conversation_id": [


### PR DESCRIPTION
We recently migrated reSolve documentation to Docusaurus v2 and the search index stopped updating. To solve the issue, I updated the **reimagined_resolve.json** file so it matches the format of [docusaurus-2.json](https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json) as Docusaurus documentation suggests.