### PR TITLE
Added 4.1.0 sitemap

### DIFF
--- a/configs/wso2.json
+++ b/configs/wso2.json
@@ -18,7 +18,8 @@
     "https://apim.docs.wso2.com/en/next/sitemap.xml",
     "https://apim.docs.wso2.com/en/3.0.0/sitemap.xml",
     "https://apim.docs.wso2.com/en/3.1.0/sitemap.xml",
-    "https://apim.docs.wso2.com/en/3.2.0/sitemap.xml"
+    "https://apim.docs.wso2.com/en/3.2.0/sitemap.xml",
+    "https://apim.docs.wso2.com/en/4.1.0/sitemap.xml"
 
   ],
   "conversation_id": [


### PR DESCRIPTION
Added the WSO2 API Manager documentation 4.1.0 sitemap because now the 4.1.0 docs [1] are live.

[1] https://apim.docs.wso2.com/en/4.1.0/