### PR TITLE
fix(activeui): update config

### DIFF
--- a/configs/activeui.json
+++ b/configs/activeui.json
@@ -1,7 +1,10 @@
 {
   "index_name": "activeui",
   "sitemap_urls": ["https://activeviam.com/activeui/documentation/sitemap.xml"],
-  "start_urls": ["https://activeviam.com/activeui/"],
+  "start_urls": [
+    "https://activeviam.com/activeui/",
+    "https://activeviam.com/activeui/documentation/5.0.0/index.html"
+  ],
   "sitemap_alternate_links": true,
   "force_sitemap_urls_crawling": true,
   "stop_urls": [],


### PR DESCRIPTION
**Summary**

It seems that the `5.0.0` version wasn't retrieved from the `sitemap.xml`, adding the entry point to the `start_urls` will solve this issue.

fixes https://github.com/algolia/docsearch-configs/issues/4364