### PR TITLE
feat: add tutorials to docsearch on GraphCMS

### DIFF
--- a/configs/graphcms.json
+++ b/configs/graphcms.json
@@ -25,6 +25,13 @@
         "ui"
       ]
     },
+    {
+      "url": "https://graphcms.com/blog/",
+      "selectors_key": "blog",
+      "tags": [
+        "blog"
+      ]
+    },
     "https://graphcms.com/docs/"
   ],
   "stop_urls": [],
@@ -70,6 +77,17 @@
       "lvl0": {
         "selector": "",
         "default_value": "UI Extensions"
+      },
+      "lvl1": "article h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "text": "article p, article li"
+    },
+    "blog": {
+      "lvl0": {
+        "selector": "",
+        "default_value": "Blog"
       },
       "lvl1": "article h1",
       "lvl2": "article h2",


### PR DESCRIPTION
# Pull request motivation(s)
We have a lot of useful tutorials/guides inside of our blog we haven't migrated to our docs/guides area that we'd like to surface inside of the search results.

### What is the expected behaviour?

Blog results show in results.

### Next steps

Update GraphCMS blog to have the `article` class around the article.