### PR TITLE
Update and rename spreadsheetalt.json to spreadsheet.json

### DIFF
--- a/configs/spreadsheet.json
+++ b/configs/spreadsheet.json
@@ -1,10 +1,10 @@
 {
-  "index_name": "spreadsheetalt",
+  "index_name": "spreadsheet",
   "start_urls": [
-    "https://docs.dhtmlx.com/spreadsheetalt/"
+    "https://docs.dhtmlx.com/spreadsheet/"
   ],
   "sitemap_urls": [
-    "https://docs.dhtmlx.com/spreadsheetalt/sitemap.xml"
+    "https://docs.dhtmlx.com/spreadsheet/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
Update and rename spreadsheetalt.json to spreadsheet.json

# Pull request motivation(s)
https://docs.dhtmlx.com/spreadsheetalt/ was updated to https://docs.dhtmlx.com/spreadsheet/

### What is the current behaviour?

The results of the search are incorrect.

### What is the expected behaviour?
The correct results. 

##### NB: Do you want to request a **feature** or report a **bug**?
No

##### NB2: Any other feedback / questions ?
No, thanks.

https://github.com/DHTMLX/docs-spreadsheet
