### PR TITLE
fix(configs): add sitemap in coding_help

### DIFF
--- a/configs/coding_help.json
+++ b/configs/coding_help.json
@@ -14,6 +14,7 @@
     "lvl5": "article h6",
     "text": "article p, article li"
   },
+  "sitemap_urls": ["https://help.coding.net/docs/sitemap.xml"],
   "conversation_id": [
     "968058209"
   ],


### PR DESCRIPTION
### What is the current behaviour?

I am the developer of CODING. I add sitemap.xml config in coding_help.
