### PR TITLE
Update tanzucommunityedition.io search

### DIFF
--- a/configs/tanzucommunityedition.json
+++ b/configs/tanzucommunityedition.json
@@ -18,7 +18,7 @@
     "version": {
       "selector": "#dropdownMenuButton",
       "global": true,
-      "default_value": "Documentation"
+      "default_value": "latest"
     }
   },
   "custom_settings": {

--- a/configs/tanzucommunityedition.json
+++ b/configs/tanzucommunityedition.json
@@ -8,17 +8,23 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": "",
+    "lvl0": "header.subproject-specific a.text-logo",
+    "lvl1": ".docs-content h1",
+    "lvl2": ".docs-content h2",
+    "lvl3": ".docs-content h3",
+    "lvl4": ".docs-content h4",
+    "lvl5": ".docs-content h5",
+    "text": ".docs-content p, .docs-content li",
+    "version": {
+      "selector": "#dropdownMenuButton",
       "global": true,
       "default_value": "Documentation"
-    },
-    "lvl1": "main h1",
-    "lvl2": "main h2",
-    "lvl3": "main h3",
-    "lvl4": "main h4",
-    "lvl5": "main h5",
-    "text": "main p, main li"
+    }
+  },
+  "custom_settings": {
+    "attributesForFaceting": [
+      "version"
+    ]
   },
   "conversation_id": [
     "1702016197"


### PR DESCRIPTION
Signed-off-by: Garry Ing <ging@vmware.com>

# Pull request motivation(s)
Updating the search crawler/index for tanzucommunityedition.io/docs/ to use the appropriate selectors and include version variable.

### What is the current behaviour?
- Search is indexing all content in the main area of docs

### What is the expected behaviour?
- Scrape main content area with the defined selectors
- Enable `version` as a variable for facetted results

##### NB: Do you want to request a **feature** or report a **bug**?
No

##### NB2: Any other feedback / questions ?