### PR TITLE
Update pester config for Docusaurus 2 and DocSearch v3

### DIFF
--- a/configs/pester.json
+++ b/configs/pester.json
@@ -6,20 +6,41 @@
   "sitemap_urls": [
     "https://pester.dev/sitemap.xml"
   ],
+  "sitemap_alternate_links": true,  
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "main h1",
-    "lvl2": "main h2",
-    "lvl3": "main h3",
-    "lvl4": "main h4",
-    "lvl5": "main h5",
-    "text": "main p, main li"
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  },    
   "conversation_id": [
     "1599143010"
   ],


### PR DESCRIPTION
Update config for the [https://pester.dev](https://pester.dev) website for:

1. Docusaurus v2
2. DocSearch v3
3. Facet Filtering
