### PR TITLE
fix(sprinklr_spaceweb): add sitemap_urls

### DIFF
--- a/configs/sprinklr_spaceweb.json
+++ b/configs/sprinklr_spaceweb.json
@@ -2,6 +2,7 @@
   "index_name": "sprinklr_spaceweb",
   "start_urls": ["https://spaceweb.netlify.app/"],
   "stop_urls": [],
+  "sitemap_urls": ["https://spaceweb.netlify.app/sitemap.xml"],
   "selectors": {
     "lvl0": "#docSearch-content h1",
     "lvl1": "#docSearch-content h2",


### PR DESCRIPTION
# Pull request motivation(s)
Algolia search results for our documentation website are irrelevant as of now. We seem to have found an underlying cause for the same. Thus, we are adding a sitemap to make it easier for the crawler to populate the algolia index.
Sitemap: https://spaceweb.netlify.app/sitemap.xml

### What is the current behaviour?

Queries do not bear relevant results

### What is the expected behaviour?

Appropriate search results post config update





