### PR TITLE
chore: enable alternate links on electron

### DIFF
--- a/configs/electronjs.json
+++ b/configs/electronjs.json
@@ -1,11 +1,12 @@
 {
   "index_name": "electronjs",
   "start_urls": [
-    "https://www.electronjs.org/docs/latest/"
+    "https://www.electronjs.org/"
   ],
   "sitemap_urls": [
-    "https://www.electronjs.org/docs/latest/sitemap.xml"
+    "https://www.electronjs.org/sitemap.xml"
   ],
+  "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
# Pull request motivation(s)

The Electron team has enabled localized content. From what I'm investigating we need to update the configuration to support localized searches.
Additionally, we have migrated the [blog to docusaurus](https://www.electronjs.org/blog) as well and it will be good to have it indexed as well so changing the start url and sitemaps.

### What is the current behaviour?

Search results are not localized

### What is the expected behaviour?

Search results in www.electronjs.org/docs/latest to be localized


@erickzhao FYI
