### PR TITLE
Update documentation paths for the "loadsterperformance" index.

### DIFF
--- a/configs/loadsterperformance.json
+++ b/configs/loadsterperformance.json
@@ -1,9 +1,10 @@
 {
   "index_name": "loadsterperformance",
   "start_urls": [
-    "https://loadster.app/documentation/",
+    "https://loadster.app/manual/",
     "https://loadster.app/faqs/",
-    "https://loadster.app/articles/"
+    "https://loadster.app/articles/",
+    "https://loadster.app/changelog/"
   ],
   "stop_urls": [],
   "sitemap_urls": ["https://loadster.app/sitemap.xml"],


### PR DESCRIPTION
We recently reorganized the documentation content on our site, and
the Loadster manual is now located under /manual instead of
/documentation/manual. We've also added a changelog.

https://github.com/loadster
