### PR TITLE
near-sdk-rs docs added to the main index

### DIFF
--- a/configs/near.json
+++ b/configs/near.json
@@ -1,34 +1,71 @@
 {
   "index_name": "near",
   "start_urls": [
-    "https://docs.near.org/docs/"
+    {
+      "url": "https://docs.near.org/docs/",
+      "selectors_key": "docs"
+    },
+    {
+      "url": "https://near-sdk.io",
+      "selectors_key": "sdk-docs"
+    }
   ],
   "sitemap_urls": [
-    "https://docs.near.org/sitemap.xml"
+    "https://docs.near.org/sitemap.xml",
+    "https://near-sdk.io/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
-      "type": "xpath",
-      "global": true,
-      "default_value": "Documentation"
+    "docs": {
+      "lvl0": {
+        "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
+        "type": "xpath",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": ".post h1",
+      "lvl2": ".post h2",
+      "lvl3": ".post h3",
+      "lvl4": ".post h4",
+      "lvl5": ".post h5",
+      "text": ".post article p, .post article li"
     },
-    "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "lvl5": ".post h5",
-    "text": ".post article p, .post article li"
+    "sdk-docs": {
+      "lvl0": {
+        "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+        "type": "xpath",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": "header h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5, article td:first-child",
+      "lvl6": "article h6",
+      "text": "article p, article li, article td:last-child"
+    }
   },
+  "strip_chars": " .,;:#",
   "selectors_exclude": [
     ".hash-link"
   ],
   "custom_settings": {
     "attributesForFaceting": [
       "language",
-      "version"
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "separatorsToIndex": "_",
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
     ]
   },
   "conversation_id": [


### PR DESCRIPTION
We want to index both https://docs.near.org/ and https://www.near-sdk.io/ on our main documentation website.
The first one is using `Docusaurus` and the second one `Docusaurus 2`. That is why I have added `selectors_key` and some parameters adviced by @shortcuts  (thanks @shortcuts  :)).