### PR TITLE
chore: Update `gatsbyjs.json` `sitemap_urls`

### DIFF
--- a/configs/gatsbyjs.json
+++ b/configs/gatsbyjs.json
@@ -34,7 +34,7 @@
     }
   ],
   "sitemap_urls": [
-    "https://www.gatsbyjs.com/sitemap.xml"
+    "https://www.gatsbyjs.com/sitemap/sitemap-0.xml"
   ],
   "stop_urls": [
     "/packages/",


### PR DESCRIPTION
We (more or less) recently changed the location of our sitemap on gatsbyjs.com.
This PR adjusts the gatsbyjs.com docsearch config accordingly.

~cc @LekoArts @DSchau please double check the new URL.~ 🙏 