### PR TITLE
Re-enable and update infographopedia config

### DIFF
--- a/disabled/adioma-infographopedia.json
+++ b/disabled/adioma-infographopedia.json
@@ -5,8 +5,11 @@
   ],
   "stop_urls": [
     "/example/",
-    "/function/",
-    "/chart-definitions"
+    "/all",
+    "/list",
+    "/function",
+    "?sortBy=",
+    "&sortOrder="
   ],
   "sitemap_urls": [
     "https://infographopedia.adioma.com/sitemap.xml"
@@ -20,6 +23,13 @@
     "lvl5": "[class*='page'] h6",
     "text": "[class*='page'] p, [class*='page'] li"
   },
+  "selectors_exclude": [
+    "#chart_parent",
+    "#chart_variations",
+    "#chart_examples",
+    "#function_charts",
+    ".ad_banner"
+  ],
   "conversation_id": [
     "845433270"
   ],


### PR DESCRIPTION
Could you please update our search configuration and re-enable the config?
I believe it was disabled by mistake. We are still in research stage but will be launching very soon.

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

Currently docsearch config of _infographopedia_ is disabled.

### What is the expected behaviour?
Seach for _infographopedia.adioma.com_ should be functional and re-index new changes.


<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
