### PR TITLE
Add Boosted v5.1 to DocSearch

### DIFF
--- a/configs/boosted-orange.json
+++ b/configs/boosted-orange.json
@@ -46,6 +46,18 @@
       },
       "selectors_key": "v5"
     },
+    {
+      "url": "https://boosted.orange.com/docs/5.1/",
+      "extra_attributes": {
+        "language": [
+          "en"
+        ],
+        "version": [
+          "5.1"
+        ]
+      },
+      "selectors_key": "v5"
+    },
     "https://boosted.orange.com/docs/4.3/",
     "https://boosted.orange.com/docs/4.4/",
     "https://boosted.orange.com/docs/4.5/",


### PR DESCRIPTION
Hello 👋 

We just released the [version 5.1.0 of Boosted](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/releases/tag/v5.1.0) so we would like to add it to DocSearch.