### PR TITLE
Update ActiveUi config.

### DIFF
--- a/configs/activeui.json
+++ b/configs/activeui.json
@@ -1,39 +1,29 @@
 {
   "index_name": "activeui",
-  "sitemap_urls": [
-    "https://activeviam.com/activeui/documentation/sitemap.xml"
-  ],
-  "start_urls": [
-    "https://activeviam.com/activeui/"
-  ],
+  "sitemap_urls": ["https://activeviam.com/activeui/documentation/sitemap.xml"],
+  "start_urls": ["https://activeviam.com/activeui/"],
   "sitemap_alternate_links": true,
   "force_sitemap_urls_crawling": true,
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "lvl5": ".post h5",
-    "text": ".post article p, .post article li"
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
-  "selectors_exclude": [
-    ".hash-link"
-  ],
+  "selectors_exclude": [".hash-link"],
   "custom_settings": {
-    "attributesForFaceting": [
-      "language",
-      "version"
-    ]
+    "attributesForFaceting": ["language", "version"]
   },
-  "conversation_id": [
-    "728521704"
-  ],
+  "conversation_id": ["728521704"],
   "nb_hits": 286012
 }

--- a/configs/activeui.json
+++ b/configs/activeui.json
@@ -20,9 +20,18 @@
     "lvl6": "article h6",
     "text": "article p, article li, article td:last-child"
   },
-  "selectors_exclude": [".hash-link"],
+  "strip_chars": " .,;:#",
   "custom_settings": {
-    "attributesForFaceting": ["language", "version"]
+    "separatorsToIndex": "_",
+    "attributesForFaceting": ["language", "version", "type", "docusaurus_tag"],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
   },
   "conversation_id": ["728521704"],
   "nb_hits": 286012


### PR DESCRIPTION
### The problem: 
After upgrading to `Docusaurus 2` from `Docusaurus 1`, the search doesn't yield any results.

### The solution:
Update our [selectors](https://github.com/algolia/docsearch-configs/blob/9454e2adbc8acfddae32a8e0bf7e1682254c0a46/configs/activeui.json#L12-L25) config to match the one from [docusaurus-2](https://github.com/algolia/docsearch-configs/blob/master/configs/docusaurus-2.json#L11-L25).

See #4364 for more details.