### PR TITLE
feat: [arco] add vue site and language config

### DIFF
--- a/configs/arco.json
+++ b/configs/arco.json
@@ -1,25 +1,43 @@
 {
   "index_name": "arco",
   "start_urls": [
-    "https://arco.design/",
-    "https://arco.design/react/docs/start"
+    {
+      "url": "https://arco.design/vue/*",
+      "tags": ["vue"],
+      "selectors_key": "vue"
+    },
+    {
+      "url": "https://arco.design/react/*",
+      "tags": ["react"]
+    },
+    {
+      "url": "https://arco.design.+?(en-US)",
+      "tags": ["en-US"]
+    }
   ],
-  "sitemap_urls": [
-    "https://arco.design/sitemap.xml"
-  ],
+  "sitemap_urls": ["https://arco.design/sitemap.xml"],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".ac-content h1",
-    "lvl1": ".ac-content h2",
-    "lvl2": ".ac-content h3",
-    "lvl3": ".ac-content h4",
-    "lvl4": ".ac-content h5",
-    "lvl5": ".ac-content h6",
-    "text": ".ac-content p, .ac-content li"
+    "default": {
+      "lvl0": ".ac-content h1",
+      "lvl1": ".ac-content h2",
+      "lvl2": ".ac-content h3",
+      "lvl3": ".ac-content h4",
+      "lvl4": ".ac-content h5",
+      "lvl5": ".ac-content h6",
+      "text": ".ac-content p, .ac-content li"
+    },
+    "vue": {
+      "lvl0": ".arco-vue-body h1",
+      "lvl1": ".arco-vue-body h2",
+      "lvl2": ".arco-vue-body h3",
+      "lvl3": ".arco-vue-body h4",
+      "lvl4": ".arco-vue-body h5",
+      "lvl5": ".arco-vue-body h6",
+      "text": ".arco-vue-body p, .arco-vue-body li"
+    }
   },
   "js_render": true,
-  "conversation_id": [
-    "1693490441"
-  ],
+  "conversation_id": ["1693490441"],
   "nb_hits": 11998
 }

--- a/configs/arco.json
+++ b/configs/arco.json
@@ -2,12 +2,12 @@
   "index_name": "arco",
   "start_urls": [
     {
-      "url": "https://arco.design/vue/*",
+      "url": "https://arco.design/vue",
       "tags": ["vue"],
       "selectors_key": "vue"
     },
     {
-      "url": "https://arco.design/react/*",
+      "url": "https://arco.design/react",
       "tags": ["react"]
     },
     {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

I want to add two configurations:
1. Distinguish the usage documentation of `react` and `vue`.
2. Distinguish between `zh-CN` and `en-US` document languages

##### NB2: Any other feedback / questions ?
I changed `start_urls`, but these two URLs have overlapping scenes, I'm not sure if this is possible.

If not, is there any good solution?


Looking forward to your reply， THX.
<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
