### PR TITLE
Add version support for PrestaShop devdocs

### DIFF
--- a/configs/prestashop.json
+++ b/configs/prestashop.json
@@ -1,7 +1,12 @@
 {
   "index_name": "prestashop",
   "start_urls": [
-    "https://devdocs.prestashop.com/"
+    {
+      url: "https://devdocs.prestashop.com/(?P<version>.*?)/",
+      "variables": {
+        "version": ["1.7", "8"]
+      }
+    }
   ],
   "sitemap_urls": [
     "https://devdocs.prestashop.com/sitemap.xml"

--- a/configs/prestashop.json
+++ b/configs/prestashop.json
@@ -2,7 +2,7 @@
   "index_name": "prestashop",
   "start_urls": [
     {
-      url: "https://devdocs.prestashop.com/(?P<version>.*?)/",
+      "url": "https://devdocs.prestashop.com/(?P<version>.*?)/",
       "variables": {
         "version": ["1.7", "8"]
       }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

PrestaShop DevDocs is now versioned for each major PrestaShop release. Documentation for each version is placed under a directory at the root of the site:

- https://devdocs.prestashop.com/1.7/
- https://devdocs.prestashop.com/8/

### What is the current behaviour?

Documentation for both versions is mixed up in search results.

### What is the expected behaviour?

Users get the most relevant results for the version they are browsing, we do this by filtering results by `version` using `facetFilters`.

##### NB: Do you want to request a **feature** or report a **bug**?

I guess it's a feature?

##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
