### PR TITLE
includes community tag for other recipe URLs

### DIFF
--- a/configs/supertokens.json
+++ b/configs/supertokens.json
@@ -10,25 +10,25 @@
     {
       "url": "https://supertokens.io/docs/emailpassword/",
       "tags": [
-        "emailpassword"
+        "emailpassword", "community"
       ]
     },
     {
       "url": "https://supertokens.io/docs/thirdparty/",
       "tags": [
-        "thirdparty"
+        "thirdparty", "community"
       ]
     },
     {
       "url": "https://supertokens.io/docs/thirdpartyemailpassword/",
       "tags": [
-        "thirdpartyemailpassword"
+        "thirdpartyemailpassword", "community"
       ]
     },
     {
       "url": "https://supertokens.io/docs/session/",
       "tags": [
-        "session"
+        "session", "community"
       ]
     },
     {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
We need search results from additional pages to be seen when using the `community` tag. 

### What is the current behaviour?
Currently, when using the `community` tag we get results from our `/community` docs, we would like this tag to include additional pages.

### What is the expected behaviour?
With this PR, the `community` tag should now also show results from the `EmailPassword`, `ThirdParty`, `ThirdPartyEmailPassword` and `Session` pages

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
