### PR TITLE
[parceljs] Don't index blog pages and marketing page

### DIFF
--- a/configs/parceljs.json
+++ b/configs/parceljs.json
@@ -37,7 +37,7 @@
       }
     }
   ],
-  "stop_urls": ["https://parceljs.org/", "https://parceljs.org/blog/.*"],
+  "stop_urls": ["https://parceljs.org/$", "https://parceljs.org/blog/"],
   "stop_content": ["assets/parcel-front.png"],
   "selectors": {
     "lvl0": "main h1",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Currently the search index includes the blog posts and homepage, ideally it would just include our documentation

### What is the current behaviour?

Search results include blog posts

### What is the expected behaviour?

Does not include blog posts

