### PR TITLE
Update mateuszdabrowski docsearch config

### DIFF
--- a/configs/mateuszdabrowski.json
+++ b/configs/mateuszdabrowski.json
@@ -1,14 +1,17 @@
 {
   "index_name": "mateuszdabrowski",
   "start_urls": [
-    "https://mateuszdabrowski.pl/docs",
-    "https://mateuszdabrowski.pl/docs/sql/sfmc-sql-date-functions/"
+    "https://mateuszdabrowski.pl/docs/"
+  ],
+  "stop_urls": [
+    "https://mateuszdabrowski.pl/sites/my-toolset/", 
+    "https://mateuszdabrowski.pl/sites/licence/", 
+    "https://mateuszdabrowski.pl/sites/privacy/"
   ],
   "sitemap_urls": [
     "https://mateuszdabrowski.pl/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
-  "stop_urls": [],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
@@ -27,6 +30,21 @@
   "strip_chars": " .,;:#",
   "custom_settings": {
     "separatorsToIndex": "_",
+    "synonyms": [
+      [
+        "js",
+        "javascript"
+      ],
+      [
+        "sql",
+        "query"
+      ],
+      [
+        "abandon",
+        "behavioral",
+        "behavioural"
+      ]
+    ],
     "attributesForFaceting": [
       "language",
       "version",
@@ -39,10 +57,12 @@
       "anchor",
       "url",
       "url_without_anchor",
-      "type"
+      "type",
+      "docusaurus_tag"
     ]
   },
   "js_render": true,
+  "user_agent": "Algolia DocSearch Crawler",
   "conversation_id": [
     "1274130707"
   ],


### PR DESCRIPTION
1. Simplified start_urls - previous version had single random documentation page
2. Added stop_urls - not sure if this will work with sitemap setting provided
3. Added synonyms - the most popular synonyms that might improve search results
4. Added override of User-Agent - per documentation the default User-Agent is changing when js_render is set to true. Bringing it back to default value (whitelisted in Cloudflare)
