### PR TITLE
fix supabase config

### DIFF
--- a/configs/supabase.json
+++ b/configs/supabase.json
@@ -1,7 +1,7 @@
 {
   "index_name": "supabase",
   "start_urls": [
-    "https://supabase.io/"
+    "https://supabase.com/"
   ],
   "stop_urls": [],
   "selectors": {
@@ -21,7 +21,7 @@
   },
   "strip_chars": " .,;:#",
   "sitemap_urls": [
-    "https://supabase.io/sitemap.xml"
+    "https://supabase.com/docs/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "custom_settings": {


### PR DESCRIPTION
This PR fixes the config for the [Supabase website](https://supabase.com/). We recently moved to the .com domain. 

We have a docusaurus website located at supabase.com/docs. Right now the search results returns pages outside the docusaurus website which leads to broken links (https://github.com/supabase/supabase/issues/4317)

I am pointing the sitemap_urls to just the sitemap for the docusaurus website