### PR TITLE
Update stop urls to ignore versions pages

### DIFF
--- a/configs/livechatinc.json
+++ b/configs/livechatinc.json
@@ -3,7 +3,7 @@
   "start_urls": [
     "https://developers.livechat.com/docs/"
   ],
-  "stop_urls": [],
+  "stop_urls": ["v1.", "v2.", "v3."],
   "sitemap_urls": [
     "https://developers.livechatinc.com/docs/sitemap.xml"
   ],


### PR DESCRIPTION
We are scraping the urls with versions, and now our search is cluttered because of that. We wanna scrape only stable versions.

See the repo for my contributions:
https://github.com/livechat/livechat-public-docs/graphs/contributors