### PR TITLE
ejabberd: Set stop_urls option to not crawl old/ and the archive section

### DIFF
--- a/configs/ejabberd.json
+++ b/configs/ejabberd.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "https://docs.ejabberd.im"
   ],
-  "stop_urls": [],
+  "stop_urls": ["/archive/", "/admin/configuration/old/"],
   "selectors": {
     "lvl0": "#content h1",
     "lvl1": "#content h2",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Since some months ago, https://docs.ejabberd.im includes a section with archived documentation. That's a copy of some specific sections that change for every ejabberd version.

### What is the current behaviour?

Right now all those copies of old documentation are also displayed in the search results.

### What is the expected behaviour?

Index only the pages with up-to-date documentation, avoiding "archive/" and "old/". 

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
