### PR TITLE
feat: add prod/beta tags for start_urls for avax.json

### DIFF
--- a/configs/avax.json
+++ b/configs/avax.json
@@ -1,7 +1,14 @@
 {
   "index_name": "avax",
   "start_urls": [
-    "https://docs.avax.network"
+    {
+      "url": "https://docs.avax.network",
+      "tags": ["prod"]
+    },
+    {
+      "url": "https://docs-beta.avax.network/",
+      "tags": ["beta"]
+    }
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->
This is to expand start_urls and add tags `prod` and `beta` to the corresponding start_url in avax.json. (Discord discussion: https://discord.com/channels/477328979074744322/477749835307548672/914796045978972180)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

To allow the crawler to index the beta site https://docs-beta.avax.network/ 

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

No contents from https://docs-beta.avax.network/  are indexed.


### What is the expected behaviour?

Contents from https://docs-beta.avax.network/  are indexed.

##### NB: Do you want to request a **feature** or report a **bug**?
Feature

##### NB2: Any other feedback / questions ?
No

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
