### PR TITLE
fix(scalafix): update config

### DIFF
--- a/configs/scalafix.json
+++ b/configs/scalafix.json
@@ -1,7 +1,7 @@
 {
   "index_name": "scalafix",
   "start_urls": [
-    "https://scalacenter.github.io/scalafix/docs"
+    "https://scalacenter.github.io/scalafix/"
   ],
   "sitemap_urls": [
     "https://scalacenter.github.io/scalafix/sitemap.xml"
@@ -33,5 +33,5 @@
   "conversation_id": [
     "662864585"
   ],
-  "nb_hits": 739
+  "nb_hits": 831
 }


### PR DESCRIPTION
fixes https://github.com/algolia/docsearch-configs/issues/5025

Last crawl of this index was more than 2 months ago in our records. It seems that the `/docs` does not redirect to `scalafix` anymore