### PR TITLE
fix(memgraph): update start_urls and sitemap_urls

### DIFF
--- a/configs/g-despot.json
+++ b/configs/g-despot.json
@@ -1,10 +1,10 @@
 {
   "index_name": "g-despot",
   "start_urls": [
-    "https://docs.memgraph.com"
+    "https://memgraph.com/docs"
   ],
   "sitemap_urls": [
-    "https://docs.memgraph.com/sitemap.xml"
+    "https://memgraph.com/docs/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation

The config file became outdated as the site `docs.memgraph.com` was migrated to `memgraph.com/docs`.
As you can imply from the [GitHub repository](https://github.com/memgraph/docs), I am the maintainer of the documentation site.