### PR TITLE
Move integrations to root level

### DIFF
--- a/configs/kineticcommunity.json
+++ b/configs/kineticcommunity.json
@@ -1,7 +1,6 @@
 {
   "index_name": "kineticcommunity",
-  "start_urls": [
-    {
+  "start_urls": [{
       "url": "https://community.kineticdata.com/admin-docs",
       "selectors_key": "admin-docs",
       "tags": [
@@ -19,7 +18,7 @@
       ]
     },
     {
-      "url": "https://community.kineticdata.com/admin-docs/integration/plugins",
+      "url": "https://community.kineticdata.com/integrations",
       "selectors_key": "integrations",
       "tags": [
         "Integrations",
@@ -107,10 +106,10 @@
       "lvl4": ".community-content h1",
       "text": ".community-content p, community-content li"
     },
-    "plugins": {
+    "integrations": {
       "lvl0": {
         "selector": "",
-        "default_value": "Plugins"
+        "default_value": "Integrations"
       },
       "lvl1": {
         "selector": ".breadcrumb .breadcrumb-item:nth-child(3)",


### PR DESCRIPTION
# Pull request motivation(s)
Restructuring integrations documentation as a root nav element.

### What is the current behaviour?
Currently the search is broken because we restructured our site. It isn't finding integrations because it used to be nested under admin-docs


### What is the expected behaviour?
Integrations show up when searching within that faucet.

##### NB: Do you want to request a **feature** or report a **bug**?
Nope, just a bug on our end.

##### NB2: Any other feedback / questions ?
N/A
