### PR TITLE
Exclude sdk/php pages from index

### DIFF
--- a/configs/xsolla.json
+++ b/configs/xsolla.json
@@ -82,7 +82,7 @@
   "stop_urls": [
     "/search",
     "/changelog/tags",
-    "https://developers.xsolla.com(/[a-z][a-z])?/sdk/php/*",
+    "/sdk/php/",
     "https://developers.xsolla.com/changelog/$",
     "https://developers.xsolla.com/ru/changelog/$",
     "https://developers.xsolla.com/de/changelog/$",

--- a/configs/xsolla.json
+++ b/configs/xsolla.json
@@ -82,6 +82,7 @@
   "stop_urls": [
     "/search",
     "/changelog/tags",
+    "https://developers.xsolla.com(/[a-z][a-z])?/sdk/php/*",
     "https://developers.xsolla.com/changelog/$",
     "https://developers.xsolla.com/ru/changelog/$",
     "https://developers.xsolla.com/de/changelog/$",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We need to exclude pages under /sdk/php from the search results.

### What is the current behaviour?

When we search for "php sdk", we see pages in the section in the search results.

### What is the expected behaviour?

When we search for "php sdk", we find nothing.

##### NB: Do you want to request a **feature** or report a **bug**?



##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
