### PR TITLE
[TypeScript] Remove old handbook pages

### DIFF
--- a/configs/typescriptlang.json
+++ b/configs/typescriptlang.json
@@ -24,7 +24,15 @@
   "stop_urls": [
     "/global-plugin/",
     "declaration-files/templates/",
-    "release-notes/overview.html"
+    "release-notes/overview.html",
+    "/docs/handbook/basic-types.html",
+    "/docs/handbook/classes.html",
+    "/docs/handbook/functions.html",
+    "/docs/handbook/generics.html",
+    "/docs/handbook/interfaces.html",
+    "/docs/handbook/literal-types.html",
+    "/docs/handbook/unions-and-intersections.html",
+    "/docs/handbook/advanced-types.html"
   ],
   "selectors": {
     "release": {


### PR DESCRIPTION
# Pull request motivation(s)

Removes the old handbook pages which are marked as deprecated from the search index

### What is the current behaviour?

We don't want to break URLs, so the pages still exist but there's a big "you want to go here instead" marker for links, it's probably about time we remove them from the search index.

##### NB: Do you want to request a **feature** or report a **bug**?

N/A

##### NB2: Any other feedback / questions ?

N/A