### PR TITLE
Update tailwindcss.json

### DIFF
--- a/configs/tailwindcss.json
+++ b/configs/tailwindcss.json
@@ -93,7 +93,8 @@
   "selectors_exclude": [
     "p.text-base",
     ".list-inside",
-    ".bg-gray-200"
+    ".bg-gray-200",
+    "[data-docsearch-ignore]"
   ],
   "custom_settings": {
     "attributesForFaceting": [


### PR DESCRIPTION
We're hoping to make it possible for us to manually exclude certain headings from search results, since we have many useless duplicate headings on the site that introduce a lot of noise.

![image](https://user-images.githubusercontent.com/4323180/143018322-92aeec07-9da7-43a5-8857-acd55c4882ae.png)

This way we can make sure that when someone is searching something like "Responsive" for example that we don't include headings we know for a fact that they aren't looking for 👍🏻 