### PR TITLE
Update klicker-uzh.json

### DIFF
--- a/configs/klicker-uzh.json
+++ b/configs/klicker-uzh.json
@@ -1,34 +1,42 @@
 {
   "index_name": "klicker-uzh",
   "start_urls": [
-    "https://uzh-bf.github.io/klicker-uzh/docs/"
+    "https://www.klicker.uzh.ch/docs/"
   ],
   "sitemap_urls": [
-    "https://uzh-bf.github.io/klicker-uzh/sitemap.xml"
+    "https://www.klicker.uzh.ch/docs/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "//*[contains(@class,'navGroups')]//*[contains(@class,'navListItemActive')]/preceding::h3[1]",
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": ".post h1",
-    "lvl2": ".post h2",
-    "lvl3": ".post h3",
-    "lvl4": ".post h4",
-    "lvl5": ".post h5",
-    "text": ".post article p, .post article li"
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
   },
-  "selectors_exclude": [
-    ".hash-link"
-  ],
+  "strip_chars": " .,;:#",
   "custom_settings": {
+    "separatorsToIndex": "_",
     "attributesForFaceting": [
-      "language",
-      "version"
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
     ]
   },
   "conversation_id": [


### PR DESCRIPTION
We have recently migrated our doc site to Docusaurus 2 on a new domain (https://www.klicker.uzh.ch/docs/). This PR should change everything necessary in the `klicker-uzh` config (based on the `docusaurus-2` config in this repo).

Thanks a lot for the great service.