### PR TITLE
Update near.json config to docusaurus v2

### DIFF
--- a/configs/near.json
+++ b/configs/near.json
@@ -17,48 +17,29 @@
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
-    "docs": {
-      "lvl0": {
-        "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
-        "type": "xpath",
-        "global": true,
-        "default_value": "Documentation"
-      },
-      "lvl1": ".post h1",
-      "lvl2": ".post h2",
-      "lvl3": ".post h3",
-      "lvl4": ".post h4",
-      "lvl5": ".post h5",
-      "text": ".post article p, .post article li"
+    "lvl0": {
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Documentation"
     },
-    "sdk-docs": {
-      "lvl0": {
-        "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
-        "type": "xpath",
-        "global": true,
-        "default_value": "Documentation"
-      },
-      "lvl1": "header h1",
-      "lvl2": "article h2",
-      "lvl3": "article h3",
-      "lvl4": "article h4",
-      "lvl5": "article h5, article td:first-child",
-      "lvl6": "article h6",
-      "text": "article p, article li, article td:last-child"
-    }
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
   "strip_chars": " .,;:#",
-  "selectors_exclude": [
-    ".hash-link"
-  ],
   "custom_settings": {
+    "separatorsToIndex": "_",
     "attributesForFaceting": [
       "language",
       "version",
       "type",
       "docusaurus_tag"
     ],
-    "separatorsToIndex": "_",
     "attributesToRetrieve": [
       "hierarchy",
       "content",


### PR DESCRIPTION
Update to Docusaurus v2

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

We have recently upgraded docs.near.org from docusaurus v1 to docusaurus v2. It seems that we missed a migration step, related to Algolia's configuration.
Now the search results point to broken/missing URLs. From the migration docs, I found out that we need to update the `near.json` config file.

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
