### PR TITLE
Base URL change for `dnnsoftware.json` config

### DIFF
--- a/configs/dnnsoftware.json
+++ b/configs/dnnsoftware.json
@@ -12,13 +12,6 @@
       ]
     },
     {
-      "url": "https://docs.dnncommunity.org/api/DotNetNuke.Common.Lists.ListInfoCollection.html",
-      "selectors_key": "api",
-      "tags": [
-        "api"
-      ]
-    },
-    {
       "url": "https://docs.dnncommunity.org/",
       "tags": [
         "docs"
@@ -58,5 +51,6 @@
     ".inheritedMembers",
     ".inheritance"
   ],
+  "scrape_start_urls": false,
   "nb_hits": 66153
 }

--- a/configs/dnnsoftware.json
+++ b/configs/dnnsoftware.json
@@ -58,6 +58,5 @@
     ".inheritedMembers",
     ".inheritance"
   ],
-  "scrape_start_url": false,
   "nb_hits": 66153
 }

--- a/configs/dnnsoftware.json
+++ b/configs/dnnsoftware.json
@@ -1,25 +1,25 @@
 {
   "index_name": "dnnsoftware",
   "sitemap_urls": [
-    "https://dnndocs.com/sitemap.xml"
+    "https://docs.dnncommunity.org/sitemap.xml"
   ],
   "start_urls": [
     {
-      "url": "https://dnndocs.com/api/",
+      "url": "https://docs.dnncommunity.org/api/",
       "selectors_key": "api",
       "tags": [
         "api"
       ]
     },
     {
-      "url": "https://dnndocs.com/api/DotNetNuke.Common.Lists.ListInfoCollection.html",
+      "url": "https://docs.dnncommunity.org/api/DotNetNuke.Common.Lists.ListInfoCollection.html",
       "selectors_key": "api",
       "tags": [
         "api"
       ]
     },
     {
-      "url": "https://dnndocs.com/",
+      "url": "https://docs.dnncommunity.org/",
       "tags": [
         "docs"
       ]


### PR DESCRIPTION
# Pull request motivation(s)
Our base URL has changed from `dnndocs.com` to `docs.dnncommunity.org`.

### What is the current behaviour?
Search results are based on the `dnndocs.com` URL.

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*
Go to https://dnndocs.com and perform a search.  You will see the results are based on the base URL of `dnndocs.com`.

### What is the expected behaviour?
Search results should be based on our new base URL `docs.dnncommunity.org`.

##### NB: Do you want to request a **feature** or report a **bug**?
n/a

##### NB2: Any other feedback / questions ?
Our GitHub repo is at https://github.com/DNNCommunity/DNNDocs and I am a maintainer of the project.