### PR TITLE
Update start_urls for runx index

### DIFF
--- a/configs/runx.json
+++ b/configs/runx.json
@@ -1,10 +1,10 @@
 {
   "index_name": "runx",
   "start_urls": [
-    "https://docs.runx.dev/"
+    "https://docs.opta.dev/"
   ],
   "sitemap_urls": [
-    "https://docs.runx.dev/sitemap.xml"
+    "https://docs.opta.dev/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION

# Pull request motivation(s)
We recently moved our documentation to a different URL dedicated for that product, hence need to update the start_urls for the index.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
