### PR TITLE
Modify Workbench config

### DIFF
--- a/configs/workbench.json
+++ b/configs/workbench.json
@@ -4,21 +4,19 @@
     "https://workbench.gusto.com/",
     "https://workbench.gusto.com/getting-started/engineers/"
   ],
-  "stop_urls": [
-    "\\/\\?"
-  ],
+  "stop_urls": ["\\/\\?"],
+  "sitemap_urls": ["https://workbench.gusto.com/sitemap/sitemap-0.xml"],
   "selectors": {
-    "lvl0": "[class^='container-'] h1",
-    "lvl1": "[class^='container-'] h2",
-    "lvl2": "[class^='container-'] h3",
-    "lvl3": "[class^='container-'] h4",
-    "lvl4": "[class^='container-'] h5",
-    "lvl5": "[class^='container-'] h6",
-    "text": "[class^='container-'] p, [class^='container-'] li"
+    "lvl0": ".DocSearch-content h1",
+    "lvl1": ".DocSearch-content h2",
+    "lvl2": ".DocSearch-content h3",
+    "lvl3": ".DocSearch-content h4",
+    "lvl4": ".DocSearch-content h5",
+    "lvl5": ".DocSearch-content h6",
+    "text": ".DocSearch-content p, .DocSearch-content li"
   },
   "js_render": true,
-  "conversation_id": [
-    "1704794238"
-  ],
+  "js_wait": 1,
+  "conversation_id": ["1704794238"],
   "nb_hits": 2271
 }


### PR DESCRIPTION
Hello! 

The crawler is not being populated with helpful data for the page that I would primarily like to surface during a search, so I am modifying a few values to hopefully get better data.

I have added a global classname to my primary body content: `DocSearch-content`

I also added a short `js_wait` as an experiment to see if perhaps header content is not yet available when the crawler begins.

As you can see in the screenshot below, I am trying to search for our Accordion component, which lives [here](https://workbench.gusto.com/components/accordion/). The first category of results show only as "#" and lists various anchors on the page, but none of the header text is being displayed, which is confusing. When searching for a component, I always want those results to appear first.

![localhost_8000_components_skeleton_](https://user-images.githubusercontent.com/687239/143962873-9cf3dc0d-a710-4ab1-a51c-9a1c4b7ff77b.png)

Please let me know if I'm doing something wrong. Thank you for your help!