### PR TITLE
chore: update mixin.json for crawler

### DIFF
--- a/configs/mixin.json
+++ b/configs/mixin.json
@@ -1,10 +1,10 @@
 {
   "index_name": "mixin",
   "start_urls": [
-    "https://developers.mixin.one/docs/"
+    "https://developers.mixin.one/"
   ],
   "sitemap_urls": [
-    "https://developers.mixin.one/docs/sitemap.xml"
+    "https://developers.mixin.one/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
The site owner has changed the base URL of docusaurus from `/docs/`  to `/`. Please check it out https://developers.mixin.one/
 
So i update the entry config of the website.