### PR TITLE
Point Orchest's URLs to new docs domain

### DIFF
--- a/configs/orchest.json
+++ b/configs/orchest.json
@@ -1,10 +1,10 @@
 {
   "index_name": "orchest",
   "start_urls": [
-    "https://orchest.readthedocs.io/en/latest/"
+    "https://docs.orchest.io/en/latest/"
   ],
   "sitemap_urls": [
-    "https://orchest.readthedocs.io/sitemap.xml"
+    "https://docs.orchest.io/sitemap.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)
Orchest's documentation has moved from https://orchest.readthedocs.io to https://docs.orchest.io

### What is the current behaviour?
The crawler is unable to crawl the documentation, because it is pointing to the old domain. Therefore all searches will have outdated results forwarding to incorrect URLs.

##### NB: Do you want to request a **feature** or report a **bug**? **bug**
