### PR TITLE
Update jitsu.json

### DIFF
--- a/configs/jitsu.json
+++ b/configs/jitsu.json
@@ -17,6 +17,7 @@
     "text": "main p, main li"
   },
   "js_render": true,
+  "js_wait": 2,
   "conversation_id": [
     "1449037867"
   ],


### PR DESCRIPTION
Attempt to fix DocSearch not indexing new pages. E.g.:
https://jitsu.com/docs/configuration/javascript-transform
https://jitsu.com/docs/sources-configuration/airbyte

Algolia crawler visits these page according to our logs. But no content appear in search results.
