### PR TITLE
Update domain for Nanoc index

### DIFF
--- a/configs/nanoc.json
+++ b/configs/nanoc.json
@@ -1,8 +1,8 @@
 {
   "index_name": "nanoc",
   "start_urls": [
-    "https://nanoc.ws/about/",
-    "https://nanoc.ws/doc/"
+    "https://nanoc.app/about/",
+    "https://nanoc.app/doc/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Pull request motivation(s)

Nanoc has moved from https://nanoc.ws to https://nanoc.app.

### What is the current behaviour?

The search on https://nanoc.app is not functioning at the moment, likely because this config points to the old https://nanoc.ws instead.

### What is the expected behaviour?

Search is working as intended.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
