### PR TITLE
Adding pipedream docs v2 index

### DIFF
--- a/configs/pipedream-v2.json
+++ b/configs/pipedream-v2.json
@@ -1,0 +1,41 @@
+{
+  "index_name": "pipedream-v2",
+  "start_urls": [
+    "https://pipedream.com/docs-v2/"
+  ],
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": {
+      "selector": "p.sidebar-heading.open",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": "main h1",
+    "lvl2": "main h2",
+    "lvl3": "main h3",
+    "lvl4": "main h4",
+    "lvl5": "main h5",
+    "text": "main p, main li",
+    "lang": {
+      "selector": "/html/@lang",
+      "type": "xpath",
+      "global": true,
+      "default_value": "en-US"
+    }
+  },
+  "selectors_exclude": [
+    ".table-of-contents"
+  ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "lang"
+    ]
+  },
+  "scrape_start_urls": false,
+  "strip_chars": " .,;:#",
+  "conversation_id": [
+    "898525983"
+  ],
+  "nb_hits": 2787
+}
+


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please:
    - provide enough information so that others can review your pull request.
    - double check [the dedicated documentation available here](https://docsearch.algolia.com/)
    - try [to implement the recommendations](https://docsearch.algolia.com/docs/required-configuration)
    - please feature [a sitemap](https://www.sitemaps.org/), it will be the most complete source of truth for our crawling.
    - [Allow edits from maintainer](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
  Please attach also a URL showing that you are a maintainer of the project.
-->
# Pull request motivation(s)

We're adding a new version of our docs 🙌 

This new version is running a brand new site with a new subpath. We'd like to make a separate index much like the Bootstrap layout.

### What is the current behaviour?

We have one index currently `pipedream`. 

*If the current behaviour is a bug, please provide all the steps to reproduce and screenshots with context.*

### What is the expected behaviour?

We'd like to add a new separate index called `pipedream-v2`

##### NB: Do you want to request a **feature** or report a **bug**?


##### NB2: Any other feedback / questions ?

None, thanks for providing this service, it's great for us and our users!

<!--
  The CI will check that the configuration is compliant with the JSON schema we have defined, please make sure the check is passed. Let us know if you do not get the issue.
-->
