### PR TITLE
Update sap_spartacus.js

### DIFF
--- a/deployed-configs/s/sap_spartacus.js
+++ b/deployed-configs/s/sap_spartacus.js
@@ -4,7 +4,6 @@ new Crawler({
   rateLimit: 8,
   startUrls: [
     "https://sap.github.io/spartacus-docs/3.x/",
-    "https://sap.github.io/",
     "https://sap.github.io/spartacus-docs/2.x/",
     "https://sap.github.io/spartacus-docs/1.x/",
     "https://sap.github.io/spartacus-docs/",


### PR DESCRIPTION
Remove `"https://sap.github.io/",` from the list of `startUrls` since this URL should never be indexed for the `spartacus-docs` site. Unless I'm mistaken and `"https://sap.github.io/",` should really be in the list of `startUrls` ? 🙂