### PR TITLE
fix: update language tags for nuxtjs.org

### DIFF
--- a/configs/nuxtjs.json
+++ b/configs/nuxtjs.json
@@ -2,12 +2,26 @@
   "index_name": "nuxtjs",
   "start_urls": [
     {
-      "url": "https://nuxtjs.org/(?P<lang>.*?)/",
+      "url": "https://nuxtjs.org/fr/",
       "variables": {
         "lang": [
-          "en",
-          "fr",
-          "ja"
+          "fr-FR"
+        ]
+      }
+    },
+    {
+      "url": "https://nuxtjs.org/ja/",
+      "variables": {
+        "lang": [
+          "ja-JP"
+        ]
+      }
+    },
+    {
+      "url": "https://nuxtjs.org/en/",
+      "variables": {
+        "lang": [
+          "en-US"
         ]
       }
     },
@@ -15,7 +29,7 @@
       "url": "https://nuxtjs.org/",
       "extra_attributes": {
         "lang": [
-          "en"
+          "en-US"
         ]
       }
     }

--- a/configs/nuxtjs.json
+++ b/configs/nuxtjs.json
@@ -5,7 +5,8 @@
       "url": "https://nuxtjs.org/fr/",
       "variables": {
         "lang": [
-          "fr-FR"
+          "fr-FR",
+          "fr"
         ]
       }
     },
@@ -13,7 +14,8 @@
       "url": "https://nuxtjs.org/ja/",
       "variables": {
         "lang": [
-          "ja-JP"
+          "ja-JP",
+          "ja"
         ]
       }
     },
@@ -21,7 +23,8 @@
       "url": "https://nuxtjs.org/en/",
       "variables": {
         "lang": [
-          "en-US"
+          "en-US",
+          "en"
         ]
       }
     },
@@ -29,7 +32,8 @@
       "url": "https://nuxtjs.org/",
       "extra_attributes": {
         "lang": [
-          "en-US"
+          "en-US",
+          "en"
         ]
       }
     }

--- a/configs/nuxtjs.json
+++ b/configs/nuxtjs.json
@@ -3,44 +3,30 @@
   "start_urls": [
     {
       "url": "https://nuxtjs.org/fr/",
-      "variables": {
-        "lang": [
-          "fr-FR",
-          "fr"
-        ]
+      "extra_attributes": {
+        "language": ["fr-FR", "fr"]
       }
     },
     {
       "url": "https://nuxtjs.org/ja/",
-      "variables": {
-        "lang": [
-          "ja-JP",
-          "ja"
-        ]
+      "extra_attributes": {
+        "language": ["ja-JP", "ja"]
       }
     },
     {
       "url": "https://nuxtjs.org/en/",
-      "variables": {
-        "lang": [
-          "en-US",
-          "en"
-        ]
+      "extra_attributes": {
+        "language": ["en-US", "en"]
       }
     },
     {
       "url": "https://nuxtjs.org/",
       "extra_attributes": {
-        "lang": [
-          "en-US",
-          "en"
-        ]
+        "language": ["en-US", "en"]
       }
     }
   ],
-  "stop_urls": [
-    "/logos/"
-  ],
+  "stop_urls": ["/logos/"],
   "selectors": {
     "lvl0": {
       "selector": "li.active h5",
@@ -54,12 +40,8 @@
     "text": "article p, article li"
   },
   "custom_settings": {
-    "attributesForFaceting": [
-      "lang"
-    ]
+    "attributesForFaceting": ["language"]
   },
-  "conversation_id": [
-    "305423545"
-  ],
+  "conversation_id": ["305423545"],
   "nb_hits": 10873
 }


### PR DESCRIPTION
# Pull request motivation(s)

Follow-up on https://github.com/algolia/docsearch-configs/pull/4607#issuecomment-921628399 

Language codes are coming from https://github.com/nuxt/nuxtjs.org/blob/a2fdf7dd45860e06085715a2ed543a41850f163a/nuxt.config.ts#L151-L168

I've suggested tagging with both iso & code in case we change the frontend behaviour in future. (cc: @Tahul)
