### PR TITLE
configs (figma): exclude blog/ too

### DIFF
--- a/configs/figma.json
+++ b/configs/figma.json
@@ -20,7 +20,10 @@
       "tags": ["plugin-docs"]
     }
   ],
-  "stop_urls": ["/blog/page"],
+  "stop_urls": [
+    "/blog/",
+    "/blog/page"
+  ],
   "selectors": {
     "default": {
       "lvl0": {


### PR DESCRIPTION
# Pull request motivation(s)

This was suggested here by @shortcuts  https://github.com/algolia/docsearch-configs/pull/4743#discussion_r730862507 and I asked to remove it 😢 - testing it out, I think we actually want this.

### What is the current behaviour?

We return the listing page as a result:

![image](https://user-images.githubusercontent.com/610102/137751123-85ac9f38-6934-46e7-8a63-6e15cfc223e7.png)

### What is the expected behaviour?

Don't index the listing page at all!
