### PR TITLE
chore(yarnpkg_next): Roll 7th level into "text"

### DIFF
--- a/configs/yarnpkg_next.json
+++ b/configs/yarnpkg_next.json
@@ -18,8 +18,7 @@
     "lvl3": "article h3",
     "lvl4": "article h4",
     "lvl5": "article h5",
-    "lvl6": "article h6",
-    "text": "article p, article li, article td"
+    "text": "article h6, article p, article li, article td"
   },
   "custom_settings": {
     "separatorsToIndex": "_",


### PR DESCRIPTION
According to https://docsearch.algolia.com/docs/config-file#selectors:
>[`selectors`] can contain up to 6 levels (`lvl0`, `lvl1`, `lvl2`, `lvl3`, `lvl4`, `lvl5`) and `text`.

... So `"lvl6": "article h6",` (a 7th level) is presumably being ignored.

This PR rolls `article h6` into `text`.

I did a quick search of https://github.com/yarnpkg/berry, the deepest markdown header I saw was `#####`, which corresponds to `h5`, see [Editor SDKs > Editor setup > VIM > Neovim Native LSP > Supporting go-to-definition et al.](https://yarnpkg.com/getting-started/editor-sdks/#supporting-go-to-definition-et-al)

I then build the `yarnpkg/berry` docs locally (`yarn build:doc` in `packages/gatsby`), so I could search them for `<h5\b`, `<h6\b`, etc. -- no `<h5>`s or above, but many more `<h5>`s in the API docs, for example see [API > plugin-exec > ExecFetcher](https://yarnpkg.com/api/classes/plugin_exec.execfetcher.html) -- methods parameters HTML looks like:
```html
<ul class="tsd-parameters">
  <li>
    <h5>locator: <a href="../interfaces/yarnpkg_core.locator.html" class="tsd-signature-type">Locator</a></h5>
  </li>
  <li>
    <h5>opts: <a href="../modules/yarnpkg_core.html#fetchoptions" class="tsd-signature-type">FetchOptions</a></h5>
  </li>
</ul>
```

Might make sense to fold / flatten `article h5` into `text` as well, which would make space to add a new level, [as proposed here](https://github.com/yarnpkg/berry/issues/3421#issuecomment-917156856), which might look like this:

```json
"selectors": {
  "lvl0": {
    "selector": "header .active",
    "global": true,
    "default_value": "Documentation"
  },
  "lvl1": "article h1",
  "lvl2": "article > div:nth-of-type(2) > p:first-child",
  "lvl3": "article h2",
  "lvl4": "article h3",
  "lvl5": "article h4",
  "text": "article h5, article h6, article p, article li, article td"
},
```

Or `lvl2` could be `meta[name="description"]` if this is supported, wasn't clear from the docs -- if not this might be a good addition to the scraper... Hmm, guessing it's not supported, judging by https://github.com/algolia/docsearch-scraper/search?q=meta