### PR TITLE
Add config file for PyTorch Live

### DIFF
--- a/configs/pytorch-live.json
+++ b/configs/pytorch-live.json
@@ -1,0 +1,50 @@
+{
+  "index_name": "pytorch-live",
+  "start_urls": [
+    "https://pytorch.org/live/"
+  ],
+  "sitemap_urls": [
+    "https://pytorch.org/live/sitemap.xml"
+  ],
+  "sitemap_alternate_links": true,
+  "stop_urls": [
+    "/tests"
+  ],
+  "selectors": {
+    "lvl0": {
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
+  },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  },
+  "conversation_id": [
+    "833762294"
+  ],
+  "nb_hits": 46250
+}


### PR DESCRIPTION
# Pull request motivation(s)

Add DocSearch config for PyTorch Live (see https://pytorch.org/live/). The index will work with PyTorch Live OSS Docusaurus website

### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

##### NB: Do you want to request a **feature** or report a **bug**?

##### NB2: Any other feedback / questions ?
