### PR TITLE
Update: documentation URL

### DIFF
--- a/configs/matic_developer.json
+++ b/configs/matic_developer.json
@@ -1,10 +1,10 @@
 {
   "index_name": "matic_developer",
   "start_urls": [
-    "https://docs.matic.network/docs/"
+    "https://docs.polygon.technology/"
   ],
   "sitemap_urls": [
-    "https://docs.matic.network/sitemap.xml"
+    "https://docs.polygon.technology/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)
We have changed the documentation URL and as a result, the latest changes to our documentation are not being put in Algolia index. So I changed the start and sitemap URLs in matic_developer.json

### What is the current behaviour?
Users are not able to use the search effectively as the latest updates are missing from the Algolia index. 

### What is the expected behaviour?
All the recent changes in the documentation should be indexed in the search. 
