### PR TITLE
fix(tailwindcss): fix domain

### DIFF
--- a/configs/tailwindcss.json
+++ b/configs/tailwindcss.json
@@ -2,46 +2,36 @@
   "index_name": "tailwindcss",
   "start_urls": [
     {
-      "url": "https://tailwindcss.com/",
+      "url": "https://v2.tailwindcss.com/",
       "selectors_key": "v2",
       "extra_attributes": {
-        "version": [
-          "v2"
-        ]
+        "version": ["v2"]
       }
     },
     {
-      "url": "https://tailwindcss.com/community",
+      "url": "https://v2.tailwindcss.com/community",
       "selectors_key": "v2",
       "extra_attributes": {
-        "version": [
-          "v2"
-        ]
+        "version": ["v2"]
       }
     },
     {
       "url": "https://v1.tailwindcss.com/",
       "selectors_key": "v1",
       "extra_attributes": {
-        "version": [
-          "v1"
-        ]
+        "version": ["v1"]
       }
     },
     {
       "url": "https://tailwindcss-v0.netlify.app/docs/",
       "extra_attributes": {
-        "version": [
-          "v0"
-        ]
+        "version": ["v0"]
       }
     },
     {
       "url": "https://tailwindcss-v0.netlify.app//docs/",
       "extra_attributes": {
-        "version": [
-          "v0"
-        ]
+        "version": ["v0"]
       }
     }
   ],
@@ -97,11 +87,7 @@
     "[data-docsearch-ignore]"
   ],
   "custom_settings": {
-    "attributesForFaceting": [
-      "version",
-      "type",
-      "tags"
-    ],
+    "attributesForFaceting": ["version", "type", "tags"],
     "attributesToRetrieve": [
       "hierarchy",
       "content",
@@ -112,8 +98,6 @@
     ],
     "separatorsToIndex": "@_"
   },
-  "conversation_id": [
-    "459164857"
-  ],
+  "conversation_id": ["459164857"],
   "nb_hits": 21393
 }


### PR DESCRIPTION
## Summary

Main domain is now the v3, which is on the new DocSearch infra. The credentials of the v2, v1 and v0 should be updated.

## Fixes

Fixes https://github.com/algolia/docsearch-configs/issues/4929
Fixes https://github.com/algolia/docsearch-configs/issues/4928
Fixes https://github.com/algolia/docsearch-configs/issues/4927

cc @bradlc