### PR TITLE
fix(httpie): only main docs page should be parsed

### DIFF
--- a/configs/httpie.json
+++ b/configs/httpie.json
@@ -1,11 +1,6 @@
 {
   "index_name": "httpie",
-  "start_urls": ["https://httpie.io/docs"],
-  "stop_urls": [
-    {
-      "url": "https://httpie.io/docs/.+"
-    }
-  ],
+  "start_urls": ["https://httpie.io/docs$"],
   "selectors": {
     "lvl0": {
       "selector": "",
@@ -18,10 +13,7 @@
   },
   "js_render": true,
   "js_wait": 1,
-  "use_anchors": true,
   "strip_chars": " .,;:#",
-  "conversation_id": [
-    "289903050"
-  ],
-  "nb_hits": 34006
+  "conversation_id": ["289903050"],
+  "nb_hits": 356
 }

--- a/configs/httpie.json
+++ b/configs/httpie.json
@@ -1,6 +1,11 @@
 {
   "index_name": "httpie",
   "start_urls": ["https://httpie.io/docs"],
+  "stop_urls": [
+    {
+      "url": "https://httpie.io/docs/.+"
+    }
+  ],
   "selectors": {
     "lvl0": {
       "selector": "",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

### What is the current behaviour?

Crawler was parsing all the https://httpie.io/docs/* pages because they were linked inside the main page.

### What is the current and expected behaviour?

It should only do that for the main `https://httpie.io/docs` page.

### Question:

We also experience the following issue:

![image](https://user-images.githubusercontent.com/7103711/134156648-0743335a-ea29-4c00-8b46-9bc81b4fd247.png)

Whatever we search for, all the suggestions are always the same. What's interesting, links seem to be correct:

![CleanShot 2021-09-21 at 12 40 56](https://user-images.githubusercontent.com/7103711/134156987-f0c430a6-af5d-445e-b6f6-040b532494f7.png)

![CleanShot 2021-09-21 at 12 41 31](https://user-images.githubusercontent.com/7103711/134157046-484147eb-47b0-42b2-b2d5-cba260d4f3be.png)


📸   Live demo at https://httpie.io/.


<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
