### PR TITLE
Update openeo.org and openeo.cloud config

### DIFF
--- a/configs/openeo-cloud.json
+++ b/configs/openeo-cloud.json
@@ -17,10 +17,6 @@
       "page_rank": 0
     },
     {
-      "url": "https://docs.openeo.cloud",
-      "page_rank": 1
-    },
-    {
       "url": "https://docs.openeo.cloud/file-formats/",
       "page_rank": 1,
       "selectors_key": "file-formats"
@@ -39,6 +35,10 @@
       "url": "https://docs.openeo.cloud/api/",
       "selectors_key": "api",
       "page_rank": -1
+    },
+    {
+      "url": "https://docs.openeo.cloud",
+      "page_rank": 1
     }
   ],
   "stop_urls": [],

--- a/configs/openeo-cloud.json
+++ b/configs/openeo-cloud.json
@@ -1,30 +1,147 @@
 {
   "index_name": "openeo-cloud",
   "start_urls": [
-    "https://docs.openeo.cloud"
+    {
+      "url": "https://open-eo.github.io/openeo-js-client/latest/",
+      "selectors_key": "js-client",
+      "page_rank": 0
+    },
+    {
+      "url": "https://open-eo.github.io/openeo-r-client/",
+      "selectors_key": "r-client",
+      "page_rank": 0
+    },
+    {
+      "url": "https://open-eo.github.io/openeo-python-client/",
+      "selectors_key": "python-client",
+      "page_rank": 0
+    },
+    {
+      "url": "https://docs.openeo.cloud",
+      "page_rank": 1
+    },
+    {
+      "url": "https://docs.openeo.cloud/file-formats/",
+      "page_rank": 1,
+      "selectors_key": "file-formats"
+    },
+    {
+      "url": "https://docs.openeo.cloud/data-collections/",
+      "selectors_key": "collections",
+      "page_rank": 2
+    },
+    {
+      "url": "https://docs.openeo.cloud/processes/",
+      "selectors_key": "processes",
+      "page_rank": 2
+    },
+    {
+      "url": "https://docs.openeo.cloud/api/",
+      "selectors_key": "api",
+      "page_rank": -1
+    }
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "p.sidebar-heading.open",
-      "global": true,
-      "default_value": "Documentation"
+    "default": {
+      "lvl0": {
+        "selector": "p.sidebar-heading.open",
+        "global": true,
+        "default_value": "openEO Platform"
+      },
+      "lvl1": ".theme-default-content h1",
+      "lvl2": ".theme-default-content h2",
+      "lvl3": ".theme-default-content h3",
+      "lvl4": ".theme-default-content h4",
+      "lvl5": ".theme-default-content h5",
+      "text": ".theme-default-content p, .theme-default-content li, .theme-default-content td"
     },
-    "lvl1": ".theme-default-content h1",
-    "lvl2": ".theme-default-content h2",
-    "lvl3": ".theme-default-content h3",
-    "lvl4": ".theme-default-content h4",
-    "lvl5": ".theme-default-content h5",
-    "text": ".theme-default-content p, .theme-default-content li",
-    "lang": {
-      "selector": "/html/@lang",
-      "type": "xpath",
-      "global": true,
-      "default_value": "en-US"
+    "api": {
+      "lvl0": {
+        "selector": "p.sidebar-heading.open",
+        "global": true,
+        "default_value": "API"
+      },
+      "lvl1": ".api-content h1",
+      "lvl2": ".api-content h2",
+      "lvl3": ".api-content h3",
+      "lvl4": ".api-content h4",
+      "lvl5": ".api-content h5",
+      "text": ".api-content p, .api-content li, .api-content td"
+    },
+    "collections": {
+      "lvl0": {
+        "selector": "p.sidebar-heading.open",
+        "global": true,
+        "default_value": "Data Collections"
+      },
+      "lvl1": ".collections h2",
+      "lvl2": ".collections .list li .summary strong",
+      "text": ".collections .list li .summary small, .collections .list li .summary .badge"
+    },
+    "file-formats": {
+      "lvl0": {
+        "selector": "p.sidebar-heading.open",
+        "global": true,
+        "default_value": "File Formats"
+      },
+      "lvl1": ".file-formats h2",
+      "lvl2": ".file-formats .list li .summary strong",
+      "text": ".file-formats .list li .summary small"
+    },
+    "processes": {
+      "lvl0": {
+        "selector": "p.sidebar-heading.open",
+        "global": true,
+        "default_value": "Processes"
+      },
+      "lvl1": ".process h2",
+      "lvl2": ".process h4",
+      "text": ".process p, .process summary"
+    },
+    "js-client": {
+      "lvl0": {
+        "selector": "#title",
+        "global": true,
+        "default_value": "JS Client"
+      },
+      "lvl1": "#main h1",
+      "lvl2": "#main h2",
+      "lvl3": "#main h3",
+      "lvl4": "#main h4",
+      "lvl5": "#main h5",
+      "text": "#main p, #main li, #main td"
+    },
+    "r-client": {
+      "lvl0": {
+        "selector": "#title",
+        "global": true,
+        "default_value": "R Client"
+      },
+      "lvl1": ".contents h1",
+      "lvl2": ".contents h2",
+      "lvl3": ".contents h3",
+      "lvl4": ".contents h4",
+      "lvl5": ".contents h5",
+      "text": ".contents p, .contents li"
+    },
+    "python-client": {
+      "lvl0": {
+        "selector": "#title",
+        "global": true,
+        "default_value": "Python Client"
+      },
+      "lvl1": ".body h1",
+      "lvl2": ".body h2",
+      "lvl3": ".body h3",
+      "lvl4": ".body h4",
+      "lvl5": ".body h5",
+      "text": ".body p, .body li"
     }
   },
   "selectors_exclude": [
-    ".table-of-contents"
+    ".table-of-contents",
+    ".toc"
   ],
   "strip_chars": " .,;:#",
   "custom_settings": {
@@ -36,5 +153,7 @@
     "1611749633"
   ],
   "scrape_start_urls": false,
-  "nb_hits": 297
+  "nb_hits": 297,
+  "js_render": true,
+  "use_anchors": true
 }

--- a/configs/openeo.json
+++ b/configs/openeo.json
@@ -28,7 +28,6 @@
   "stop_urls": [],
   "selectors": {
     "default": {
-      "$comment": ".theme-default-content is for VuePress, .api-content is for API/ReDoc, .process is for the process docgen",
       "lvl0": {
         "selector": "p.sidebar-heading.open",
         "global": true,

--- a/configs/openeo.json
+++ b/configs/openeo.json
@@ -1,30 +1,89 @@
 {
   "index_name": "openeo",
   "start_urls": [
-    "https://openeo.org"
+    {
+      "url": "https://open-eo.github.io/openeo-js-client/latest/",
+      "selectors_key": "js-client",
+      "page_rank": 0
+    },
+    {
+      "url": "https://open-eo.github.io/openeo-r-client/",
+      "selectors_key": "r-client",
+      "page_rank": 0
+    },
+    {
+      "url": "https://open-eo.github.io/openeo-python-client/",
+      "selectors_key": "python-client",
+      "page_rank": 0
+    },
+    {
+      "url": "https://openeo.org",
+      "page_rank": 1
+    },
+    {
+      "url": "https://openeo.org/documentation/0.4/",
+      "page_rank": -1
+    }
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "p.sidebar-heading.open",
-      "global": true,
-      "default_value": "Documentation"
+    "default": {
+      "$comment": ".theme-default-content is for VuePress, .api-content is for API/ReDoc, .process is for the process docgen",
+      "lvl0": {
+        "selector": "p.sidebar-heading.open",
+        "global": true,
+        "default_value": "openEO Platform"
+      },
+      "lvl1": ".theme-default-content h1, .process h2, .api-content h1",
+      "lvl2": ".theme-default-content h2, .process h4, .api-content h2",
+      "lvl3": ".theme-default-content h3, .api-content h3",
+      "lvl4": ".theme-default-content h4, .api-content h4",
+      "lvl5": ".theme-default-content h5, .api-content h5",
+      "text": ".theme-default-content p, .theme-default-content li, .theme-default-content td, .process p, .process summary, .api-content p, .api-content li, .api-content td"
     },
-    "lvl1": ".theme-default-content h1",
-    "lvl2": ".theme-default-content h2",
-    "lvl3": ".theme-default-content h3",
-    "lvl4": ".theme-default-content h4",
-    "lvl5": ".theme-default-content h5",
-    "text": ".theme-default-content p, .theme-default-content li",
-    "lang": {
-      "selector": "/html/@lang",
-      "type": "xpath",
-      "global": true,
-      "default_value": "en-US"
+    "js-client": {
+      "lvl0": {
+        "selector": "#title",
+        "global": true,
+        "default_value": "JS Client"
+      },
+      "lvl1": "#main h1",
+      "lvl2": "#main h2",
+      "lvl3": "#main h3",
+      "lvl4": "#main h4",
+      "lvl5": "#main h5",
+      "text": "#main p, #main li, #main td"
+    },
+    "r-client": {
+      "lvl0": {
+        "selector": "#title",
+        "global": true,
+        "default_value": "R Client"
+      },
+      "lvl1": ".contents h1",
+      "lvl2": ".contents h2",
+      "lvl3": ".contents h3",
+      "lvl4": ".contents h4",
+      "lvl5": ".contents h5",
+      "text": ".contents p, .contents li"
+    },
+    "python-client": {
+      "lvl0": {
+        "selector": "#title",
+        "global": true,
+        "default_value": "Python Client"
+      },
+      "lvl1": ".body h1",
+      "lvl2": ".body h2",
+      "lvl3": ".body h3",
+      "lvl4": ".body h4",
+      "lvl5": ".body h5",
+      "text": ".body p, .body li"
     }
   },
   "selectors_exclude": [
-    ".table-of-contents"
+    ".table-of-contents",
+    ".toc"
   ],
   "strip_chars": " .,;:#",
   "custom_settings": {
@@ -36,5 +95,7 @@
     "1579012028"
   ],
   "scrape_start_urls": false,
-  "nb_hits": 2253
+  "nb_hits": 2253,
+  "js_render": true,
+  "use_anchors": true
 }

--- a/configs/openeo.json
+++ b/configs/openeo.json
@@ -17,12 +17,12 @@
       "page_rank": 0
     },
     {
-      "url": "https://openeo.org",
-      "page_rank": 1
-    },
-    {
       "url": "https://openeo.org/documentation/0.4/",
       "page_rank": -1
+    },
+    {
+      "url": "https://openeo.org",
+      "page_rank": 1
     }
   ],
   "stop_urls": [],


### PR DESCRIPTION
# Pull request motivation(s)

Site crawling is incomplete, see https://github.com/openEOPlatform/documentation/issues/26

Question: Can I set js_render and js_wait per start URL? Most sites are pre-rendered, but only some need js_render (and rarely js_wait) to be set. It would probably speed up crawling if I could do that, otherwise the PR is good as it is.

### What is the current behaviour?

Some search terms don't return results.

### What is the expected behaviour?

All valid search terms return results.