### PR TITLE
Update pan.json

### DIFF
--- a/configs/pan.json
+++ b/configs/pan.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "url": "https://strata.pan.dev/",
+      "url": "https://panos.pan.dev/",
       "tags": [
         "strata"
       ]
@@ -36,7 +36,7 @@
     "https://cortex.pan.dev/sitemap.xml",
     "https://xsoar.pan.dev/sitemap.xml",
     "https://prisma.pan.dev/sitemap.xml",
-    "https://strata.pan.dev/sitemap.xml",
+    "https://panos.pan.dev/sitemap.xml",
     "https://gallery.pan.dev/sitemap.xml"
   ],
   "sitemap_alternate_links": true,


### PR DESCRIPTION
Switching to use canonical URL

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


Noticed that we are no longer indexing content from panos.pan.dev after move to Firebase and migration to new DocSearch.

# Pull request motivation(s)


### What is the current behaviour?

No search results for facet filter `tags:strata`.

### What is the expected behaviour?

Should be seeing search results.

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
