### PR TITLE
Remove js_render from mateuszdabrowski config

### DIFF
--- a/configs/mateuszdabrowski.json
+++ b/configs/mateuszdabrowski.json
@@ -61,7 +61,6 @@
       "docusaurus_tag"
     ]
   },
-  "js_render": true,
   "user_agent": "Algolia DocSearch Crawler",
   "conversation_id": [
     "1274130707"


### PR DESCRIPTION
Removing js_render config to check whether the standard, more performant solution will work with Bot Fight Mode disabled as per Cloudflare bug: https://community.cloudflare.com/t/bot-fight-mode-cannot-be-bypassed-by-firewall-rules/263256