### PR TITLE
Update iota.json

### DIFF
--- a/configs/iota.json
+++ b/configs/iota.json
@@ -9,17 +9,17 @@
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+    "lvl0": ".navbar__link--active .link__label",
+    "lvl1": {
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link--active')]/text())[last()]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"
     },
-    "lvl1": "header h1",
-    "lvl2": "article h2",
-    "lvl3": "article h3",
-    "lvl4": "article h4",
-    "lvl5": "article h5, article td:first-child",
+    "lvl2": "header h1",
+    "lvl3": "article h2",
+    "lvl4": "article h3",
+    "lvl5": "article h4",
     "text": "article p, article li, article td:last-child"
   },
   "strip_chars": " .,;:#",


### PR DESCRIPTION
# Pull request motivation(s)
 
As the [IOTA wiki](https://wiki.iota.org) is actually around 15 docs sites in one, we want to move the `lvl0` selector to the top navbar so the users know if the results are within the "Learn", "Participate" or "Build" section, and if within the "Build" section within which project.

### What is the current behaviour?

The current behavior is what we'd expect from a single repo docusarus site, which selects the current sidebar element as lvl0, we aim to move `lvl0` to `lvl1`, `lvl1` to `lvl2`, `lvl2` to `lvl3`, `lvl3` to `lvl4`, and `lvl4` to `lvl5`.


### What is the expected behaviour?

We need to adjust the search config to use the top navbar element as lvl0.

##Description of Changes

Made lvl0 select the top navbar item so users can know if the results are within the "Learn", "Build" or "Participate" sections.  
Moved the current `lvl0` to `lvl1`, `lvl1` to `lvl2`, `lvl2` to `lvl3`, `lvl3` to `lvl4`, and `lvl4` to `lvl5`.
