### PR TITLE
[fig] Add crawling for support documentation

### DIFF
--- a/configs/fig.json
+++ b/configs/fig.json
@@ -1,7 +1,8 @@
 {
   "index_name": "fig",
   "start_urls": [
-    "https://fig.io/docs/"
+    "https://fig.io/docs/",
+    "https://fig.io/support/"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We have added support specific documentation under a different url that /docs. We would like doc search to also crawl pages under /support.

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

Docsearch crawls pages under /docs

### What is the expected behaviour?

Docsearch crawls pages under both /docs and /support

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
