### PR TITLE
Add missing cert-manager versions

### DIFF
--- a/configs/cert-manager.json
+++ b/configs/cert-manager.json
@@ -10,7 +10,14 @@
           "v0.12-docs",
           "v0.13-docs",
           "v0.14-docs",
-          "v0.15-docs"
+          "v0.15-docs",
+          "v0.16-docs",
+          "v1.0-docs",
+          "v1.1-docs",
+          "v1.2-docs",
+          "v1.3-docs",
+          "v1.4-docs",
+          "v1.5-docs"
         ]
       }
     }


### PR DESCRIPTION
# Pull request motivation(s)

Updating this config file wasn't part of our release process documentation so we've missed several releases. We've now added a task to update the config file and we'll work to automate this process.

I'm a cert-manager maintainer, listed on the CNCF [project-maintainers.csv](https://github.com/cncf/foundation/blob/main/project-maintainers.csv#L706) and the [cert-manager GitHub Org](https://github.com/cert-manager/).