### PR TITLE
Update Flarum docs to Docusaurus

### DIFF
--- a/configs/flarum.json
+++ b/configs/flarum.json
@@ -3,33 +3,44 @@
   "start_urls": [
     "https://docs.flarum.org/"
   ],
+  "sitemap_urls": [
+    "https://docs.flarum.org/sitemap.xml"
+  ],
   "stop_urls": [],
   "selectors": {
-    "text": ".theme-default-content p, .theme-default-content li",
     "lvl0": {
-      "selector": "p.sidebar-heading.open",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".theme-default-content h2",
-    "lvl2": ".theme-default-content h3",
-    "lvl3": ".theme-default-content h4",
-    "lvl4": ".theme-default-content h5",
-    "lvl5": ".theme-default-content h6",
-    "lang": {
-      "selector": "/html/@lang",
-      "type": "xpath",
-      "global": true,
-      "default_value": "en-US"
-    }
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
-  "scrape_start_urls": false,
   "strip_chars": " .,;:#",
   "custom_settings": {
+    "separatorsToIndex": "_",
     "attributesForFaceting": [
-      "lang"
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
     ]
   },
+  "scrape_start_urls": false,
   "min_indexed_level": 0,
   "nb_hits": 873
 }


### PR DESCRIPTION
We've switched from Vuepress to Docusaurus v2, and are changing this config in accordance with [the template](https://raw.githubusercontent.com/algolia/docsearch-configs/master/configs/docusaurus-2.json). 

Thank you so much for providing this service!