### PR TITLE
storybook-js: Add `version` to facet attributes

### DIFF
--- a/configs/storybook-js.json
+++ b/configs/storybook-js.json
@@ -45,7 +45,7 @@
   "selectors_exclude": ["[class*='Release__EmailWrapper']"],
   "custom_settings": {
     "separatorsToIndex": "_",
-    "attributesForFaceting": ["framework", "tags"]
+    "attributesForFaceting": ["framework", "tags", "version"]
   },
   "js_render": true,
   "conversation_id": ["1251295597"],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

Corresponds with https://github.com/storybookjs/frontpage/pull/332, which adds the `version` meta tag and uses it as a facet in the Algolia DocSearch for our docs pages.



<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
