### PR TITLE
[yarnpkg_next] add synonym up <--> upgrade

### DIFF
--- a/configs/yarnpkg_next.json
+++ b/configs/yarnpkg_next.json
@@ -33,6 +33,12 @@
       "url",
       "url_without_anchor",
       "type"
+    ],
+    "synonyms": [
+      [
+        "up",
+        "upgrade"
+      ]
     ]
   },
   "selectors_exclude": [


### PR DESCRIPTION
As per https://github.com/yarnpkg/berry/issues/3421

Relevant docs: https://docsearch.algolia.com/docs/legacy/config-file/#custom_settingssynonyms-optional

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

When searching the [Yarn 2 documentation](https://yarnpkg.com/getting-started) for "upgrade", the results do not include [`yarn up` (CLI)](https://yarnpkg.com/cli/up).

### What is the expected behaviour?

When searching the [Yarn 2 documentation](https://yarnpkg.com/getting-started) for "upgrade", the results should include [`yarn up` (CLI)](https://yarnpkg.com/cli/up).