### PR TITLE
Remove stop_urls (critical fix)

### DIFF
--- a/configs/statamic_3.json
+++ b/configs/statamic_3.json
@@ -15,12 +15,7 @@
     },
     "https://statamic.dev"
   ],
-  "stop_urls": [
-    "https://statamic.dev/fieldtypes",
-    "https://statamic.dev/knowledge-base",
-    "https://statamic.dev/tags",
-    "https://statamic.dev/modifiers"
-  ],
+  "stop_urls": [],
   "sitemap_urls": ["https://statamic.dev/sitemap.xml"],
   "selectors": {
     "default": {


### PR DESCRIPTION
I completely misunderstood how the `stop_urls` work and now nearly all of our most important pages are no longer indexed. This is a huge issue with our users right now.