### PR TITLE
Update objectiv.json

### DIFF
--- a/configs/objectiv.json
+++ b/configs/objectiv.json
@@ -23,6 +23,8 @@
     "text": "article p, article li, article td:last-child"
   },
   "selectors_exclude": ["footer"],
+  "js_render": true,
+  "js_wait": 2,
   "strip_chars": " .,;:#",
   "custom_settings": {
     "separatorsToIndex": "_",

--- a/configs/objectiv.json
+++ b/configs/objectiv.json
@@ -24,7 +24,7 @@
   },
   "selectors_exclude": ["footer"],
   "js_render": true,
-  "js_wait": 2,
+  "js_wait": 1,
   "strip_chars": " .,;:#",
   "custom_settings": {
     "separatorsToIndex": "_",


### PR DESCRIPTION
The pages of the Modeling section in our docs (https://objectiv.io/docs/modeling/) load content dynamically. 

This PR adds the `js_render` and `js_wait` options to our config to enable crawling the content on those pages. We set `js_wait` to 2 seconds to be on the safe side, though the pages generally load in a few hundred milliseconds; we hope the impact on crawling speed is not too high.
