### PR TITLE
Ignore urls without trailing slash

### DIFF
--- a/configs/livechatinc.json
+++ b/configs/livechatinc.json
@@ -3,9 +3,9 @@
   "start_urls": [
     "https://developers.livechat.com/docs/"
   ],
-  "stop_urls": ["v1.", "v2.", "v3."],
+  "stop_urls": ["v1.", "v2.", "v3.", "[^/]+$"],
   "sitemap_urls": [
-    "https://developers.livechatinc.com/docs/sitemap.xml"
+    "https://developers.livechat.com/docs/sitemap.xml"
   ],
   "selectors": {
     "lvl0": "article h1",


### PR DESCRIPTION
With current issue with Next.js and netlify not supporting trailing slashes, we are having some duplicates in Algolia with and without `/` . This fix will ignore urls without trailing slash.

See the repo for my contributions:
https://github.com/livechat/livechat-public-docs/graphs/contributors