### PR TITLE
discord.json: index h6

### DIFF
--- a/configs/discord.json
+++ b/configs/discord.json
@@ -9,6 +9,7 @@
     "lvl3": "[class*='contentWrapperInner'] h3",
     "lvl4": "[class*='contentWrapperInner'] h4",
     "lvl5": "[class*='contentWrapperInner'] h5",
+    "lvl6": "[class*='contentWrapperInner'] h6",
     "text": "[class*='contentWrapperInner'] p, [class*='contentWrapperInner'] li, [class*='contentWrapperInner'] td:first-child"
   },
   "js_render": true,


### PR DESCRIPTION
There are useful `h6` tags that we should index, e.g. on https://discord.com/developers/docs/reference

<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)


### What is the current behaviour?

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?


##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
