### PR TITLE
fix(secureauth): update `custom_settings`

### DIFF
--- a/configs/secureauth.json
+++ b/configs/secureauth.json
@@ -1,6 +1,6 @@
 {
   "index_name": "secureauth",
-  "start_urls": ["url": "https://docs.secureauth.com/"],
+  "start_urls": ["https://docs.secureauth.com/"],
   "stop_urls": ["/login", "/label/", "/download", "/pages/"],
   "selectors": {
     "lvl0": "section h1",

--- a/configs/secureauth.json
+++ b/configs/secureauth.json
@@ -1,10 +1,6 @@
 {
   "index_name": "secureauth",
-  "start_urls": [
-    {
-      "url": "https://docs.secureauth.com/"      
-    }
-  ],
+  "start_urls": ["url": "https://docs.secureauth.com/"],
   "stop_urls": ["/login", "/label/", "/download", "/pages/"],
   "selectors": {
     "lvl0": "section h1",

--- a/configs/secureauth.json
+++ b/configs/secureauth.json
@@ -19,9 +19,8 @@
     "text": "section p, section li"
   },
   "custom_settings": {
-    "attributesForFaceting": ["version"]
-  },
-  "attributesToRetrieve": [
+    "attributesForFaceting": ["version"],
+    "attributesToRetrieve": [
       "hierarchy",
       "content",
       "anchor",
@@ -35,6 +34,7 @@
       "cat4",
       "cat5"
     ]
+  },  
   "conversation_id": ["1071099184"],
   "nb_hits": 82113
 }

--- a/configs/secureauth.json
+++ b/configs/secureauth.json
@@ -18,6 +18,23 @@
     "lvl5": "section h6",
     "text": "section p, section li"
   },
+  "custom_settings": {
+    "attributesForFaceting": ["version"]
+  },
+  "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type",
+      "version",
+      "cat1",
+      "cat2",
+      "cat3",
+      "cat4",
+      "cat5"
+    ]
   "conversation_id": ["1071099184"],
   "nb_hits": 82113
 }

--- a/configs/secureauth.json
+++ b/configs/secureauth.json
@@ -2,10 +2,7 @@
   "index_name": "secureauth",
   "start_urls": [
     {
-      "url": "https://docs.secureauth.com/(?P<version>.*?)/",
-      "variables": {
-        "version": ["2104test", "2006test", "1907test"]
-      }
+      "url": "https://docs.secureauth.com/"      
     }
   ],
   "stop_urls": ["/login", "/label/", "/download", "/pages/"],


### PR DESCRIPTION
# Pull request motivation(s)
My clients at SecureAuth are looking to enhance their search functionality by both restricting search to a particular version and adding more metadata into the presentation of search results.

### What is the current behaviour?
There is no ability to restrict searching to a particular version.

### What is the expected behaviour?
We should now be able to facet our results. We're also hoping that metatags prefixed with "docusearch:" will show up in results so that they may possibly be utilized in transformData function.
