### PR TITLE
Update start_url to include all docs in search

### DIFF
--- a/configs/chatwoot.json
+++ b/configs/chatwoot.json
@@ -1,7 +1,7 @@
 {
   "index_name": "chatwoot",
   "start_urls": [
-    "https://www-internal-docs.chatwoot.com/docs/self-hosted/"
+    "https://www-internal-docs.chatwoot.com/docs/"
   ],
   "sitemap_urls": [
     "https://www-internal-docs.chatwoot.com/docs/sitemap.xml"


### PR DESCRIPTION
### Context 

Search on Chatwoot docs currently returns only the results from the `/docs/self-hosted` path. This PR is to include all the docs in search results.

### Changes

- [x] Change start_urls to `/docs` instead of `/docs/self-hosted`
