### PR TITLE
Update getdoks configuration

### DIFF
--- a/configs/getdoks.json
+++ b/configs/getdoks.json
@@ -17,6 +17,10 @@
     "text": ".docs-content p, .docs-content li"
   },
   "strip_chars": "#",
+  "selectors_exclude": [
+    "#announcement",
+    "#_carbonads_js"
+  ],
   "conversation_id": [
     "1378511290"
   ],


### PR DESCRIPTION
# Pull request motivation(s)

Adds to `configs/getdoks.json`:

```
  "selectors_exclude": [
    "#announcement",
    "#_carbonads_js"
  ],
```

## What is the current behaviour?

`#announcement` + `#_carbonads_js` show up in the search results.

## What is the expected behaviour?

`#announcement` + `#_carbonads_js` do NOT show up in the search results.
