### PR TITLE
px4.json: add sitemap.xml

### DIFF
--- a/configs/px4.json
+++ b/configs/px4.json
@@ -1,5 +1,6 @@
 {
   "index_name": "px4",
+  "sitemap_urls": ["https://docs.px4.io/sitemap.xml"],
   "start_urls": [
     {
       "url": "https://docs.px4.io/master/",

--- a/configs/px4.json
+++ b/configs/px4.json
@@ -38,7 +38,7 @@
       "lvl3": ".theme-default-content h3",
       "lvl4": ".theme-default-content h4",
       "lvl5": ".theme-default-content h5",
-      "text": ".theme-default-content p, .theme-default-content li",
+      "text": ".theme-default-content p, .theme-default-content li, .theme-default-content td:first-child", 
       "lang": {
         "selector": "/html/@lang",
         "type": "xpath",


### PR DESCRIPTION
This adds a sitemap.xml for the whole site, which I hope will fix our inconsistent search result issue.

If this makes a difference I will do the work to make this more modular. Note, this only specifies URLs and update frequency.

Also tries to add selector for our parameter docs which are often in tables. 

As advised by ClementV. Thanks!

EDIT: NOTE, moved to draft. The auto-generated sitemap is a bit crap. let me have another go. 