### PR TITLE
Update objectiv.json

### DIFF
--- a/configs/objectiv.json
+++ b/configs/objectiv.json
@@ -20,8 +20,9 @@
     "lvl3": "article h3",
     "lvl4": "article h4",
     "lvl5": "article h5, article td:first-child",
-    "text": "article p, article li:not(.ignore-for-search), article td:last-child"
+    "text": "article p, article li, article td:last-child"
   },
+  "selectors_exclude": ["footer"],
   "strip_chars": " .,;:#",
   "custom_settings": {
     "separatorsToIndex": "_",

--- a/configs/objectiv.json
+++ b/configs/objectiv.json
@@ -20,7 +20,7 @@
     "lvl3": "article h3",
     "lvl4": "article h4",
     "lvl5": "article h5, article td:first-child",
-    "text": "article p, article li, article td:last-child"
+    "text": "article p, article li:not(.ignore-for-search), article td:last-child"
   },
   "strip_chars": " .,;:#",
   "custom_settings": {


### PR DESCRIPTION
Update `text` selector for our search config. We will deploy an update to our docs to include the `ignore-for-search` class to filter on.

URL: https://objectiv.io/docs/ (search not enabled yet)

# Pull request motivation(s)
The footer in our documentation currently gets indexed, resulting in search results that list the items in the footer multiple times.

### What is the current behaviour?
Search for e.g. 'dataframe' and see 'Edit This Page' multiple times:
![image](https://user-images.githubusercontent.com/920184/142637151-bfe5490c-19e0-4871-8aad-8f058b1cf767.png)

### What is the expected behaviour?
The search results do not show the 'Edit This Page' item multiple times. The links in the footer of our docs are filtered out of the search results / not indexed.