### PR TITLE
Update radar.json

### DIFF
--- a/configs/radar.json
+++ b/configs/radar.json
@@ -16,6 +16,24 @@
     "lvl5": "h6",
     "text": "p, li"
   },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  },
   "conversation_id": [
     "1495879294"
   ],


### PR DESCRIPTION
# Pull request motivation(s)
Updating the radar.json to better resemble the Docusaurus 2 config: https://github.com/facebook/docusaurus/issues/4555#issuecomment-936527991

### What is the current behaviour?
- Anchor links (the `#` that accompany headers) are appearing in search results 
- TOC links are appearing in search results

### What is the expected behaviour?
Search results should omit the anchor links symbol and TOC links should not appear in search results