### PR TITLE
Update apereo/cas config to use the 6.4.x tree 

### DIFF
--- a/configs/apereo.json
+++ b/configs/apereo.json
@@ -5,6 +5,7 @@
       "url": "https://apereo.github.io/cas/(?P<version>.*?)/",
       "variables": {
         "version": [
+          "6.4.x",
           "6.3.x",
           "6.2.x",
           "6.1.x",


### PR DESCRIPTION
Update the Apereo configuration to use the 6.4.x tree.