### PR TITLE
fix(sprinklr_spaceweb): remove js_render

### DIFF
--- a/configs/sprinklr_spaceweb.json
+++ b/configs/sprinklr_spaceweb.json
@@ -12,7 +12,6 @@
     "lvl5": "#docSearch-content h6",
     "text": "#docSearch-content p, #docSearch-content li"
   },
-  "js_render": true,
   "conversation_id": ["1208777037"],
   "nb_hits": 521
 }


### PR DESCRIPTION
# Pull request motivation(s)
Improve search results

### What is the current behaviour?

URLs in sitemap not being crawled. `nb_hits: 521`
<img width="780" alt="Screenshot 2021-10-12 at 10 05 10 AM" src="https://user-images.githubusercontent.com/38891571/136911180-480a4e79-7780-47f5-ad3f-d6fefa68d437.png">

### What is the expected behaviour?

URLs in sitemap being crawled. `nb_hits: 1651`
<img width="831" alt="Screenshot 2021-10-12 at 12 58 44 PM" src="https://user-images.githubusercontent.com/38891571/136911249-d61f0834-ba66-4269-b9ba-948d55be7b5e.png">
