### PR TITLE
[airphp] Fix selectors

### DIFF
--- a/configs/airephp.json
+++ b/configs/airephp.json
@@ -5,13 +5,13 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".markdown h1",
-    "lvl1": ".markdown h2",
-    "lvl2": ".markdown h3",
-    "lvl3": ".markdown h4",
-    "lvl4": ".markdown h5",
-    "lvl5": ".markdown h6",
-    "text": ".markdown p, .markdown li"
+    "lvl0": ".docs-content h1",
+    "lvl1": ".docs-content h2",
+    "lvl2": ".docs-content h3",
+    "lvl3": ".docs-content h4",
+    "lvl4": ".docs-content h5",
+    "lvl5": ".docs-content h6",
+    "text": ".docs-content p, .docs-content li"
   },
   "conversation_id": [
     "1704382767"


### PR DESCRIPTION
The configured selectors for https://airephp.com/ only worked for homepage content. This updates them to apply to content on any page of the site.