### PR TITLE
[smartpy] - Update documentation base URL

### DIFF
--- a/configs/smartpy.json
+++ b/configs/smartpy.json
@@ -1,10 +1,10 @@
 {
   "index_name": "smartpy",
   "start_urls": [
-    "https://docs.smartpy.io/"
+    "https://smartpy.io/docs"
   ],
   "sitemap_urls": [
-    "https://docs.smartpy.io/sitemap.xml"
+    "https://smartpy.io/docs/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
This PR updates the documentation base URL from [https://docs.smartpy.io](https://docs.smartpy.io) to [https://smartpy.io/docs](https://smartpy.io/docs)