### PR TITLE
px4.json - add extra version for v1.12

### DIFF
--- a/configs/px4.json
+++ b/configs/px4.json
@@ -14,6 +14,7 @@
       "url": "https://docs.px4.io/(?P<version>.*?)/",
       "variables": {
         "version": [
+          "v1.12",
           "v1.11",
           "v1.10",
           "v1.9.0",


### PR DESCRIPTION
I "hope" this is enough to add a v1.12 search on our docs - essentially https://docs.px4.io/v1.12/en/