### PR TITLE
Update lvl0 selector for Galasa

### DIFF
--- a/configs/galasa.json
+++ b/configs/galasa.json
@@ -9,7 +9,9 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": "",
+      "selector": "(//nav[@id='sidebar']//div[contains(concat(' ', normalize-space(@class), ' '), ' markerInNavPath ') and not(contains(concat(' ', normalize-space(@class), ' '), ' selected '))]/a/text() | //nav[@id='headerNav']//a[contains(concat(' ', normalize-space(@class), ' '), ' selected ')]/text())[last()]",
+      "type": "xpath",
+      "global": true,
       "default_value": "Documentation"
     },
     "lvl1": "[class*='docContent'] h1",

--- a/configs/galasa.json
+++ b/configs/galasa.json
@@ -9,10 +9,12 @@
   ],
   "selectors": {
     "lvl0": {
-      "selector": "(//nav[@id='sidebar']//div[contains(concat(' ', normalize-space(@class), ' '), ' markerInNavPath ') and not(contains(concat(' ', normalize-space(@class), ' '), ' selected '))]/a/text() | //nav[@id='headerNav']//a[contains(concat(' ', normalize-space(@class), ' '), ' selected ')]/text())[last()]",
-      "type": "xpath",
+      "selectors": [
+        "#sidebar div.markerInNavPath:not(.selected)",
+        "#headerNav a.selected"
+      ],
       "global": true,
-      "default_value": "Documentation"
+      "default_value": "Docs"
     },
     "lvl1": "[class*='docContent'] h1",
     "lvl2": "[class*='docContent'] h2",

--- a/configs/galasa.json
+++ b/configs/galasa.json
@@ -9,10 +9,7 @@
   ],
   "selectors": {
     "lvl0": {
-      "selectors": [
-        "#sidebar div.markerInNavPath:not(.selected)",
-        "#headerNav a.selected"
-      ],
+      "selector": "#sidebar div.markerInNavPath:not(.selected)",
       "global": true,
       "default_value": "Docs"
     },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We're in the process of adding DocSearch to galasa.dev. User testing shows that the default 'Documentation' category is being selected for everything, plus the React component then limits to 5 results from a single category. So this PR adds a better lvl0 selector.

### What is the current behaviour?

Every results comes under the 'Documentation' section, with no distinction between them, and max 5 results.

### What is the expected behaviour?

The user gets an awareness of the hierarchy of a result in the search modal, with up to 5 results from each of several categories.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
