### PR TITLE
--refac: Wrongfully named attribute changed to 'lang'

### DIFF
--- a/configs/circuly.json
+++ b/configs/circuly.json
@@ -18,7 +18,7 @@
     "text": "main p, main li"
   },
   "custom_settings": {
-    "attributesForFaceting": ["language", "version"]
+    "attributesForFaceting": ["lang", "version"]
   },
   "conversation_id": [
     "1501914169"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Renamed to support Vuepress "lang" faceting attribute.

### What is the current behaviour?
Currently wrongfully faceting by 'language'.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?
Expected to accept faceting by 'lang'.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
