### PR TITLE
remove stop_urls

### DIFF
--- a/configs/celo.json
+++ b/configs/celo.json
@@ -6,9 +6,7 @@
   "sitemap_urls": [
     "https://docs.celo.org/sitemap.xml"
   ],
-  "stop_urls": [
-    "https://docs.celo.org/es/"
-  ],
+  "stop_urls": [],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

I added contextual search to the main docs repo, so shouldn't need `stop_urls` anymore.

### What is the current behaviour?

With contextual search off, translated pages were showing up in all searches, so translated pages were added to `stop_urls`.

### What is the expected behaviour?

Translated pages should only appear in search when browsing docs of the same language.

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
